### PR TITLE
Clear current grouping object before prune in destroyer

### DIFF
--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -70,6 +70,11 @@ func (d *Destroyer) Run() <-chan event.Event {
 	go func() {
 		defer close(ch)
 		infos, _ := d.ApplyOptions.GetObjects()
+		// Clear the data/inventory section of the grouping object configmap,
+		// so the prune will calculate the prune set as all the objects,
+		// deleting everything. We can ignore the error, since the Prune
+		// will catch the same problems.
+		_ = prune.ClearGroupingObj(infos)
 		err := d.PruneOptions.Prune(infos, ch)
 		if err != nil {
 			// If we see an error here we just report it on the channel and then

--- a/pkg/apply/prune/grouping.go
+++ b/pkg/apply/prune/grouping.go
@@ -230,6 +230,7 @@ func RetrieveInventoryFromGroupingObj(infos []*resource.Info) ([]*ObjMetadata, e
 // we can't set the empty inventory on the grouping object. If successful,
 // returns nil.
 func ClearGroupingObj(infos []*resource.Info) error {
+	// Initially, find the grouping object ConfigMap (in Unstructured format).
 	var groupingObj *unstructured.Unstructured
 	for _, info := range infos {
 		obj := info.Object
@@ -242,13 +243,9 @@ func ClearGroupingObj(infos []*resource.Info) error {
 			break
 		}
 	}
-
-	// If we've found the grouping object, store the object metadata inventory
-	// in the grouping config map.
 	if groupingObj == nil {
 		return fmt.Errorf("grouping object not found")
 	}
-
 	// Clears the inventory map of the ConfigMap "data" section.
 	emptyMap := map[string]string{}
 	err := unstructured.SetNestedStringMap(groupingObj.UnstructuredContent(),


### PR DESCRIPTION
* Creates new method `ClearGroupingObject` to clear the inventory data in the grouping `ConfigMap`.
* Run `ClearGroupingObject` in `Destroyer` before `Prune` to fix bug where `ConfigMap` has non-empty or non-inventory data map.
* Adds unit tests for `ClearGroupingObject`
* Tested manually to destroy applied objects when `ConfigMap` has entries in the data (inventory) section.

/sig cli
/priority important-soon

```release-note
NONE
```