### PR TITLE
First version of kapply init command

### DIFF
--- a/cmd/initcmd/cmdinit.go
+++ b/cmd/initcmd/cmdinit.go
@@ -1,0 +1,29 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package initcmd
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"sigs.k8s.io/cli-utils/pkg/config"
+)
+
+// NewCmdInit creates the `init` command, which generates the
+// grouping object template ConfigMap for a package.
+func NewCmdInit(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	io := config.NewInitOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:                   "init DIRECTORY",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a prune manifest ConfigMap as a grouping object"),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(io.Complete(args))
+			cmdutil.CheckErr(io.Run())
+		},
+	}
+	cmd.Flags().StringVarP(&io.GroupName, "group-name", "g", "", "Name to group applied resources. Must be composed of valid label characters.")
+	return cmd
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/apply"
 	"sigs.k8s.io/cli-utils/cmd/destroy"
 	"sigs.k8s.io/cli-utils/cmd/diff"
+	"sigs.k8s.io/cli-utils/cmd/initcmd"
 	"sigs.k8s.io/cli-utils/cmd/preview"
 
 	// This is here rather than in the libraries because of
@@ -43,7 +44,9 @@ func main() {
 		ErrOut: os.Stderr,
 	}
 
-	names := []string{"apply", "preview", "diff", "destroy"}
+	names := []string{"init", "apply", "preview", "diff", "destroy"}
+	initCmd := initcmd.NewCmdInit(ioStreams)
+	updateHelp(names, initCmd)
 	applyCmd := apply.NewCmdApply(f, ioStreams)
 	updateHelp(names, applyCmd)
 	previewCmd := preview.NewCmdPreview(f, ioStreams)
@@ -51,7 +54,9 @@ func main() {
 	diffCmd := diff.NewCmdDiff(f, ioStreams)
 	updateHelp(names, diffCmd)
 	destroyCmd := destroy.NewCmdDestroy(f, ioStreams)
-	cmd.AddCommand(applyCmd, diffCmd, destroyCmd, previewCmd)
+	updateHelp(names, destroyCmd)
+
+	cmd.AddCommand(initCmd, applyCmd, diffCmd, destroyCmd, previewCmd)
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
* First version of `kapply init` command, which generates the grouping object template ConfigMap for a directory of resources.
* Manually tested.
NOTE: initcmd package name, since init collides with the global init function.

/sig cli
/priority important-soon

```release-note
NONE
```