### PR TITLE
Adds file license to several files.

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package apply
 
 import (

--- a/cmd/diff/cmddiff.go
+++ b/cmd/diff/cmddiff.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package diff
 
 import (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (


### PR DESCRIPTION
* Adds Apache 2 license to three files: `cmdapply.go`, `cmddiff.go`, and `main.go`

/sig cli
/priority important-soon

```release-note
NONE
```