### PR TITLE
Fixes destroy command crash when dry-run flag not defined

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -42,6 +42,8 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 
 	// The following flags are added, but hidden because other code
 	// dependencies when parsing flags. These flags are hidden and unused.
+	var unusedBool bool
+	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
 	cmdutil.AddValidateFlags(cmd)
 	_ = cmd.Flags().MarkHidden("validate")
 	// Server-side flags are hidden for now.


### PR DESCRIPTION
* Fixes crash where `dry-run` flag is not defined in `destroy` command. This flag is referenced elsewhere, and it is necessary, even if unused.
* Tested manually by running `kapply destroy ...`

/sig cli
/priority important-soon

```release-note
NONE
```