### PR TITLE
Rename DefaultObserver to genericObserver

### DIFF
--- a/pkg/kstatus/observe/observers/common.go
+++ b/pkg/kstatus/observe/observers/common.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (

--- a/pkg/kstatus/observe/observers/common_test.go
+++ b/pkg/kstatus/observe/observers/common_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (

--- a/pkg/kstatus/observe/observers/deployment_test.go
+++ b/pkg/kstatus/observe/observers/deployment_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (

--- a/pkg/kstatus/observe/observers/generic_test.go
+++ b/pkg/kstatus/observe/observers/generic_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (
@@ -23,7 +26,7 @@ var (
 	namespace = "default"
 )
 
-func TestDefaultObserver(t *testing.T) {
+func TestGenericObserver(t *testing.T) {
 	testCases := map[string]struct {
 		result             *status.Result
 		err                error
@@ -57,7 +60,7 @@ func TestDefaultObserver(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			fakeReader := testutil.NewNoopObserverReader()
 			fakeMapper := testutil.NewFakeRESTMapper()
-			observer := NewDefaultObserver(fakeReader, fakeMapper)
+			observer := NewGenericObserver(fakeReader, fakeMapper)
 			observer.SetComputeStatusFunc(func(u *unstructured.Unstructured) (*status.Result, error) {
 				return tc.result, tc.err
 			})

--- a/pkg/kstatus/observe/observers/replicaset.go
+++ b/pkg/kstatus/observe/observers/replicaset.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (
@@ -31,6 +34,8 @@ type replicaSetObserver struct {
 
 	PodObserver observer.ResourceObserver
 }
+
+var _ observer.ResourceObserver = &replicaSetObserver{}
 
 func (r *replicaSetObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
 	rs, err := r.LookupResource(ctx, identifier)

--- a/pkg/kstatus/observe/observers/replicaset_test.go
+++ b/pkg/kstatus/observe/observers/replicaset_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (

--- a/pkg/kstatus/observe/observers/statefulset.go
+++ b/pkg/kstatus/observe/observers/statefulset.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (
@@ -13,7 +16,7 @@ import (
 )
 
 func NewStatefulSetObserver(reader observer.ClusterReader, mapper meta.RESTMapper, podObserver observer.ResourceObserver) observer.ResourceObserver {
-	return &StatefulSetObserver{
+	return &statefulSetObserver{
 		BaseObserver: BaseObserver{
 			Reader:            reader,
 			Mapper:            mapper,
@@ -26,13 +29,15 @@ func NewStatefulSetObserver(reader observer.ClusterReader, mapper meta.RESTMappe
 // StatefulObserver is an observer that can fetch StatefulSet resources
 // from the cluster, knows how to find any Pods belonging to the
 // StatefulSet, and compute status for the StatefulSet.
-type StatefulSetObserver struct {
+type statefulSetObserver struct {
 	BaseObserver
 
 	PodObserver observer.ResourceObserver
 }
 
-func (s *StatefulSetObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
+var _ observer.ResourceObserver = &statefulSetObserver{}
+
+func (s *statefulSetObserver) Observe(ctx context.Context, identifier wait.ResourceIdentifier) *event.ObservedResource {
 	statefulSet, err := s.LookupResource(ctx, identifier)
 	if err != nil {
 		return s.handleObservedResourceError(identifier, err)
@@ -40,7 +45,7 @@ func (s *StatefulSetObserver) Observe(ctx context.Context, identifier wait.Resou
 	return s.ObserveObject(ctx, statefulSet)
 }
 
-func (s *StatefulSetObserver) ObserveObject(ctx context.Context, statefulSet *unstructured.Unstructured) *event.ObservedResource {
+func (s *statefulSetObserver) ObserveObject(ctx context.Context, statefulSet *unstructured.Unstructured) *event.ObservedResource {
 	identifier := toIdentifier(statefulSet)
 
 	observedPods, err := s.ObserveGeneratedResources(ctx, s.PodObserver, statefulSet,

--- a/pkg/kstatus/observe/observers/statefulset_test.go
+++ b/pkg/kstatus/observe/observers/statefulset_test.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (

--- a/pkg/kstatus/observe/observers/testing.go
+++ b/pkg/kstatus/observe/observers/testing.go
@@ -1,3 +1,6 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package observers
 
 import (


### PR DESCRIPTION
This PR addresses some comments in #37.
It renames the DefaultObserver to genericObserver and makes all the other observer types package private.
Adds `var _ observer.ResourceObserver = &<ObserverType>` to each of the observers.

@pwittrock 