### PR TITLE
Update the flags used to enable and configure wait for status in applier

### DIFF
--- a/examples/alphaTestExamples/MultipleServcies.md
+++ b/examples/alphaTestExamples/MultipleServcies.md
@@ -90,7 +90,7 @@ kind create cluster
 Let's apply the wordpress and mysql services.
 <!-- @RunWordpressAndMysql @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE/mysql --status > $OUTPUT/status;
+kapply apply $BASE/mysql --wait-for-reconcile > $OUTPUT/status;
 
 expectedOutputLine "deployment.apps/mysql is Current: Deployment is available. Replicas: 1"
 
@@ -100,7 +100,7 @@ expectedOutputLine "configmap/inventory-map-mysql-57005c71 is Current: Resource 
 
 expectedOutputLine "service/mysql is Current: Service is ready"
 
-kapply apply $BASE/wordpress --status > $OUTPUT/status;
+kapply apply $BASE/wordpress --wait-for-reconcile > $OUTPUT/status;
 
 expectedOutputLine "configmap/inventory-map-wordpress-2fbd5b91 is Current: Resource is always ready"
 

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -167,7 +167,7 @@ kind create cluster
 Use the `kapply` binary in `MYGOBIN` to apply a deployment and verify it is successful.
 <!-- @runHelloApp @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE --status > $OUTPUT/status;
+kapply apply $BASE --wait-for-reconcile > $OUTPUT/status;
 
 expectedOutputLine "namespace/hellospace is Current: Resource is current"
 
@@ -198,7 +198,7 @@ EOF
 
 rm $BASE/configMap.yaml
 
-kapply apply $BASE --status > $OUTPUT/status;
+kapply apply $BASE --wait-for-reconcile > $OUTPUT/status;
 
 expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
 

--- a/pkg/apply/status.go
+++ b/pkg/apply/status.go
@@ -24,7 +24,7 @@ type StatusOptions struct {
 }
 
 func (s *StatusOptions) AddFlags(c *cobra.Command) {
-	c.Flags().BoolVar(&s.wait, "status", s.wait, "Wait for all applied resources to reach the Current status.")
-	c.Flags().DurationVar(&s.period, "status-period", s.period, "Polling period for resource statuses.")
-	c.Flags().DurationVar(&s.Timeout, "status-timeout", s.Timeout, "Timeout threshold for waiting for all resources to reach the Current status.")
+	c.Flags().BoolVar(&s.wait, "wait-for-reconcile", s.wait, "Wait for all applied resources to reach the Current status.")
+	c.Flags().DurationVar(&s.period, "wait-polling-period", s.period, "Polling period for resource statuses.")
+	c.Flags().DurationVar(&s.Timeout, "wait-timeout", s.Timeout, "Timeout threshold for waiting for all resources to reach the Current status.")
 }


### PR DESCRIPTION
Update the name of the flags for enabling and configuring status during apply. The names are a little longer than I wanted, but both `--wait` and `--timeout` are unavailable because they are already set by existing kubectl code.

@seans3 
@pwittrock 