### PR TITLE
Hides server-side and record flags.

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -42,16 +42,21 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
+	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
 	cmdutil.CheckErr(applier.SetFlags(cmd))
+
+	// The following flags are added, but hidden because other code
+	// depend on them when parsing flags. These flags are hidden and unused.
+	var unusedBool bool
+	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
+	_ = cmd.Flags().MarkHidden("dry-run")
 	cmdutil.AddValidateFlags(cmd)
 	_ = cmd.Flags().MarkHidden("validate")
-
-	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
-	// Necessary because ApplyOptions depends on it--hidden.
-	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun, "NOT USED")
-	_ = cmd.Flags().MarkHidden("dry-run")
-
+	// Server-side flags are hidden for now.
 	cmdutil.AddServerSideApplyFlags(cmd)
+	_ = cmd.Flags().MarkHidden("server-side")
+	_ = cmd.Flags().MarkHidden("force-conflicts")
+	_ = cmd.Flags().MarkHidden("field-manager")
 
 	return cmd
 }

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -40,11 +40,15 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 
 	cmdutil.CheckErr(destroyer.SetFlags(cmd))
 
+	// The following flags are added, but hidden because other code
+	// dependencies when parsing flags. These flags are hidden and unused.
 	cmdutil.AddValidateFlags(cmd)
 	_ = cmd.Flags().MarkHidden("validate")
-
-	cmd.Flags().BoolVar(&destroyer.DryRun, "dry-run", destroyer.DryRun, "If true, only print the objects that would be deleted, without performing it.")
-
+	// Server-side flags are hidden for now.
 	cmdutil.AddServerSideApplyFlags(cmd)
+	_ = cmd.Flags().MarkHidden("server-side")
+	_ = cmd.Flags().MarkHidden("force-conflicts")
+	_ = cmd.Flags().MarkHidden("field-manager")
+
 	return cmd
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -45,16 +45,21 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		},
 	}
 
+	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
 	cmdutil.CheckErr(applier.SetFlags(cmd))
+
+	// The following flags are added, but hidden because other code
+	// dependend on them when parsing flags. These flags are hidden and unused.
+	var unusedBool bool
+	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
+	_ = cmd.Flags().MarkHidden("dry-run")
 	cmdutil.AddValidateFlags(cmd)
 	_ = cmd.Flags().MarkHidden("validate")
-
-	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
-	// Necessary because ApplyOptions depends on it--hidden.
-	cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun, "NOT USED")
-	_ = cmd.Flags().MarkHidden("dry-run")
-
+	// Server-side flags are hidden for now.
 	cmdutil.AddServerSideApplyFlags(cmd)
+	_ = cmd.Flags().MarkHidden("server-side")
+	_ = cmd.Flags().MarkHidden("force-conflicts")
+	_ = cmd.Flags().MarkHidden("field-manager")
 
 	return cmd
 }

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -99,6 +99,7 @@ func (a *Applier) SetFlags(cmd *cobra.Command) error {
 		}
 	}
 	a.ApplyOptions.RecordFlags.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("record")
 	_ = cmd.Flags().MarkHidden("cascade")
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -106,6 +106,7 @@ func (d *Destroyer) SetFlags(cmd *cobra.Command) error {
 		}
 	}
 	d.ApplyOptions.RecordFlags.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("record")
 	_ = cmd.Flags().MarkHidden("cascade")
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")


### PR DESCRIPTION
* Hides server-side and record flags for the following commands:
1. `kapply apply`
2. `kapply preview`
3. `kapply destroy`

* Re-organizes flags so the hidden/unused flags are grouped together.
* Tested manually by running `kapply <cmd> -h` and manually checking flags.

/sig cli
/priority important-soon

```release-note
NONE
```