### PR TITLE
Fixes case where some resources evolve from extensions group

### DIFF
--- a/pkg/apply/prune/objmetadata.go
+++ b/pkg/apply/prune/objmetadata.go
@@ -85,11 +85,26 @@ func (o *ObjMetadata) Equals(other *ObjMetadata) bool {
 	return o.String() == other.String()
 }
 
+// GroupKinds that must be normalized from the "extensions" group.
+var normalizeGK = map[schema.GroupKind]schema.GroupKind{
+	{Group: "extensions", Kind: "Deployment"}:        {Group: "apps", Kind: "Deployment"},
+	{Group: "extensions", Kind: "DaemonSet"}:         {Group: "apps", Kind: "DaemonSet"},
+	{Group: "extensions", Kind: "ReplicaSet"}:        {Group: "apps", Kind: "ReplicaSet"},
+	{Group: "extensions", Kind: "Ingress"}:           {Group: "networking", Kind: "Ingress"},
+	{Group: "extensions", Kind: "NetworkPolicy"}:     {Group: "networking", Kind: "NetworkPolicy"},
+	{Group: "extensions", Kind: "PodSecurityPolicy"}: {Group: "policy", Kind: "PodSecurityPolicy"},
+}
+
 // String create a string version of the ObjMetadata struct.
 func (o *ObjMetadata) String() string {
+	gk := o.GroupKind
+	normalized, exists := normalizeGK[o.GroupKind]
+	if exists {
+		gk = normalized
+	}
 	return fmt.Sprintf("%s%s%s%s%s%s%s",
 		o.Namespace, fieldSeparator,
 		o.Name, fieldSeparator,
-		o.GroupKind.Group, fieldSeparator,
-		o.GroupKind.Kind)
+		gk.Group, fieldSeparator,
+		gk.Kind)
 }

--- a/pkg/apply/prune/objmetadata_test.go
+++ b/pkg/apply/prune/objmetadata_test.go
@@ -166,6 +166,60 @@ func TestObjMetadataEqual(t *testing.T) {
 			},
 			isEqual: false,
 		},
+		// Normalized Deployment is the same.
+		{
+			inventory1: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "extensions",
+					Kind:  "Deployment",
+				},
+			},
+			inventory2: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+			},
+			isEqual: true,
+		},
+		// Normalized NetworkPolicy is the same
+		{
+			inventory1: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "extensions",
+					Kind:  "NetworkPolicy",
+				},
+			},
+			inventory2: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "networking",
+					Kind:  "NetworkPolicy",
+				},
+			},
+			isEqual: true,
+		},
+		// Normalized PodSecurityPolicy is the same
+		{
+			inventory1: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "extensions",
+					Kind:  "PodSecurityPolicy",
+				},
+			},
+			inventory2: &ObjMetadata{
+				Name: "test-inv",
+				GroupKind: schema.GroupKind{
+					Group: "policy",
+					Kind:  "PodSecurityPolicy",
+				},
+			},
+			isEqual: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
* Normalize `GroupKind` in the `ObjMetadata.String()` function by changing the `extensions` group for some resources. For example, a `Deployment` may be either in the `extensions` group or the `apps` group. But these resources are in the same keyspace on the APIServer. So they should be considered the same object (if the namespace/name is the same). Since the `String()` function is used to determine equality, we normalize the `GroupKind`.
* In addition to unit tests, tested manually.

/sig cli
/priority important-soon

```release-note
NONE
```