### PR TITLE
Changed travis go version from 1.12 to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 - GO111MODULE=on 
 
 go:
-- "1.12"
+- "1.13"
 
 git:
   depth: 1


### PR DESCRIPTION
* Changes go version used by travis from 1.12 to 1.13

/sig cli
/priority important-soon

```release-note
NONE
```