### PR TITLE
Add linter to prow make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: generate license fix vet fmt test lint tidy
 # https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/cli-utils
 .PHONY: prow-presubmit-check
 prow-presubmit-check: \
-	test
+	test lint
 
 fix:
 	go fix ./...


### PR DESCRIPTION
This should make the prow build equivalent to the travis build so we can turn off travis.

@seans3 @monopole 