### PR TITLE
Preview command with printing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"os"
+	"sigs.k8s.io/cli-utils/cmd/preview"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -46,8 +47,10 @@ func main() {
 	updateHelp(names, applyCmd)
 	diffCmd := diff.NewCmdDiff(f, ioStreams)
 	updateHelp(names, diffCmd)
+	previewCmd := preview.NewCmdPreview(f, ioStreams)
+	updateHelp(names, previewCmd)
 
-	cmd.AddCommand(applyCmd, diffCmd)
+	cmd.AddCommand(applyCmd, diffCmd, previewCmd)
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -1,7 +1,7 @@
 // Copyright 2020 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package preview
 
 import (
 	"context"
@@ -14,17 +14,18 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 )
 
-// NewCmdApply creates the `apply` command
-func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+// NewCmdPreview creates the `preview` command
+func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	applier := apply.NewApplier(f, ioStreams)
+	applier.Preview = true
 	printer := &apply.BasicPrinter{
 		IOStreams: ioStreams,
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "apply (-f FILENAME | -k DIRECTORY)",
+		Use:                   "preview (-f FILENAME | -k DIRECTORY)",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Apply a configuration to a resource by filename or stdin"),
+		Short:                 i18n.T("Preview a configuration to a resource by filename or stdin"),
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) > 0 {
@@ -49,12 +50,14 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 
 	applier.SetFlags(cmd)
 
+	serverDryRun := applier.ApplyOptions.ServerDryRun || applier.Preview
+
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
 	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun,
 		"If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result "+
 			"of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.")
-	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun,
+	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", serverDryRun,
 		"If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
 	cmdutil.AddServerSideApplyFlags(cmd)
 

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -57,6 +57,7 @@ type Applier struct {
 
 	NoPrune bool
 	DryRun  bool
+	Preview bool
 }
 
 // Initialize sets up the Applier for actually doing an apply against

--- a/pkg/apply/basic_printer.go
+++ b/pkg/apply/basic_printer.go
@@ -15,6 +15,14 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
 )
 
+// Color codes
+const (
+	StartGreen = "\033[1;32m"
+	StartRed = "\033[1;31m"
+	StartYellow = "\033[1;33m"
+	ResetColor = "\033[0m"
+)
+
 // BasicPrinter is a simple implementation that just prints the events
 // from the channel in the default format for kubectl.
 // We need to support different printers for different output formats.
@@ -26,7 +34,11 @@ type BasicPrinter struct {
 // format on StdOut. As we support other printer implementations
 // this should probably be an interface.
 // This function will block until the channel is closed.
-func (b *BasicPrinter) Print(ch <-chan Event) {
+func (b *BasicPrinter) Print(ch <-chan Event, applier *Applier) {
+	if (applier.Preview) {
+		b.PrintPreviewEvents(ch)
+		return
+	}
 	for event := range ch {
 		switch event.EventType {
 		case ErrorEventType:
@@ -57,7 +69,46 @@ func (b *BasicPrinter) Print(ch <-chan Event) {
 	}
 }
 
+// PrintPreviewEvents outputs only preview events from the provided channel in a preview
+// format on StdOut.
+func (b *BasicPrinter) PrintPreviewEvents(ch <-chan Event) {
+	createdCnt := 0
+	modifiedCnt := 0
+	deletedCnt := 0
+	fmt.Fprintf(b.IOStreams.Out, "\nA preview of operations is shown below. Please use apply to perform the operations.\n\n")
+	for event := range ch {
+		obj := event.ApplyEvent.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		name := "<unknown>"
+		if acc, err := meta.Accessor(obj); err == nil {
+			if n := acc.GetName(); len(n) > 0 {
+				name = n
+			}
+		}
+		switch event.ApplyEvent.Operation {
+		case "created":
+			fmt.Fprintf(b.IOStreams.Out, "%s+%s%s %s\n\n", StartGreen, resourceIdInPreviewFmt(gvk, name), ResetColor, event.ApplyEvent.Operation)
+			createdCnt++
+		case "deleted":
+			fmt.Fprintf(b.IOStreams.Out, "%s-%s%s %s\n\n", StartRed, resourceIdInPreviewFmt(gvk, name), ResetColor, event.ApplyEvent.Operation)
+			deletedCnt++
+		case "unchanged":
+			fmt.Fprintf(b.IOStreams.Out, "%s %s\n\n", resourceIdInPreviewFmt(gvk, name), event.ApplyEvent.Operation)
+		default:
+			fmt.Fprintf(b.IOStreams.Out, "%s~%s%s %s\n\n", StartYellow, resourceIdInPreviewFmt(gvk, name), ResetColor, event.ApplyEvent.Operation)
+			modifiedCnt++
+		}
+	}
+	fmt.Fprintf(b.IOStreams.Out, "\nResources: %s%d to create%s, %s%d to modify%s, %s%d to delete%s\n",
+		StartGreen, createdCnt, ResetColor, StartYellow, modifiedCnt, ResetColor, StartRed, deletedCnt, ResetColor)
+}
+
 // resourceIDToString returns the string representation of a GroupKind and a resource name.
 func resourceIDToString(gk schema.GroupKind, name string) string {
 	return fmt.Sprintf("%s/%s", strings.ToLower(gk.String()), name)
+}
+
+// resourceIdInPreviewFmt returns the string representation of a GroupVersionKind in preview format.
+func resourceIdInPreviewFmt(gvk schema.GroupVersionKind, name string) string {
+	return fmt.Sprintf("%s.%s.%s", strings.ToLower(gvk.Version), strings.ToLower(gvk.Kind), name)
 }


### PR DESCRIPTION
*Why*

This PR should be merged/used only after the dry-run flags are implemented in apply/prune

1. Initial commit for the new preview command and printing format.
2. Should add E2E tests.

Example Output:
![image](https://user-images.githubusercontent.com/58999035/73406317-fe819480-42aa-11ea-9e34-0a3b768b7806.png)
