### PR TITLE
Move cobra command code under cmd directory

### DIFF
--- a/cmd/common/commands.go
+++ b/cmd/common/commands.go
@@ -1,27 +1,25 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package common
 
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/kubectl/pkg/cmd/apply"
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/cmd/util"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
-	"sigs.k8s.io/cli-utils/pkg/apply/prune"
+	"sigs.k8s.io/cli-utils/pkg/apply"
 )
 
-// GetCommand returns a command from kubectl to install
-func GetCommand(parent *cobra.Command) *cobra.Command {
+// NewKapplyCommand returns a command from kubectl to install
+func NewKapplyCommand(parent *cobra.Command) *cobra.Command {
 
 	r := &cobra.Command{
 		Use:   "kapply",
@@ -72,28 +70,26 @@ func updateHelp(names []string, c *cobra.Command) {
 
 // NewCmdApply creates the `apply` command
 func NewCmdApply(baseName string, f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	applier := newApplier(f, ioStreams)
-	printer := &BasicPrinter{
-		ioStreams: ioStreams,
+	applier := apply.NewApplier(f, ioStreams)
+	printer := &apply.BasicPrinter{
+		IOStreams: ioStreams,
 	}
 
 	cmd := &cobra.Command{
-		Use: "apply (-f FILENAME | -k DIRECTORY)",
+		Use:                   "apply (-f FILENAME | -k DIRECTORY)",
 		DisableFlagsInUseLine: true,
-		Short: i18n.T("Apply a configuration to a resource by filename or stdin"),
-		//Long:                  applyLong,
-		//Example:               applyExample,
-		Args: cobra.MaximumNArgs(1),
+		Short:                 i18n.T("Apply a configuration to a resource by filename or stdin"),
+		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) > 0 {
 				// check is kustomize, if so update
-				applier.applyOptions.DeleteFlags.FileNameFlags.Kustomize = &args[0]
+				applier.ApplyOptions.DeleteFlags.FileNameFlags.Kustomize = &args[0]
 			}
 
 			cmdutil.CheckErr(applier.Initialize(cmd))
 
 			// Create a context with the provided timout from the cobra parameter.
-			ctx, cancel := context.WithTimeout(context.Background(), applier.statusOptions.timeout)
+			ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
 			defer cancel()
 			// Run the applier. It will return a channel where we can receive updates
 			// to keep track of progress and any issues.
@@ -108,46 +104,9 @@ func NewCmdApply(baseName string, f util.Factory, ioStreams genericclioptions.IO
 	applier.SetFlags(cmd)
 
 	cmdutil.AddValidateFlags(cmd)
-	cmd.Flags().BoolVar(&applier.applyOptions.ServerDryRun, "server-dry-run", applier.applyOptions.ServerDryRun, "If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
+	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun, "If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
 	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.")
 	cmdutil.AddServerSideApplyFlags(cmd)
 
 	return cmd
-}
-
-// PrependGroupingObject orders the objects to apply so the "grouping"
-// object stores the inventory, and it is first to be applied.
-func PrependGroupingObject(o *apply.ApplyOptions) func() error {
-	return func() error {
-		if o == nil {
-			return fmt.Errorf("ApplyOptions are nil")
-		}
-		infos, err := o.GetObjects()
-		if err != nil {
-			return err
-		}
-		_, exists := prune.FindGroupingObject(infos)
-		if exists {
-			if err := prune.AddInventoryToGroupingObj(infos); err != nil {
-				return err
-			}
-			if !prune.SortGroupingObject(infos) {
-				return err
-			}
-		}
-		return nil
-	}
-}
-
-// Prune deletes previously applied objects that have been
-// omitted in the current apply. The previously applied objects
-// are reached through ConfigMap grouping objects.
-func Prune(f util.Factory, o *apply.ApplyOptions) func() error {
-	return func() error {
-		po, err := prune.NewPruneOptions(f, o)
-		if err != nil {
-			return err
-		}
-		return po.Prune()
-	}
 }

--- a/cmd/kapply/kapply.go
+++ b/cmd/kapply/kapply.go
@@ -6,16 +6,14 @@ package main
 import (
 	"os"
 
-	"sigs.k8s.io/cli-utils/pkg/apply"
-
 	// This is here rather than in the libraries because of
 	// https://github.com/kubernetes-sigs/kustomize/issues/2060
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"sigs.k8s.io/cli-utils/cmd/common"
 )
 
 func main() {
-	//os.Setenv(commandutil.EnableAlphaCommmandsEnvName, "true")
-	if err := apply.GetCommand(nil).Execute(); err != nil {
+	if err := common.NewKapplyCommand(nil).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -102,7 +102,7 @@ func TestPrependGroupingObject(t *testing.T) {
 
 	for _, test := range tests {
 		applyOptions := createApplyOptions(test.infos)
-		f := PrependGroupingObject(applyOptions)
+		f := prependGroupingObject(applyOptions)
 		err := f()
 		if err != nil {
 			t.Errorf("Error running pre-processor callback: %s", err)

--- a/pkg/apply/basic_printer.go
+++ b/pkg/apply/basic_printer.go
@@ -19,7 +19,7 @@ import (
 // from the channel in the default format for kubectl.
 // We need to support different printers for different output formats.
 type BasicPrinter struct {
-	ioStreams genericclioptions.IOStreams
+	IOStreams genericclioptions.IOStreams
 }
 
 // Print outputs the events from the provided channel in a simple
@@ -40,18 +40,18 @@ func (b *BasicPrinter) Print(ch <-chan Event) {
 					name = n
 				}
 			}
-			fmt.Fprintf(b.ioStreams.Out, "%s %s\n", resourceIdToString(gvk.GroupKind(), name), event.ApplyEvent.Operation)
+			fmt.Fprintf(b.IOStreams.Out, "%s %s\n", resourceIdToString(gvk.GroupKind(), name), event.ApplyEvent.Operation)
 		case StatusEventType:
 			statusEvent := event.StatusEvent
 			switch statusEvent.Type {
 			case wait.ResourceUpdate:
 				id := statusEvent.EventResource.ResourceIdentifier
 				gk := id.GroupKind
-				fmt.Fprintf(b.ioStreams.Out, "%s is %s: %s\n", resourceIdToString(gk, id.Name), statusEvent.EventResource.Status.String(), statusEvent.EventResource.Message)
+				fmt.Fprintf(b.IOStreams.Out, "%s is %s: %s\n", resourceIdToString(gk, id.Name), statusEvent.EventResource.Status.String(), statusEvent.EventResource.Message)
 			case wait.Completed:
-				fmt.Fprint(b.ioStreams.Out, "all resources has reached the Current status\n")
+				fmt.Fprint(b.IOStreams.Out, "all resources has reached the Current status\n")
 			case wait.Aborted:
-				fmt.Fprintf(b.ioStreams.Out, "resources failed to the reached Current status\n")
+				fmt.Fprintf(b.IOStreams.Out, "resources failed to the reached Current status\n")
 			}
 		}
 	}

--- a/pkg/apply/status.go
+++ b/pkg/apply/status.go
@@ -13,18 +13,18 @@ func NewStatusOptions() *StatusOptions {
 	return &StatusOptions{
 		wait:    false,
 		period:  2 * time.Second,
-		timeout: time.Minute,
+		Timeout: time.Minute,
 	}
 }
 
 type StatusOptions struct {
 	wait    bool
 	period  time.Duration
-	timeout time.Duration
+	Timeout time.Duration
 }
 
 func (s *StatusOptions) AddFlags(c *cobra.Command) {
 	c.Flags().BoolVar(&s.wait, "status", s.wait, "Wait for all applied resources to reach the Current status.")
 	c.Flags().DurationVar(&s.period, "status-period", s.period, "Polling period for resource statuses.")
-	c.Flags().DurationVar(&s.timeout, "status-timeout", s.timeout, "Timeout threshold for waiting for all resources to reach the Current status.")
+	c.Flags().DurationVar(&s.Timeout, "status-timeout", s.Timeout, "Timeout threshold for waiting for all resources to reach the Current status.")
 }


### PR DESCRIPTION
* Separates some `cobra.Command` code from `pkg` into `cmd`.
* Tested manually.

/sig cli
/priority important-soon

```release-note
NONE
```