### PR TITLE
Use channel directly in prune instead of ToPrinter

### DIFF
--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -1,0 +1,53 @@
+package event
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+// Type determines the type of events that are available.
+type Type string
+
+const (
+	ErrorEventType  Type = "error"
+	ApplyEventType  Type = "apply"
+	StatusEventType Type = "status"
+	PruneEventType  Type = "prune"
+)
+
+// Event is the type of the objects that will be returned through
+// the channel that is returned from a call to Run. It contains
+// information about progress and errors encountered during
+// the process of doing apply, waiting for status and doing a prune.
+type Event struct {
+	// Type is the type of event.
+	Type Type
+
+	// ErrorEvent contains information about any errors encountered.
+	ErrorEvent ErrorEvent
+
+	// ApplyEvent contains information about progress pertaining to
+	// applying a resource to the cluster.
+	ApplyEvent ApplyEvent
+
+	// StatusEvents contains information about the status of one of
+	// the applied resources.
+	StatusEvent wait.Event
+
+	// PruneEvent contains information about objects that have been
+	// pruned.
+	PruneEvent PruneEvent
+}
+
+type ErrorEvent struct {
+	Err error
+}
+
+type ApplyEvent struct {
+	Operation string
+	Object    runtime.Object
+}
+
+type PruneEvent struct {
+	Object runtime.Object
+}

--- a/pkg/apply/printer_adapter.go
+++ b/pkg/apply/printer_adapter.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
 // KubectlPrinterAdapter is a workaround for capturing progress from
@@ -16,22 +17,22 @@ import (
 // plugs into ApplyOptions as a ToPrinter function, but instead of
 // printing the info, it emits it as an event on the provided channel.
 type KubectlPrinterAdapter struct {
-	ch chan<- Event
+	ch chan<- event.Event
 }
 
 // resourcePrinterImpl implements the ResourcePrinter interface. But
 // instead of printing, it emits information on the provided channel.
 type resourcePrinterImpl struct {
 	operation string
-	ch        chan<- Event
+	ch        chan<- event.Event
 }
 
 // PrintObj takes the provided object and operation and emits
 // it on the channel.
 func (r *resourcePrinterImpl) PrintObj(obj runtime.Object, _ io.Writer) error {
-	r.ch <- Event{
-		EventType: ApplyEventType,
-		ApplyEvent: ApplyEvent{
+	r.ch <- event.Event{
+		Type: event.ApplyEventType,
+		ApplyEvent: event.ApplyEvent{
 			Operation: r.operation,
 			Object:    obj,
 		},

--- a/pkg/apply/printer_adapter_test.go
+++ b/pkg/apply/printer_adapter_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
 func TestKubectlPrinterAdapter(t *testing.T) {
-	ch := make(chan Event)
+	ch := make(chan event.Event)
 	buffer := bytes.Buffer{}
 	operation := "operation"
 

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -13,15 +13,14 @@ package prune
 
 import (
 	"fmt"
-	"io"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/validation"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
 // PruneOptions encapsulates the necessary information to
@@ -42,9 +41,6 @@ type PruneOptions struct {
 	// easier by manually setting the retrieved grouping infos.
 	pastGroupingObjects      []*resource.Info
 	retrievedGroupingObjects bool
-
-	ToPrinter func(string) (printers.ResourcePrinter, error)
-	out       io.Writer
 
 	DryRun    bool
 	validator validation.Schema
@@ -202,7 +198,7 @@ func (po *PruneOptions) calcPruneSet(pastGroupingInfos []*resource.Info) (*Inven
 // (retrieved from previous grouping objects) but omitted in
 // the current apply. Prune also delete all previous grouping
 // objects. Returns an error if there was a problem.
-func (po *PruneOptions) Prune(currentObjects []*resource.Info) error {
+func (po *PruneOptions) Prune(currentObjects []*resource.Info, eventChannel chan<- event.Event) error {
 	currentGroupingObject, found := FindGroupingObject(currentObjects)
 	if !found {
 		return fmt.Errorf("current grouping object not found during prune")
@@ -241,12 +237,11 @@ func (po *PruneOptions) Prune(currentObjects []*resource.Info) error {
 				return err
 			}
 		}
-		printer, err := po.ToPrinter("deleted")
-		if err != nil {
-			return err
-		}
-		if err = printer.PrintObj(obj, po.out); err != nil {
-			return err
+		eventChannel <- event.Event{
+			Type: event.PruneEventType,
+			PruneEvent: event.PruneEvent{
+				Object: obj,
+			},
 		}
 	}
 	// Delete previous grouping objects.
@@ -259,12 +254,11 @@ func (po *PruneOptions) Prune(currentObjects []*resource.Info) error {
 				return err
 			}
 		}
-		printer, err := po.ToPrinter("deleted")
-		if err != nil {
-			return err
-		}
-		if err = printer.PrintObj(pastGroupInfo.Object, po.out); err != nil {
-			return err
+		eventChannel <- event.Event{
+			Type: event.PruneEventType,
+			PruneEvent: event.PruneEvent{
+				Object: pastGroupInfo.Object,
+			},
 		}
 	}
 	return nil


### PR DESCRIPTION
Remove the `ToPrinter` from prune and use the channel directly. It removes the need to use the adapter. This also adds a new event type for prune.

@seans3 @monopole 