### PR TITLE
Better support for aggregators on deletion

### DIFF
--- a/pkg/kstatus/polling/aggregator/aggregator.go
+++ b/pkg/kstatus/polling/aggregator/aggregator.go
@@ -9,22 +9,34 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/wait"
 )
 
-// BasicAggregator implements StatusAggregator.
-// Aggregate status will be Current when all polled
-// resources are either Current or NotFound.
-// TODO: Treating resources that doesn't exist as Current is
-// weird. But it kinda does make sense when we track
-// resources that are deleted/pruned. We should see if
-// there is a better way to handle this.
-type BasicAggregator struct {
-	resourceCurrentStatus map[wait.ResourceIdentifier]status.Status
+// NewAllCurrentAggregator returns a new aggregator that will consider
+// the set to be completed when all resources have reached the Current status.
+func NewAllCurrentAggregator(identifiers []wait.ResourceIdentifier) *genericAggregator {
+	return newGenericAggregator(identifiers, status.CurrentStatus)
 }
 
-// NewBasicAggregator returns a BasicAggregator that will track
-// resources identified by the argument.
-func NewAllCurrentOrNotFoundStatusAggregator(identifiers []wait.ResourceIdentifier) *BasicAggregator {
-	aggregator := &BasicAggregator{
+// NewAllNotFoundAggregator returns a new aggregator that will consider
+// the set to be completed when all resources have reached the NotFound status.
+func NewAllNotFoundAggregator(identifiers []wait.ResourceIdentifier) *genericAggregator {
+	return newGenericAggregator(identifiers, status.NotFoundStatus)
+}
+
+// genericAggregator implements the StatusAggregator interface. It can
+// be customized by providing the desired status that all resources
+// should reach.
+type genericAggregator struct {
+	resourceCurrentStatus map[wait.ResourceIdentifier]status.Status
+	desiredStatus         status.Status
+}
+
+// newGenericAggregator returns a new Aggregator that will track the
+// resources identified by the slice of ResourceIdentifiers. It will consider
+// the change to be complete when all resources have reached the specified
+// desired status.
+func newGenericAggregator(identifiers []wait.ResourceIdentifier, desiredStatus status.Status) *genericAggregator {
+	aggregator := &genericAggregator{
 		resourceCurrentStatus: make(map[wait.ResourceIdentifier]status.Status),
+		desiredStatus:         desiredStatus,
 	}
 	for _, id := range identifiers {
 		aggregator.resourceCurrentStatus[id] = status.UnknownStatus
@@ -35,36 +47,43 @@ func NewAllCurrentOrNotFoundStatusAggregator(identifiers []wait.ResourceIdentifi
 // ResourceStatus is called whenever we have an observation of a resource. In this
 // case, we just keep the latest status so we can later compute the aggregate status
 // for all the resources.
-func (d *BasicAggregator) ResourceStatus(r *event.ResourceStatus) {
-	d.resourceCurrentStatus[r.Identifier] = r.Status
+func (g *genericAggregator) ResourceStatus(r *event.ResourceStatus) {
+	g.resourceCurrentStatus[r.Identifier] = r.Status
 }
 
-// AggregateStatus computes the aggregate status for all the resources. In this
-// implementation of the Aggregator, we treat resources with the NotFound status as Current.
-func (d *BasicAggregator) AggregateStatus() status.Status {
-	// if we are not observing any resources, we consider status be Current.
-	if len(d.resourceCurrentStatus) == 0 {
-		return status.CurrentStatus
+// AggregateStatus computes the aggregate status for all the resources.
+// The rules are the following:
+// - If any of the resources has the FailedStatus, the aggregate status is also
+//   FailedStatus
+// - If none of the resources have the FailedStatus and at least one is
+//   UnknownStatus, the aggregate status is UnknownStatus
+// - If all the resources have the desired status, the aggregate status is the
+//   desired status.
+// - If none of the first three rules apply, the aggregate status is
+//   InProgressStatus
+func (g *genericAggregator) AggregateStatus() status.Status {
+	if len(g.resourceCurrentStatus) == 0 {
+		return g.desiredStatus
 	}
 
-	allCurrentOrNotFound := true
+	allDesired := true
 	anyUnknown := false
-	for _, s := range d.resourceCurrentStatus {
+	for _, s := range g.resourceCurrentStatus {
 		if s == status.FailedStatus {
 			return status.FailedStatus
 		}
 		if s == status.UnknownStatus {
 			anyUnknown = true
 		}
-		if !(s == status.CurrentStatus || s == status.NotFoundStatus) {
-			allCurrentOrNotFound = false
+		if s != g.desiredStatus {
+			allDesired = false
 		}
 	}
 	if anyUnknown {
 		return status.UnknownStatus
 	}
-	if allCurrentOrNotFound {
-		return status.CurrentStatus
+	if allDesired {
+		return g.desiredStatus
 	}
 	return status.InProgressStatus
 }
@@ -72,6 +91,6 @@ func (d *BasicAggregator) AggregateStatus() status.Status {
 // Completed is used by the framework to decide if the set of resources has
 // all reached the desired status, i.e. the aggregate status. This is used to determine
 // when to stop polling resources.
-func (d *BasicAggregator) Completed() bool {
-	return d.AggregateStatus() == status.CurrentStatus
+func (g *genericAggregator) Completed() bool {
+	return g.AggregateStatus() == g.desiredStatus
 }

--- a/pkg/kstatus/polling/aggregator/aggregator_test.go
+++ b/pkg/kstatus/polling/aggregator/aggregator_test.go
@@ -82,23 +82,6 @@ func TestAggregator(t *testing.T) {
 			},
 			aggregateStatus: status.UnknownStatus,
 		},
-		"multiple resources with all current or not found": {
-			identifiers: []wait.ResourceIdentifier{
-				resourceIdentifiers["deployment"],
-				resourceIdentifiers["statefulset"],
-			},
-			resourceStatuses: []event.ResourceStatus{
-				{
-					Identifier: resourceIdentifiers["deployment"],
-					Status:     status.NotFoundStatus,
-				},
-				{
-					Identifier: resourceIdentifiers["statefulset"],
-					Status:     status.CurrentStatus,
-				},
-			},
-			aggregateStatus: status.CurrentStatus,
-		},
 		"multiple resources with one failed": {
 			identifiers: []wait.ResourceIdentifier{
 				resourceIdentifiers["deployment"],
@@ -125,7 +108,7 @@ func TestAggregator(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			aggregator := NewAllCurrentOrNotFoundStatusAggregator(tc.identifiers)
+			aggregator := newGenericAggregator(tc.identifiers, status.CurrentStatus)
 
 			for _, rs := range tc.resourceStatuses {
 				resourceStatus := rs

--- a/pkg/kstatus/polling/engine/engine_test.go
+++ b/pkg/kstatus/polling/engine/engine_test.go
@@ -104,7 +104,11 @@ func TestStatusPollerRunner(t *testing.T) {
 
 			identifiers := tc.identifiers
 
-			engine := PollerEngine{
+			engine := PollerEngine{}
+
+			options := Options{
+				PollInterval:       2 * time.Second,
+				PollUntilCancelled: false,
 				AggregatorFactoryFunc: func(identifiers []wait.ResourceIdentifier) StatusAggregator {
 					return newFakeAggregator(identifiers)
 				},
@@ -118,7 +122,7 @@ func TestStatusPollerRunner(t *testing.T) {
 				},
 			}
 
-			eventChannel := engine.Poll(ctx, identifiers, 2*time.Second, false)
+			eventChannel := engine.Poll(ctx, identifiers, options)
 
 			var eventTypes []event.EventType
 			for ch := range eventChannel {
@@ -138,10 +142,13 @@ func TestNewStatusPollerRunnerCancellation(t *testing.T) {
 
 	timer := time.NewTimer(5 * time.Second)
 
-	engine := PollerEngine{
+	engine := PollerEngine{}
+
+	options := Options{
+		PollInterval:       2 * time.Second,
+		PollUntilCancelled: true,
 		AggregatorFactoryFunc: func(identifiers []wait.ResourceIdentifier) StatusAggregator {
 			return newFakeAggregator(identifiers)
-			//return aggregator.NewAllCurrentOrNotFoundStatusAggregator(identifiers)
 		},
 		ClusterReaderFactoryFunc: func(_ client.Reader, _ meta.RESTMapper, _ []wait.ResourceIdentifier) (
 			ClusterReader, error) {
@@ -153,7 +160,7 @@ func TestNewStatusPollerRunnerCancellation(t *testing.T) {
 		},
 	}
 
-	eventChannel := engine.Poll(ctx, identifiers, 2*time.Second, true)
+	eventChannel := engine.Poll(ctx, identifiers, options)
 
 	var lastEvent event.Event
 	for {


### PR DESCRIPTION
Instead of having a single aggregator implementation for both apply and deletion scenarios, this instead splits it up into two separate aggregators. As far as I know, there is no way to apply/delete in a way where we want to both wait for resources to finish reconcile _and_ be deleted with the same command. So this just allows users of the library to specify whether this is a situation where we want to wait for all the provided resources to reconcile or if we are waiting for them all to be deleted. We will use the former option after apply and the latter after we prune.

@monopole @seans3 @knverey