### PR TITLE
Check for presence of grouping object before applying resources

### DIFF
--- a/pkg/apply/prune/grouping.go
+++ b/pkg/apply/prune/grouping.go
@@ -104,13 +104,14 @@ func PrependGroupingObject(o *apply.ApplyOptions) func() error {
 			return err
 		}
 		_, exists := FindGroupingObject(infos)
-		if exists {
-			if err := AddInventoryToGroupingObj(infos); err != nil {
-				return err
-			}
-			if !SortGroupingObject(infos) {
-				return err
-			}
+		if !exists {
+			return fmt.Errorf("no grouping object found")
+		}
+		if err := AddInventoryToGroupingObj(infos); err != nil {
+			return err
+		}
+		if !SortGroupingObject(infos) {
+			return err
 		}
 		return nil
 	}


### PR DESCRIPTION
Currently a missing grouping object is not detected until after the resources have been applied. With this change, we check for this situation before making any changes to the cluster and report an error if we can't it.

@seans3 