### PR TITLE
Remove the -f and -k flags for apply

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -22,17 +22,12 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "apply (-f FILENAME | -k DIRECTORY)",
+		Use:                   "apply (FILENAME... | DIRECTORY)",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Apply a configuration to a resource by filename or stdin"),
-		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 {
-				// check is kustomize, if so update
-				applier.ApplyOptions.DeleteFlags.FileNameFlags.Kustomize = &args[0]
-			}
-
-			cmdutil.CheckErr(applier.Initialize(cmd))
+			paths := args
+			cmdutil.CheckErr(applier.Initialize(cmd, paths))
 
 			// Create a context with the provided timout from the cobra parameter.
 			ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
@@ -47,7 +42,7 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
-	applier.SetFlags(cmd)
+	cmdutil.CheckErr(applier.SetFlags(cmd))
 
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -27,15 +27,10 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Preview the apply of a configuration"),
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) > 0 {
-				// check is kustomize, if so update
-				applier.ApplyOptions.DeleteFlags.FileNameFlags.Kustomize = &args[0]
-			}
-
 			// Set DryRun option true before Initialize. DryRun is propagated to
 			// ApplyOptions and PruneOptions in Initialize.
 			applier.DryRun = true
-			cmdutil.CheckErr(applier.Initialize(cmd))
+			cmdutil.CheckErr(applier.Initialize(cmd, args))
 
 			// Create a context with the provided timout from the cobra parameter.
 			ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
@@ -50,7 +45,7 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		},
 	}
 
-	applier.SetFlags(cmd)
+	cmdutil.CheckErr(applier.SetFlags(cmd))
 
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -61,12 +61,18 @@ type Applier struct {
 // Initialize sets up the Applier for actually doing an apply against
 // a cluster. This involves validating command line inputs and configuring
 // clients for communicating with the cluster.
-func (a *Applier) Initialize(cmd *cobra.Command) error {
+
+func (a *Applier) Initialize(cmd *cobra.Command, paths []string) error {
 	a.ApplyOptions.PreProcessorFn = prune.PrependGroupingObject(a.ApplyOptions)
+
+	fileNameFlags := processPaths(paths)
+	a.ApplyOptions.DeleteFlags.FileNameFlags = &fileNameFlags
+
 	err := a.ApplyOptions.Complete(a.factory, cmd)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up ApplyOptions", 1)
 	}
+
 	err = a.PruneOptions.Initialize(a.factory, a.ApplyOptions.Namespace)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)
@@ -87,12 +93,18 @@ func (a *Applier) Initialize(cmd *cobra.Command) error {
 // SetFlags configures the command line flags needed for apply and
 // status. This is a temporary solution as we should separate the configuration
 // of cobra flags from the Applier.
-func (a *Applier) SetFlags(cmd *cobra.Command) {
+func (a *Applier) SetFlags(cmd *cobra.Command) error {
 	a.ApplyOptions.DeleteFlags.AddFlags(cmd)
+	for _, flag := range []string{"kustomize", "filename", "recursive"} {
+		err := cmd.Flags().MarkHidden(flag)
+		if err != nil {
+			return err
+		}
+	}
 	a.ApplyOptions.RecordFlags.AddFlags(cmd)
-	a.ApplyOptions.PrintFlags.AddFlags(cmd)
 	a.StatusOptions.AddFlags(cmd)
 	a.ApplyOptions.Overwrite = true
+	return nil
 }
 
 // newResolver sets up a new Resolver for computing status. The configuration

--- a/pkg/apply/path.go
+++ b/pkg/apply/path.go
@@ -1,0 +1,20 @@
+package apply
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func processPaths(paths []string) genericclioptions.FileNameFlags {
+	// No arguments means we are reading from StdIn
+	fileNameFlags := genericclioptions.FileNameFlags{}
+	if len(paths) == 0 {
+		fileNames := []string{"-"}
+		fileNameFlags.Filenames = &fileNames
+		return fileNameFlags
+	}
+
+	t := true
+	fileNameFlags.Filenames = &paths
+	fileNameFlags.Recursive = &t
+	return fileNameFlags
+}

--- a/pkg/apply/path_test.go
+++ b/pkg/apply/path_test.go
@@ -1,0 +1,45 @@
+package apply
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestProcessPaths(t *testing.T) {
+	trueVal := true
+	testCases := map[string]struct {
+		paths                 []string
+		expectedFileNameFlags genericclioptions.FileNameFlags
+	}{
+		"empty slice means reading from StdIn": {
+			paths: []string{},
+			expectedFileNameFlags: genericclioptions.FileNameFlags{
+				Filenames: &[]string{"-"},
+			},
+		},
+		"single element in slice means reading from that file/path": {
+			paths: []string{"object.yaml"},
+			expectedFileNameFlags: genericclioptions.FileNameFlags{
+				Filenames: &[]string{"object.yaml"},
+				Recursive: &trueVal,
+			},
+		},
+		"multiple elements in slice means reading from all files": {
+			paths: []string{"rs.yaml", "dep.yaml"},
+			expectedFileNameFlags: genericclioptions.FileNameFlags{
+				Filenames: &[]string{"rs.yaml", "dep.yaml"},
+				Recursive: &trueVal,
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			fileNameFlags := processPaths(tc.paths)
+
+			assert.DeepEqual(t, tc.expectedFileNameFlags, fileNameFlags)
+		})
+	}
+}


### PR DESCRIPTION
This allows users to apply either a folder with a Kustomization file or just plain manifests without specifying either -f or -k. The rule that is implemented is the following:
 - If no paths are given, we will read from Stdin.
 - If more than one path are given, they must all point to files (not folders), thus kustomizations are not supported.
 - If a single folder is given, we check for the existence of a kustomization file. If one is found, we use Kustomize, otherwise it will be a normal `apply`.

These are the simplest rules I could think of that doesn't have too many special cases.

This change also makes it clear that we need to do something about the flags that are being added the cobra inside of ApplyOptions. This just hides the -f, -k and -r flags since there is no easy way to avoid adding them.

@seans3 @monopole 