### PR TITLE
Turn off default kubectl prune

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -70,6 +70,7 @@ func (a *Applier) Initialize(cmd *cobra.Command, paths []string) error {
 		return errors.WrapPrefix(err, "error setting up ApplyOptions", 1)
 	}
 	a.ApplyOptions.PreProcessorFn = prune.PrependGroupingObject(a.ApplyOptions)
+	a.ApplyOptions.PostProcessorFn = nil // Turn off the default kubectl pruning
 	err = a.PruneOptions.Initialize(a.factory, a.ApplyOptions.Namespace)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)


### PR DESCRIPTION
* Turns off the default `kubectl print and prune` by setting the `PostProcessorFn` to nil.
* Ensures previous pruning functionality can not be invoked (since we've created another prune).
* Manually tested.

/sig cli
/priority important-soon

```release-note
NONE
```