### PR TITLE
Connect dry-run flag to prune delete; Add no-prune flag

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -50,11 +50,12 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 	applier.SetFlags(cmd)
 
 	cmdutil.AddValidateFlags(cmd)
-	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun,
-		"If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
-	cmd.Flags().Bool("dry-run", false,
+	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
+	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun,
 		"If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result "+
 			"of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.")
+	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun,
+		"If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
 	cmdutil.AddServerSideApplyFlags(cmd)
 
 	return cmd


### PR DESCRIPTION
* Moves `dry-run` flag to `applier`, and plumbs flag through.
* Adds `no-prune` flag to `applier`, and plumbs flag through.
* Tested manually by building binary and running dry-run.

/sig cli
/priority important-soon

```release-note
NONE
```