### PR TITLE
Collector to help consumers of the Observer library

### DIFF
--- a/pkg/kstatus/observe/collector/collector.go
+++ b/pkg/kstatus/observe/collector/collector.go
@@ -1,0 +1,111 @@
+package collector
+
+import (
+	"sort"
+	"sync"
+
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func NewObservedStatusCollector(identifiers []wait.ResourceIdentifier) *ObservedStatusCollector {
+	observations := make(map[wait.ResourceIdentifier]*event.ObservedResource)
+	for _, id := range identifiers {
+		observations[id] = &event.ObservedResource{
+			Identifier: id,
+			Status:     status.UnknownStatus,
+		}
+	}
+	return &ObservedStatusCollector{
+		aggregateStatus: status.UnknownStatus,
+		observations:    observations,
+	}
+}
+
+// ObservedStatusCollector is for use by clients of the observe library and provides
+// a way to keep track of the latest status/state for all the observed resources. The collector
+// is set up to listen to the eventChannel and keep the latest event for each resource. It also
+// provides a way to fetch the latest state for all resources and the aggregated status at any point.
+// The functions already handles synchronization so it can be used by multiple goroutines.
+type ObservedStatusCollector struct {
+	mux sync.RWMutex
+
+	lastEventType event.EventType
+
+	aggregateStatus status.Status
+
+	observations map[wait.ResourceIdentifier]*event.ObservedResource
+
+	error error
+}
+
+// Observe kicks off the goroutine that will listen for the events on the eventChannel. It is also
+// provided a stop channel that can be used by the caller to stop the collector before the
+// eventChannel is closed. It returns a channel that will be closed the collector stops listening to
+// the eventChannel.
+func (o *ObservedStatusCollector) Observe(eventChannel <-chan event.Event, stop <-chan struct{}) <-chan struct{} {
+	completed := make(chan struct{})
+	go func() {
+		defer close(completed)
+		for {
+			select {
+			case <-stop:
+				return
+			case event, more := <-eventChannel:
+				if !more {
+					return
+				}
+				o.processEvent(event)
+			}
+		}
+	}()
+	return completed
+}
+
+func (o *ObservedStatusCollector) processEvent(e event.Event) {
+	o.mux.Lock()
+	defer o.mux.Unlock()
+	o.lastEventType = e.EventType
+	if e.EventType == event.ErrorEvent {
+		o.error = e.Error
+		return
+	}
+	o.aggregateStatus = e.AggregateStatus
+	if e.EventType == event.ResourceUpdateEvent {
+		observedResource := e.Resource
+		o.observations[observedResource.Identifier] = observedResource
+	}
+}
+
+// Observation contains the latest state known by the collector as returned
+// by a call to the LatestObservation function.
+type Observation struct {
+	LastEventType event.EventType
+
+	AggregateStatus status.Status
+
+	ObservedResources []*event.ObservedResource
+
+	Error error
+}
+
+// LatestObservation returns an Observation instance, which contains the
+// latest information about the resources known by the collector.
+func (o *ObservedStatusCollector) LatestObservation() *Observation {
+	o.mux.RLock()
+	defer o.mux.RUnlock()
+
+	var observedResources event.ObservedResources
+	for _, observedResource := range o.observations {
+		observedResources = append(observedResources, observedResource)
+	}
+	sort.Sort(observedResources)
+
+	return &Observation{
+		LastEventType:     o.lastEventType,
+		AggregateStatus:   o.aggregateStatus,
+		ObservedResources: observedResources,
+		Error:             o.error,
+	}
+}

--- a/pkg/kstatus/observe/collector/collector_test.go
+++ b/pkg/kstatus/observe/collector/collector_test.go
@@ -1,0 +1,181 @@
+package collector
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/observe/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
+)
+
+func TestCollectorStopsWhenEventChannelIsClosed(t *testing.T) {
+	var identifiers []wait.ResourceIdentifier
+
+	collector := NewObservedStatusCollector(identifiers)
+
+	eventCh := make(chan event.Event)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	completedCh := collector.Observe(eventCh, stopCh)
+
+	timer := time.NewTimer(3 * time.Second)
+
+	close(eventCh)
+	select {
+	case <-timer.C:
+		t.Errorf("expected collector to close the completedCh, but it didn't")
+	case <-completedCh:
+		timer.Stop()
+	}
+}
+
+func TestCollectorStopWhenStopChannelIsClosed(t *testing.T) {
+	var identifiers []wait.ResourceIdentifier
+
+	collector := NewObservedStatusCollector(identifiers)
+
+	eventCh := make(chan event.Event)
+	defer close(eventCh)
+	stopCh := make(chan struct{})
+
+	completedCh := collector.Observe(eventCh, stopCh)
+
+	timer := time.NewTimer(3 * time.Second)
+
+	close(stopCh)
+	select {
+	case <-timer.C:
+		t.Errorf("expected collector to close the completedCh, but it didn't")
+	case <-completedCh:
+		timer.Stop()
+	}
+}
+
+var (
+	deploymentGVK       = appsv1.SchemeGroupVersion.WithKind("Deployment")
+	statefulSetGVK      = appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+	resourceIdentifiers = map[string]wait.ResourceIdentifier{
+		"deployment": {
+			GroupKind: deploymentGVK.GroupKind(),
+			Name:      "Foo",
+			Namespace: "default",
+		},
+		"statefulSet": {
+			GroupKind: statefulSetGVK.GroupKind(),
+			Name:      "Bar",
+			Namespace: "default",
+		},
+	}
+)
+
+func TestCollectorEventProcessing(t *testing.T) {
+	testCases := map[string]struct {
+		identifiers []wait.ResourceIdentifier
+		events      []event.Event
+	}{
+		"no resources and no events": {},
+		"single resource and single event": {
+			identifiers: []wait.ResourceIdentifier{
+				resourceIdentifiers["deployment"],
+			},
+			events: []event.Event{
+				{
+					EventType:       event.ResourceUpdateEvent,
+					AggregateStatus: status.CurrentStatus,
+					Resource: &event.ObservedResource{
+						Identifier: resourceIdentifiers["deployment"],
+					},
+				},
+			},
+		},
+		"multiple resources and multiple events": {
+			identifiers: []wait.ResourceIdentifier{
+				resourceIdentifiers["deployment"],
+				resourceIdentifiers["statefulSet"],
+			},
+			events: []event.Event{
+				{
+					EventType:       event.ResourceUpdateEvent,
+					AggregateStatus: status.UnknownStatus,
+					Resource: &event.ObservedResource{
+						Identifier: resourceIdentifiers["deployment"],
+					},
+				},
+				{
+					EventType:       event.ResourceUpdateEvent,
+					AggregateStatus: status.InProgressStatus,
+					Resource: &event.ObservedResource{
+						Identifier: resourceIdentifiers["statefulSet"],
+					},
+				},
+				{
+					EventType:       event.ResourceUpdateEvent,
+					AggregateStatus: status.CurrentStatus,
+					Resource: &event.ObservedResource{
+						Identifier: resourceIdentifiers["deployment"],
+					},
+				},
+				{
+					EventType:       event.ResourceUpdateEvent,
+					AggregateStatus: status.InProgressStatus,
+					Resource: &event.ObservedResource{
+						Identifier: resourceIdentifiers["statefulSet"],
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			collector := NewObservedStatusCollector(tc.identifiers)
+
+			eventCh := make(chan event.Event)
+			defer close(eventCh)
+			stopCh := make(chan struct{})
+
+			collector.Observe(eventCh, stopCh)
+
+			var latestEvent *event.Event
+			latestEventByIdentifier := make(map[wait.ResourceIdentifier]event.Event)
+			for _, event := range tc.events {
+				if event.Resource != nil {
+					latestEventByIdentifier[event.Resource.Identifier] = event
+				}
+				e := event
+				latestEvent = &e
+				eventCh <- event
+			}
+			// Give the collector some time to process the event.
+			<-time.NewTimer(time.Second).C
+
+			observation := collector.LatestObservation()
+
+			var expectedObservation *Observation
+			if latestEvent != nil {
+				expectedObservation = &Observation{
+					LastEventType:   latestEvent.EventType,
+					AggregateStatus: latestEvent.AggregateStatus,
+				}
+			} else {
+				expectedObservation = &Observation{
+					AggregateStatus: status.UnknownStatus,
+				}
+			}
+
+			var observedResources event.ObservedResources
+			for _, event := range latestEventByIdentifier {
+				observedResources = append(observedResources, event.Resource)
+			}
+			sort.Sort(observedResources)
+			expectedObservation.ObservedResources = observedResources
+
+			assert.DeepEqual(t, expectedObservation, observation)
+		})
+	}
+}


### PR DESCRIPTION
The Observe library provides a stream of events back to the caller. This is useful in many situations, but sometimes the client needs to be able to access the status and state of all resources at a point in time. The Collector listens to the stream of events from the Observer library, and keeps track of the latest event for each resource. It provides a function for clients to fetch the latest state/status at any point. The Collector is threadsafe.

@monopole @pwittrock 