### PR TITLE
Prune not exit when deletion item not found

### DIFF
--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -233,6 +234,10 @@ func (po *PruneOptions) Prune(currentObjects []*resource.Info) error {
 		namespacedClient := po.client.Resource(mapping.Resource).Namespace(inv.Namespace)
 		obj, err := namespacedClient.Get(inv.Name, metav1.GetOptions{})
 		if err != nil {
+			// Do not return if object to prune (delete) is not found
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			return err
 		}
 		if !po.DryRun {


### PR DESCRIPTION
* Don't break when pruning and we don't find one of the objects to delete. The algorithm depends on continuing the clean-up (prune) when objects are not found that are to be deleted.
* Tested manually by creating a grouping object with invalid inventory; then subsequent apply when inventory is valid. Steps:
1. Create an invalid resource adding capital letters to the resource config (e.g. `ngiNX-Deployment`).
2. Apply the resources including a grouping object. The grouping object will be created, but the apply will stop when it reaches the resource with the invalid name.
3. Fix the name of the resource (i.e. all lower-case letters).
4. Run the same apply. Notice the resource is created and the old inventory object is deleted.

/sig cli
/priority important-soon

```release-note
NONE
```