### PR TITLE
Remove/hide unused flags for kapply commands

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -43,14 +43,14 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 	}
 
 	cmdutil.CheckErr(applier.SetFlags(cmd))
-
 	cmdutil.AddValidateFlags(cmd)
+	_ = cmd.Flags().MarkHidden("validate")
+
 	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
-	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun,
-		"If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result "+
-			"of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.")
-	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun,
-		"If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
+	// Necessary because ApplyOptions depends on it--hidden.
+	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun, "NOT USED")
+	_ = cmd.Flags().MarkHidden("dry-run")
+
 	cmdutil.AddServerSideApplyFlags(cmd)
 
 	return cmd

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -44,8 +44,10 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	destroyer.SetFlags(cmd)
 
 	cmdutil.AddValidateFlags(cmd)
-	cmd.Flags().BoolVar(&destroyer.DryRun, "dry-run", destroyer.DryRun,
-		"If true, only print the object that would be sent and action which would be performed, without performing it.")
+	_ = cmd.Flags().MarkHidden("validate")
+
+	cmd.Flags().BoolVar(&destroyer.DryRun, "dry-run", destroyer.DryRun, "If true, only print the objects that would be deleted, without performing it.")
+
 	cmdutil.AddServerSideApplyFlags(cmd)
 	return cmd
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -46,10 +46,11 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	}
 
 	cmdutil.CheckErr(applier.SetFlags(cmd))
-
 	cmdutil.AddValidateFlags(cmd)
+	_ = cmd.Flags().MarkHidden("validate")
+
 	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
-	// Necessary because ApplyOptions depends on it--not used.
+	// Necessary because ApplyOptions depends on it--hidden.
 	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun, "NOT USED")
 	_ = cmd.Flags().MarkHidden("dry-run")
 

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -61,18 +61,14 @@ type Applier struct {
 // Initialize sets up the Applier for actually doing an apply against
 // a cluster. This involves validating command line inputs and configuring
 // clients for communicating with the cluster.
-
 func (a *Applier) Initialize(cmd *cobra.Command, paths []string) error {
-	a.ApplyOptions.PreProcessorFn = prune.PrependGroupingObject(a.ApplyOptions)
-
 	fileNameFlags := processPaths(paths)
 	a.ApplyOptions.DeleteFlags.FileNameFlags = &fileNameFlags
-
 	err := a.ApplyOptions.Complete(a.factory, cmd)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up ApplyOptions", 1)
 	}
-
+	a.ApplyOptions.PreProcessorFn = prune.PrependGroupingObject(a.ApplyOptions)
 	err = a.PruneOptions.Initialize(a.factory, a.ApplyOptions.Namespace)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)
@@ -102,6 +98,11 @@ func (a *Applier) SetFlags(cmd *cobra.Command) error {
 		}
 	}
 	a.ApplyOptions.RecordFlags.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("cascade")
+	_ = cmd.Flags().MarkHidden("force")
+	_ = cmd.Flags().MarkHidden("grace-period")
+	_ = cmd.Flags().MarkHidden("timeout")
+	_ = cmd.Flags().MarkHidden("wait")
 	a.StatusOptions.AddFlags(cmd)
 	a.ApplyOptions.Overwrite = true
 	return nil

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -97,6 +97,10 @@ func (d *Destroyer) Run() <-chan event.Event {
 // of cobra flags from the Destroyer.
 func (d *Destroyer) SetFlags(cmd *cobra.Command) {
 	d.ApplyOptions.DeleteFlags.AddFlags(cmd)
-	d.ApplyOptions.RecordFlags.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("cascade")
+	_ = cmd.Flags().MarkHidden("force")
+	_ = cmd.Flags().MarkHidden("grace-period")
+	_ = cmd.Flags().MarkHidden("timeout")
+	_ = cmd.Flags().MarkHidden("wait")
 	d.ApplyOptions.Overwrite = true
 }


### PR DESCRIPTION
* First pass at removing (and hiding) unused command flags for the following commands:
1. `kapply apply`
2. `kapply preview`
3. `kapply destroy`

* Tested manually by running `kapply <cmd> -h` and manually checking flags.
* Address  `server-side` flags in future PR.

/sig cli
/priority important-soon

```release-note
NONE
```