### PR TITLE
Improve status for pods

### DIFF
--- a/pkg/kstatus/status/status_augment_test.go
+++ b/pkg/kstatus/status/status_augment_test.go
@@ -58,7 +58,7 @@ func TestAugmentConditions(t *testing.T) {
 				{
 					Type:   ConditionInProgress,
 					Status: corev1.ConditionTrue,
-					Reason: "PodNotReady",
+					Reason: "PodRunningNotReady",
 				},
 			},
 		},
@@ -77,7 +77,7 @@ func TestAugmentConditions(t *testing.T) {
 				{
 					Type:   ConditionInProgress,
 					Status: corev1.ConditionTrue,
-					Reason: "PodNotReady",
+					Reason: "PodRunningNotReady",
 				},
 				{
 					Type:   "Ready",

--- a/pkg/kstatus/status/util.go
+++ b/pkg/kstatus/status/util.go
@@ -22,6 +22,15 @@ func newInProgressCondition(reason, message string) Condition {
 	}
 }
 
+func newFailedCondition(reason, message string) Condition {
+	return Condition{
+		Type:    ConditionFailed,
+		Status:  corev1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
 // newInProgressStatus creates a status Result with the InProgress status
 // and an InProgress condition.
 func newInProgressStatus(reason, message string) *Result {
@@ -29,6 +38,14 @@ func newInProgressStatus(reason, message string) *Result {
 		Status:     InProgressStatus,
 		Message:    message,
 		Conditions: []Condition{newInProgressCondition(reason, message)},
+	}
+}
+
+func newFailedStatus(reason, message string) *Result {
+	return &Result{
+		Status:     FailedStatus,
+		Message:    message,
+		Conditions: []Condition{newFailedCondition(reason, message)},
 	}
 }
 
@@ -66,6 +83,20 @@ func GetObjectWithConditions(in map[string]interface{}) (*ObjWithConditions, err
 		return nil, err
 	}
 	return out, nil
+}
+
+func hasConditionWithStatus(conditions []BasicCondition, conditionType string, status corev1.ConditionStatus) bool {
+	_, found := getConditionWithStatus(conditions, conditionType, status)
+	return found
+}
+
+func getConditionWithStatus(conditions []BasicCondition, conditionType string, status corev1.ConditionStatus) (BasicCondition, bool) {
+	for _, c := range conditions {
+		if c.Type == conditionType && c.Status == status {
+			return c, true
+		}
+	}
+	return BasicCondition{}, false
 }
 
 // GetStringField return field as string defaulting to value if not found


### PR DESCRIPTION
This improves the status rules for pods. It makes a few changes:
- A pod that has the `Failed` phase (completed unsuccessfully), is considered Current. I think this makes the most sense from the apply perspective.
- This now checks to see if the pod is unschedulable, and if so, returns the `Failed` status. 
- It checks to see if the pod has any containers that is crashlooping. If so, it sets the status to `Failed`.

This change also demonstrates that working with unstructured objects in the status rules are pretty awkward. We should consider either converting to the actual types or use the kyaml library.

@seans3 @pwittrock @monopole @knverey