### PR TITLE
Adds kapply binary with apply/diff commands

### DIFF
--- a/cmd/kapply/kapply.go
+++ b/cmd/kapply/kapply.go
@@ -1,0 +1,21 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+
+	"sigs.k8s.io/cli-utils/pkg/apply"
+
+	// This is here rather than in the libraries because of
+	// https://github.com/kubernetes-sigs/kustomize/issues/2060
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func main() {
+	//os.Setenv(commandutil.EnableAlphaCommmandsEnvName, "true")
+	if err := apply.GetCommand(nil).Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,19 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
+github.com/Azure/go-autorest/autorest/adal v0.5.0 h1:q2gDruN08/guU9vAjuPWff0+QIrpH6ediguzdAzXAUU=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
+github.com/Azure/go-autorest/autorest/date v0.1.0 h1:YGrhWfrgtFs84+h0o46rJrlmsZtyZRg470CqAXTZaGM=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
+github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VYyQflFE619k=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -47,6 +53,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0 h1:w3NnFcKR5241cfmQU5ZZAsf0xcpId6mWOupTvJlUX2U=
@@ -154,6 +161,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/pkg/apply/commands.go
+++ b/pkg/apply/commands.go
@@ -22,18 +22,11 @@ import (
 
 // GetCommand returns a command from kubectl to install
 func GetCommand(parent *cobra.Command) *cobra.Command {
-	// if !commandutil.GetAlphaEnabled() {
-	// 	return &cobra.Command{
-	// 		Use:   "resources",
-	// 		Short: "[Alpha] To enable set KUSTOMIZE_ENABLE_ALPHA_COMMANDS=true",
-	// 		Long:  "[Alpha] To enable set KUSTOMIZE_ENABLE_ALPHA_COMMANDS=true",
-	// 	}
-	// }
 
 	r := &cobra.Command{
-		Use:   "resources",
-		Short: "[Alpha] Perform cluster operations using declarative configuration",
-		Long:  "[Alpha] Perform cluster operations using declarative configuration",
+		Use:   "kapply",
+		Short: "Perform cluster operations using declarative configuration",
+		Long:  "Perform cluster operations using declarative configuration",
 	}
 
 	// configure kubectl dependencies and flags
@@ -58,7 +51,7 @@ func GetCommand(parent *cobra.Command) *cobra.Command {
 	}
 
 	names := []string{"apply", "diff"}
-	applyCmd := NewCmdApply("kustomize", f, ioStreams)
+	applyCmd := NewCmdApply("kapply", f, ioStreams)
 	updateHelp(names, applyCmd)
 	diffCmd := diff.NewCmdDiff(f, ioStreams)
 	updateHelp(names, diffCmd)
@@ -71,9 +64,9 @@ func GetCommand(parent *cobra.Command) *cobra.Command {
 func updateHelp(names []string, c *cobra.Command) {
 	for i := range names {
 		name := names[i]
-		c.Short = strings.ReplaceAll(c.Short, "kubectl "+name, "kustomize "+name)
-		c.Long = strings.ReplaceAll(c.Long, "kubectl "+name, "kustomize "+name)
-		c.Example = strings.ReplaceAll(c.Example, "kubectl "+name, "kustomize "+name)
+		c.Short = strings.ReplaceAll(c.Short, "kubectl "+name, "kapply "+name)
+		c.Long = strings.ReplaceAll(c.Long, "kubectl "+name, "kapply "+name)
+		c.Example = strings.ReplaceAll(c.Example, "kubectl "+name, "kapply "+name)
 	}
 }
 


### PR DESCRIPTION
* Creates new binary `kapply` as driver for `apply/prune/diff/status` commands
* Updates cobra command help to reference `kapply`
* Tested manually

/sig cli
/priority important-soon

```release-note
NONE
```