### PR TITLE
Destroy flag for preview

### DIFF
--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -12,11 +12,14 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
 // NewCmdApply creates the `apply` command
 func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	applier := apply.NewApplier(f, ioStreams)
+	destroyer := apply.NewDestroyer(f, ioStreams)
+
 	printer := &apply.BasicPrinter{
 		IOStreams: ioStreams,
 	}
@@ -27,17 +30,26 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Short:                 i18n.T("Preview the apply of a configuration"),
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			// Set DryRun option true before Initialize. DryRun is propagated to
-			// ApplyOptions and PruneOptions in Initialize.
-			applier.DryRun = true
-			cmdutil.CheckErr(applier.Initialize(cmd, args))
+			var ch <-chan event.Event
+			cmdutil.CheckErr(destroyer.Initialize(cmd, args))
+			// if destroy flag is set in preview, transmit it to destroyer DryRun flag
+			// and pivot execution to destroy with dry-run
+			if !destroyer.DryRun {
+				// Set DryRun option true before Initialize. DryRun is propagated to
+				// ApplyOptions and PruneOptions in Initialize.
+				applier.DryRun = true
+				cmdutil.CheckErr(applier.Initialize(cmd, args))
 
-			// Create a context with the provided timout from the cobra parameter.
-			ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
-			defer cancel()
-			// Run the applier. It will return a channel where we can receive updates
-			// to keep track of progress and any issues.
-			ch := applier.Run(ctx)
+				// Create a context with the provided timout from the cobra parameter.
+				ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
+				defer cancel()
+
+				// Run the applier. It will return a channel where we can receive updates
+				// to keep track of progress and any issues.
+				ch = applier.Run(ctx)
+			} else {
+				ch = destroyer.Run()
+			}
 
 			// The printer will print updates from the channel. It will block
 			// until the channel is closed.
@@ -52,6 +64,7 @@ func NewCmdPreview(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	// dependend on them when parsing flags. These flags are hidden and unused.
 	var unusedBool bool
 	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
+	cmd.Flags().BoolVar(&destroyer.DryRun, "destroy", destroyer.DryRun, "If true, preview of destroy operations will be displayed.")
 	_ = cmd.Flags().MarkHidden("dry-run")
 	cmdutil.AddValidateFlags(cmd)
 	_ = cmd.Flags().MarkHidden("validate")

--- a/examples/alphaTestExamples/MultipleServcies.md
+++ b/examples/alphaTestExamples/MultipleServcies.md
@@ -115,15 +115,11 @@ Destroy one service and make sure that only that service is destroyed and clean-
 ```
 kapply destroy $BASE/wordpress > $OUTPUT/status;
 
-expectedOutputLine "service/wordpress pruned"
+expectedOutputLine "service/wordpress deleted"
 
-expectedOutputLine "deployment.apps/wordpress pruned"
+expectedOutputLine "deployment.apps/wordpress deleted"
 
-expectedOutputLine "configmap/inventory-map-wordpress-2fbd5b91 pruned"
-
-test 3 == \
-  $(grep "" $OUTPUT/status | wc -l); \
-  echo $?
+expectedOutputLine "configmap/inventory-map-wordpress-2fbd5b91 deleted"
 
 kind delete cluster;
 ```

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -217,15 +217,25 @@ expectedOutputLine "configmap/inventory-map-78829196 pruned"
 Clean-up the cluster 
 <!-- @deleteKindCluster @testE2EAgainstLatestRelease -->
 ```
+kapply preview $BASE --destroy > $OUTPUT/status;
+
+expectedOutputLine "deployment.apps/the-deployment deleted"
+
+expectedOutputLine "configmap/the-map2 deleted"
+
+expectedOutputLine "service/the-service deleted"
+
+expectedOutputLine "configmap/inventory-map-7e38956e deleted"
+
 kapply destroy $BASE > $OUTPUT/status;
 
-expectedOutputLine "deployment.apps/the-deployment pruned"
+expectedOutputLine "deployment.apps/the-deployment deleted"
 
-expectedOutputLine "configmap/the-map2 pruned"
+expectedOutputLine "configmap/the-map2 deleted"
 
-expectedOutputLine "service/the-service pruned"
+expectedOutputLine "service/the-service deleted"
 
-expectedOutputLine "configmap/inventory-map-7e38956e pruned"
+expectedOutputLine "configmap/inventory-map-7e38956e deleted"
 
 kind delete cluster;
 ```


### PR DESCRIPTION
*Why*

This PR is to add destroy flag to preview command. By this, users can see the preview of operations of destroy command.