### PR TITLE
ResourceObservers for the Observe framework

### DIFF
--- a/pkg/kstatus/observe/observers/common.go
+++ b/pkg/kstatus/observe/observers/common.go
@@ -1,0 +1,171 @@
+package observers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+// BaseObserver provides some basic functionality needed by the observers.
+type BaseObserver struct {
+	Reader observer.ClusterReader
+
+	Mapper meta.RESTMapper
+
+	computeStatusFunc observer.ComputeStatusFunc
+}
+
+// SetComputeStatusFunc allows for setting the function used by the observer for computing status. The default
+// value here is to use the status package. This is provided for testing purposes.
+func (b *BaseObserver) SetComputeStatusFunc(statusFunc observer.ComputeStatusFunc) {
+	b.computeStatusFunc = statusFunc
+}
+
+// LookupResource looks up a resource with the given identifier. It will use the rest mapper to resolve
+// the version of the GroupKind given in the identifier.
+// If the resource is found, it will be returned and the observedResource will be nil. If there is an error
+// or the resource is not found, the observedResource will be returned containing information about the resource
+// and the problem.
+func (b *BaseObserver) LookupResource(ctx context.Context, identifier wait.ResourceIdentifier) (*unstructured.Unstructured, error) {
+	GVK, err := b.GVK(identifier.GroupKind)
+	if err != nil {
+		return nil, err
+	}
+
+	var u unstructured.Unstructured
+	u.SetGroupVersionKind(GVK)
+	key := keyForNamespacedResource(identifier)
+	err = b.Reader.Get(ctx, key, &u)
+	if err != nil {
+		return nil, err
+	}
+	u.SetNamespace(identifier.Namespace)
+	return &u, nil
+}
+
+// ObservedGeneratedResources provides a way to fetch the statuses for all resources of a given GroupKind
+// that match the selector in the provided resource. Typically, this is used to fetch the status of generated
+// resources.
+func (b *BaseObserver) ObserveGeneratedResources(ctx context.Context, observer observer.ResourceObserver, object *unstructured.Unstructured,
+	gk schema.GroupKind, selectorPath ...string) (event.ObservedResources, error) {
+	namespace := getNamespaceForNamespacedResource(object)
+	selector, err := toSelector(object, selectorPath...)
+	if err != nil {
+		return event.ObservedResources{}, err
+	}
+
+	var objectList unstructured.UnstructuredList
+	gvk, err := b.GVK(gk)
+	if err != nil {
+		return event.ObservedResources{}, err
+	}
+	objectList.SetGroupVersionKind(gvk)
+	err = b.Reader.ListNamespaceScoped(ctx, &objectList, namespace, selector)
+	if err != nil {
+		return event.ObservedResources{}, err
+	}
+
+	var observedObjects event.ObservedResources
+	for i := range objectList.Items {
+		generatedObject := objectList.Items[i]
+		observedObject := observer.ObserveObject(ctx, &generatedObject)
+		observedObjects = append(observedObjects, observedObject)
+	}
+	sort.Sort(observedObjects)
+	return observedObjects, nil
+}
+
+// handleObservedResourceError construct the appropriate ObservedResource
+// object based on the type of error.
+func (b *BaseObserver) handleObservedResourceError(identifier wait.ResourceIdentifier, err error) *event.ObservedResource {
+	if errors.IsNotFound(err) {
+		return &event.ObservedResource{
+			Identifier: identifier,
+			Status:     status.NotFoundStatus,
+			Message:    "Resource not found",
+		}
+	}
+	return &event.ObservedResource{
+		Identifier: identifier,
+		Status:     status.UnknownStatus,
+		Error:      err,
+	}
+}
+
+// GVK looks up the GVK from a GroupKind using the rest mapper.
+func (b *BaseObserver) GVK(gk schema.GroupKind) (schema.GroupVersionKind, error) {
+	mapping, err := b.Mapper.RESTMapping(gk)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	return mapping.GroupVersionKind, nil
+}
+
+func toSelector(resource *unstructured.Unstructured, path ...string) (labels.Selector, error) {
+	selector, found, err := unstructured.NestedMap(resource.Object, path...)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("no selector found")
+	}
+	bytes, err := json.Marshal(selector)
+	if err != nil {
+		return nil, err
+	}
+	var s metav1.LabelSelector
+	err = json.Unmarshal(bytes, &s)
+	if err != nil {
+		return nil, err
+	}
+	return metav1.LabelSelectorAsSelector(&s)
+}
+
+func toIdentifier(u *unstructured.Unstructured) wait.ResourceIdentifier {
+	return wait.ResourceIdentifier{
+		GroupKind: u.GroupVersionKind().GroupKind(),
+		Name:      u.GetName(),
+		Namespace: u.GetNamespace(),
+	}
+}
+
+// getNamespaceForNamespacedResource returns the namespace for the given object,
+// but includes logic for returning the default namespace if it is not set.
+func getNamespaceForNamespacedResource(object runtime.Object) string {
+	acc, err := meta.Accessor(object)
+	if err != nil {
+		panic(err)
+	}
+	ns := acc.GetNamespace()
+	if ns == "" {
+		return "default"
+	}
+	return ns
+}
+
+// keyForNamespacedResource returns the object key for the given identifier. It makes
+// sure to set the namespace to default if it is not provided.
+func keyForNamespacedResource(identifier wait.ResourceIdentifier) types.NamespacedName {
+	namespace := "default"
+	if identifier.Namespace != "" {
+		namespace = identifier.Namespace
+	}
+	return types.NamespacedName{
+		Name:      identifier.Name,
+		Namespace: namespace,
+	}
+}

--- a/pkg/kstatus/observe/observers/common_test.go
+++ b/pkg/kstatus/observe/observers/common_test.go
@@ -1,0 +1,225 @@
+package observers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+var (
+	deploymentGVK = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	deploymentGVR = appsv1.SchemeGroupVersion.WithResource("deployments")
+
+	rsGVK = appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
+)
+
+func TestLookupResource(t *testing.T) {
+	deploymentIdentifier := wait.ResourceIdentifier{
+		GroupKind: deploymentGVK.GroupKind(),
+		Name:      "Foo",
+		Namespace: "Bar",
+	}
+
+	testCases := map[string]struct {
+		identifier         wait.ResourceIdentifier
+		readerErr          error
+		expectErr          bool
+		expectedErrMessage string
+	}{
+		"unknown GVK": {
+			identifier: wait.ResourceIdentifier{
+				GroupKind: schema.GroupKind{
+					Group: "custom.io",
+					Kind:  "Custom",
+				},
+				Name:      "Bar",
+				Namespace: "default",
+			},
+			expectErr:          true,
+			expectedErrMessage: "",
+		},
+		"resource does not exist": {
+			identifier:         deploymentIdentifier,
+			readerErr:          errors.NewNotFound(deploymentGVR.GroupResource(), "Foo"),
+			expectErr:          true,
+			expectedErrMessage: "",
+		},
+		"getting resource fails": {
+			identifier:         deploymentIdentifier,
+			readerErr:          errors.NewInternalError(fmt.Errorf("this is a test")),
+			expectErr:          true,
+			expectedErrMessage: "",
+		},
+		"getting resource succeeds": {
+			identifier: deploymentIdentifier,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			fakeReader := &fakeObserverReader{
+				getErr: tc.readerErr,
+			}
+			fakeMapper := testutil.NewFakeRESTMapper(deploymentGVK)
+
+			baseObserver := &BaseObserver{
+				Reader: fakeReader,
+				Mapper: fakeMapper,
+			}
+
+			u, err := baseObserver.LookupResource(context.Background(), tc.identifier)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("expected error, but didn't get one")
+				} else {
+					assert.ErrorContains(t, err, tc.expectedErrMessage)
+				}
+				return
+			}
+
+			assert.NilError(t, err)
+
+			assert.Equal(t, deploymentGVK, u.GroupVersionKind())
+		})
+	}
+}
+
+func TestObserveGeneratedResources(t *testing.T) {
+	testCases := map[string]struct {
+		manifest    string
+		listObjects []unstructured.Unstructured
+		listErr     error
+		gk          schema.GroupKind
+		path        []string
+		expectError bool
+		errMessage  string
+	}{
+		"invalid selector": {
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Foo
+spec:
+  replicas: 1
+`,
+			gk:          appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+			path:        []string{"spec", "selector"},
+			expectError: true,
+			errMessage:  "no selector found",
+		},
+		"Invalid GVK": {
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+`,
+			gk: schema.GroupKind{
+				Group: "custom.io",
+				Kind:  "Custom",
+			},
+			path:        []string{"spec", "selector"},
+			expectError: true,
+			errMessage:  "no matches for kind",
+		},
+		"error listing replicasets": {
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+`,
+			listErr:     fmt.Errorf("this is a test"),
+			gk:          appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+			path:        []string{"spec", "selector"},
+			expectError: true,
+			errMessage:  "this is a test",
+		},
+		"successfully lists and observe the generated resources": {
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+`,
+			listObjects: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "ReplicaSet",
+						"metadata": map[string]interface{}{
+							"name":      "Foo-12345",
+							"namespace": "default",
+						},
+					},
+				},
+			},
+			gk:          appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
+			path:        []string{"spec", "selector"},
+			expectError: false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			fakeObserverReader := &fakeObserverReader{
+				listResources: &unstructured.UnstructuredList{
+					Items: tc.listObjects,
+				},
+				listErr: tc.listErr,
+			}
+			fakeMapper := testutil.NewFakeRESTMapper(rsGVK)
+			fakeResourceObserver := &fakeResourceObserver{}
+
+			object := testutil.YamlToUnstructured(t, tc.manifest)
+
+			observer := &BaseObserver{
+				Reader: fakeObserverReader,
+				Mapper: fakeMapper,
+			}
+
+			observedResources, err := observer.ObserveGeneratedResources(context.Background(), fakeResourceObserver, object, tc.gk, tc.path...)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error, but didn't get one")
+					return
+				}
+				assert.ErrorContains(t, err, tc.errMessage)
+				return
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("did not expect an error, but got %v", err)
+			}
+
+			assert.Equal(t, len(tc.listObjects), len(observedResources))
+			assert.Assert(t, sort.IsSorted(observedResources))
+		})
+	}
+}

--- a/pkg/kstatus/observe/observers/default.go
+++ b/pkg/kstatus/observe/observers/default.go
@@ -1,0 +1,60 @@
+package observers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func NewDefaultObserver(reader observer.ClusterReader, mapper meta.RESTMapper) observer.ResourceObserver {
+	return &DefaultObserver{
+		BaseObserver: BaseObserver{
+			Reader:            reader,
+			Mapper:            mapper,
+			computeStatusFunc: status.Compute,
+		},
+	}
+}
+
+// DefaultObserver is an observer that will be used for any resource that
+// doesn't have a specific observer. It will just delegate computation of
+// status to the status library.
+// This should work pretty well for resources that doesn't have any
+// generated resources and where status can be computed only based on the
+// resource itself.
+type DefaultObserver struct {
+	BaseObserver
+}
+
+func (d *DefaultObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
+	u, err := d.LookupResource(ctx, identifier)
+	if err != nil {
+		return d.handleObservedResourceError(identifier, err)
+	}
+	return d.ObserveObject(ctx, u)
+}
+
+func (d *DefaultObserver) ObserveObject(_ context.Context, resource *unstructured.Unstructured) *event.ObservedResource {
+	identifier := toIdentifier(resource)
+
+	res, err := d.computeStatusFunc(resource)
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier: identifier,
+			Status:     status.UnknownStatus,
+			Error:      err,
+		}
+	}
+
+	return &event.ObservedResource{
+		Identifier: identifier,
+		Status:     res.Status,
+		Resource:   resource,
+		Message:    res.Message,
+	}
+}

--- a/pkg/kstatus/observe/observers/default_test.go
+++ b/pkg/kstatus/observe/observers/default_test.go
@@ -1,0 +1,76 @@
+package observers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+var (
+	customGVK = schema.GroupVersionKind{
+		Group:   "custom.io",
+		Version: "v1beta1",
+		Kind:    "Custom",
+	}
+	name      = "Foo"
+	namespace = "default"
+)
+
+func TestDefaultObserver(t *testing.T) {
+	testCases := map[string]struct {
+		result             *status.Result
+		err                error
+		expectedIdentifier wait.ResourceIdentifier
+		expectedStatus     status.Status
+	}{
+		"successfully computes status": {
+			result: &status.Result{
+				Status:  status.InProgressStatus,
+				Message: "this is a test",
+			},
+			expectedIdentifier: wait.ResourceIdentifier{
+				GroupKind: customGVK.GroupKind(),
+				Name:      name,
+				Namespace: namespace,
+			},
+			expectedStatus: status.InProgressStatus,
+		},
+		"computing status fails": {
+			err: fmt.Errorf("this error is a test"),
+			expectedIdentifier: wait.ResourceIdentifier{
+				GroupKind: customGVK.GroupKind(),
+				Name:      name,
+				Namespace: namespace,
+			},
+			expectedStatus: status.UnknownStatus,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			fakeReader := testutil.NewNoopObserverReader()
+			fakeMapper := testutil.NewFakeRESTMapper()
+			observer := NewDefaultObserver(fakeReader, fakeMapper)
+			observer.SetComputeStatusFunc(func(u *unstructured.Unstructured) (*status.Result, error) {
+				return tc.result, tc.err
+			})
+
+			object := &unstructured.Unstructured{}
+			object.SetGroupVersionKind(customGVK)
+			object.SetName(name)
+			object.SetNamespace(namespace)
+
+			observedResource := observer.ObserveObject(context.Background(), object)
+
+			assert.Equal(t, tc.expectedIdentifier, observedResource.Identifier)
+			assert.Equal(t, tc.expectedStatus, observedResource.Status)
+		})
+	}
+}

--- a/pkg/kstatus/observe/observers/deployment.go
+++ b/pkg/kstatus/observe/observers/deployment.go
@@ -1,0 +1,78 @@
+package observers
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func NewDeploymentObserver(reader observer.ClusterReader, mapper meta.RESTMapper, rsObserver observer.ResourceObserver) observer.ResourceObserver {
+	return &DeploymentObserver{
+		BaseObserver: BaseObserver{
+			Reader:            reader,
+			Mapper:            mapper,
+			computeStatusFunc: status.Compute,
+		},
+		RsObserver: rsObserver,
+	}
+}
+
+// DeploymentObserver is an observer that can fetch Deployment resources
+// from the cluster, knows how to find any ReplicaSets belonging to the
+// Deployment, and compute status for the deployment.
+type DeploymentObserver struct {
+	BaseObserver
+
+	RsObserver observer.ResourceObserver
+}
+
+func (d *DeploymentObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
+	deployment, err := d.LookupResource(ctx, identifier)
+	if err != nil {
+		return d.handleObservedResourceError(identifier, err)
+	}
+	return d.ObserveObject(ctx, deployment)
+}
+
+func (d *DeploymentObserver) ObserveObject(ctx context.Context, deployment *unstructured.Unstructured) *event.ObservedResource {
+	identifier := toIdentifier(deployment)
+
+	observedReplicaSets, err := d.ObserveGeneratedResources(ctx, d.RsObserver, deployment,
+		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(), "spec", "selector")
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier: identifier,
+			Status:     status.UnknownStatus,
+			Resource:   deployment,
+			Error:      err,
+		}
+	}
+
+	// Currently this observer just uses the status library for computing
+	// status for the deployment. But we do have the status and state for all
+	// ReplicaSets and Pods in the ObservedReplicaSets data structure, so the
+	// rules can be improved to take advantage of this information.
+	res, err := d.computeStatusFunc(deployment)
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier:         identifier,
+			Status:             status.UnknownStatus,
+			Error:              err,
+			GeneratedResources: observedReplicaSets,
+		}
+	}
+
+	return &event.ObservedResource{
+		Identifier:         identifier,
+		Status:             res.Status,
+		Resource:           deployment,
+		Message:            res.Message,
+		GeneratedResources: observedReplicaSets,
+	}
+}

--- a/pkg/kstatus/observe/observers/deployment_test.go
+++ b/pkg/kstatus/observe/observers/deployment_test.go
@@ -1,0 +1,56 @@
+package observers
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+)
+
+func TestDeploymentObserver(t *testing.T) {
+	deploymentManifest := `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+`
+
+	replicaSetManifest1 := `
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: Foo-12345
+spec:
+  replicas: 1
+`
+
+	replicaSetManifest2 := `
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: Foo-54321
+spec:
+  replicas: 14
+`
+
+	replicaSetGVK := appsv1.SchemeGroupVersion.WithKind("ReplicaSet")
+
+	generatedObjects := []unstructured.Unstructured{
+		*testutil.YamlToUnstructured(t, replicaSetManifest1),
+		*testutil.YamlToUnstructured(t, replicaSetManifest2),
+	}
+
+	var newRsObserverFunc newResourceObserverFunc = func(reader observer.ClusterReader, mapper meta.RESTMapper) observer.ResourceObserver {
+		return NewDeploymentObserver(reader, mapper, &fakeResourceObserver{})
+	}
+
+	basicObserverTest(t, deploymentManifest, replicaSetGVK, generatedObjects, newRsObserverFunc)
+}

--- a/pkg/kstatus/observe/observers/replicaset.go
+++ b/pkg/kstatus/observe/observers/replicaset.go
@@ -1,0 +1,74 @@
+package observers
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func NewReplicaSetObserver(reader observer.ClusterReader, mapper meta.RESTMapper, podObserver observer.ResourceObserver) observer.ResourceObserver {
+	return &replicaSetObserver{
+		BaseObserver: BaseObserver{
+			Reader:            reader,
+			Mapper:            mapper,
+			computeStatusFunc: status.Compute,
+		},
+		PodObserver: podObserver,
+	}
+}
+
+// replicaSetObserver is an observer that can fetch ReplicaSet resources
+// from the cluster, knows how to find any Pods belonging to the ReplicaSet,
+// and compute status for the ReplicaSet.
+type replicaSetObserver struct {
+	BaseObserver
+
+	PodObserver observer.ResourceObserver
+}
+
+func (r *replicaSetObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
+	rs, err := r.LookupResource(ctx, identifier)
+	if err != nil {
+		return r.handleObservedResourceError(identifier, err)
+	}
+	return r.ObserveObject(ctx, rs)
+}
+
+func (r *replicaSetObserver) ObserveObject(ctx context.Context, rs *unstructured.Unstructured) *event.ObservedResource {
+	identifier := toIdentifier(rs)
+
+	observedPods, err := r.ObserveGeneratedResources(ctx, r.PodObserver, rs,
+		v1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "spec", "selector")
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier: identifier,
+			Status:     status.UnknownStatus,
+			Resource:   rs,
+			Error:      err,
+		}
+	}
+
+	res, err := r.computeStatusFunc(rs)
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier:         identifier,
+			Status:             status.UnknownStatus,
+			Error:              err,
+			GeneratedResources: observedPods,
+		}
+	}
+
+	return &event.ObservedResource{
+		Identifier:         identifier,
+		Status:             res.Status,
+		Resource:           rs,
+		Message:            res.Message,
+		GeneratedResources: observedPods,
+	}
+}

--- a/pkg/kstatus/observe/observers/replicaset_test.go
+++ b/pkg/kstatus/observe/observers/replicaset_test.go
@@ -1,0 +1,52 @@
+package observers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+)
+
+func TestReplicaSetObserver(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: Bar
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+`
+
+	podManifest1 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Bar-12345
+`
+
+	podManifest2 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Bar-54321
+`
+
+	gvk := v1.SchemeGroupVersion.WithKind("Pod")
+
+	generatedObjects := []unstructured.Unstructured{
+		*testutil.YamlToUnstructured(t, podManifest1),
+		*testutil.YamlToUnstructured(t, podManifest2),
+	}
+
+	var newRsObserverFunc newResourceObserverFunc = func(reader observer.ClusterReader, mapper meta.RESTMapper) observer.ResourceObserver {
+		return NewReplicaSetObserver(reader, mapper, &fakeResourceObserver{})
+	}
+
+	basicObserverTest(t, manifest, gvk, generatedObjects, newRsObserverFunc)
+}

--- a/pkg/kstatus/observe/observers/statefulset.go
+++ b/pkg/kstatus/observe/observers/statefulset.go
@@ -1,0 +1,74 @@
+package observers
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func NewStatefulSetObserver(reader observer.ClusterReader, mapper meta.RESTMapper, podObserver observer.ResourceObserver) observer.ResourceObserver {
+	return &StatefulSetObserver{
+		BaseObserver: BaseObserver{
+			Reader:            reader,
+			Mapper:            mapper,
+			computeStatusFunc: status.Compute,
+		},
+		PodObserver: podObserver,
+	}
+}
+
+// StatefulObserver is an observer that can fetch StatefulSet resources
+// from the cluster, knows how to find any Pods belonging to the
+// StatefulSet, and compute status for the StatefulSet.
+type StatefulSetObserver struct {
+	BaseObserver
+
+	PodObserver observer.ResourceObserver
+}
+
+func (s *StatefulSetObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
+	statefulSet, err := s.LookupResource(ctx, identifier)
+	if err != nil {
+		return s.handleObservedResourceError(identifier, err)
+	}
+	return s.ObserveObject(ctx, statefulSet)
+}
+
+func (s *StatefulSetObserver) ObserveObject(ctx context.Context, statefulSet *unstructured.Unstructured) *event.ObservedResource {
+	identifier := toIdentifier(statefulSet)
+
+	observedPods, err := s.ObserveGeneratedResources(ctx, s.PodObserver, statefulSet,
+		v1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "spec", "selector")
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier: identifier,
+			Status:     status.UnknownStatus,
+			Resource:   statefulSet,
+			Error:      err,
+		}
+	}
+
+	res, err := s.computeStatusFunc(statefulSet)
+	if err != nil {
+		return &event.ObservedResource{
+			Identifier:         identifier,
+			Status:             status.UnknownStatus,
+			Error:              err,
+			GeneratedResources: observedPods,
+		}
+	}
+
+	return &event.ObservedResource{
+		Identifier:         identifier,
+		Status:             res.Status,
+		Resource:           statefulSet,
+		Message:            res.Message,
+		GeneratedResources: observedPods,
+	}
+}

--- a/pkg/kstatus/observe/observers/statefulset_test.go
+++ b/pkg/kstatus/observe/observers/statefulset_test.go
@@ -1,0 +1,56 @@
+package observers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+)
+
+func TestStatefulSetObserver(t *testing.T) {
+	manifest := `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: FooBar
+spec:
+  selector:
+    matchLabels:
+      app: foobar
+  replicas: 3
+`
+
+	podManifest1 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Foobar-2
+  labels:
+    app: foobar
+`
+
+	podManifest2 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: Foobar-1
+  labels:
+    app: foobar
+`
+
+	gvk := v1.SchemeGroupVersion.WithKind("Pod")
+
+	generatedObjects := []unstructured.Unstructured{
+		*testutil.YamlToUnstructured(t, podManifest1),
+		*testutil.YamlToUnstructured(t, podManifest2),
+	}
+
+	var newRsObserverFunc newResourceObserverFunc = func(reader observer.ClusterReader, mapper meta.RESTMapper) observer.ResourceObserver {
+		return NewStatefulSetObserver(reader, mapper, &fakeResourceObserver{})
+	}
+
+	basicObserverTest(t, manifest, gvk, generatedObjects, newRsObserverFunc)
+}

--- a/pkg/kstatus/observe/observers/testing.go
+++ b/pkg/kstatus/observe/observers/testing.go
@@ -1,0 +1,138 @@
+package observers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/observer"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/testutil"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type newResourceObserverFunc func(reader observer.ClusterReader, mapper meta.RESTMapper) observer.ResourceObserver
+
+func basicObserverTest(t *testing.T, manifest string, generatedGVK schema.GroupVersionKind,
+	generatedObjects []unstructured.Unstructured, newObserverFunc newResourceObserverFunc) {
+	testCases := map[string]struct {
+		manifest       string
+		generatedGVK   schema.GroupVersionKind
+		listObjects    []unstructured.Unstructured
+		statusResult   *status.Result
+		statusErr      error
+		expectedStatus status.Status
+		expectError    bool
+		errMessage     string
+	}{
+		"observer has generated resources": {
+			manifest:     manifest,
+			generatedGVK: generatedGVK,
+			listObjects:  generatedObjects,
+			statusResult: &status.Result{
+				Status: status.CurrentStatus,
+			},
+			expectedStatus: status.CurrentStatus,
+			expectError:    false,
+		},
+		"looking up listObjects fails": {
+			manifest: manifest,
+			statusResult: &status.Result{
+				Status: status.CurrentStatus,
+			},
+			expectedStatus: status.UnknownStatus,
+			expectError:    true,
+			errMessage:     "no matches for",
+		},
+		"computing status fails": {
+			manifest:     manifest,
+			generatedGVK: generatedGVK,
+			statusResult: &status.Result{
+				Status: status.CurrentStatus,
+			},
+			statusErr:      fmt.Errorf("this is a test"),
+			expectedStatus: status.UnknownStatus,
+			expectError:    true,
+			errMessage:     "this is a test",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			fakeReader := &fakeObserverReader{
+				listResources: &unstructured.UnstructuredList{
+					Items: tc.listObjects,
+				},
+			}
+			fakeMapper := testutil.NewFakeRESTMapper(tc.generatedGVK)
+
+			object := testutil.YamlToUnstructured(t, tc.manifest)
+
+			observer := newObserverFunc(fakeReader, fakeMapper)
+			observer.SetComputeStatusFunc(func(u *unstructured.Unstructured) (*status.Result, error) {
+				return tc.statusResult, tc.statusErr
+			})
+
+			observedResource := observer.ObserveObject(context.Background(), object)
+
+			if tc.expectError {
+				if observedResource.Error == nil {
+					t.Errorf("expected error, but didn't get one")
+				}
+				assert.ErrorContains(t, observedResource.Error, tc.errMessage)
+				return
+			}
+
+			assert.Equal(t, tc.expectedStatus, observedResource.Status)
+			assert.Equal(t, len(tc.listObjects), len(observedResource.GeneratedResources))
+			assert.Assert(t, sort.IsSorted(observedResource.GeneratedResources))
+		})
+	}
+}
+
+type fakeObserverReader struct {
+	testutil.NoopObserverReader
+
+	getResource *unstructured.Unstructured
+	getErr      error
+
+	listResources *unstructured.UnstructuredList
+	listErr       error
+}
+
+func (f *fakeObserverReader) Get(_ context.Context, key client.ObjectKey, u *unstructured.Unstructured) error {
+	if f.getResource != nil {
+		u.Object = f.getResource.Object
+	}
+	return f.getErr
+}
+
+func (f *fakeObserverReader) ListNamespaceScoped(_ context.Context, list *unstructured.UnstructuredList, ns string, selector labels.Selector) error {
+	if f.listResources != nil {
+		list.Items = f.listResources.Items
+	}
+	return f.listErr
+}
+
+type fakeResourceObserver struct{}
+
+func (f *fakeResourceObserver) Observe(ctx context.Context, resource wait.ResourceIdentifier) *event.ObservedResource {
+	return nil
+}
+
+func (f *fakeResourceObserver) ObserveObject(ctx context.Context, object *unstructured.Unstructured) *event.ObservedResource {
+	identifier := toIdentifier(object)
+	return &event.ObservedResource{
+		Identifier: identifier,
+	}
+}
+
+func (f *fakeResourceObserver) SetComputeStatusFunc(_ observer.ComputeStatusFunc) {}


### PR DESCRIPTION
Implementations of the ResourceObserver interface for some of the common Kubernetes resources. 

There is still some boilerplate code needed, but I haven't found a better way to handle it yet while still making them somewhat readable. I plan to keep iterating on this as we add support for more resource types.

@pwittrock @monopole 