### PR TITLE
Use current grouping object namespace in prune

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -74,7 +74,7 @@ func (a *Applier) Initialize(cmd *cobra.Command, paths []string) error {
 	}
 	a.ApplyOptions.PreProcessorFn = prune.PrependGroupingObject(a.ApplyOptions)
 	a.ApplyOptions.PostProcessorFn = nil // Turn off the default kubectl pruning
-	err = a.PruneOptions.Initialize(a.factory, a.ApplyOptions.Namespace)
+	err = a.PruneOptions.Initialize(a.factory)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)
 	}

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -52,7 +52,7 @@ func (d *Destroyer) Initialize(cmd *cobra.Command, paths []string) error {
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up ApplyOptions", 1)
 	}
-	err = d.PruneOptions.Initialize(d.factory, d.ApplyOptions.Namespace)
+	err = d.PruneOptions.Initialize(d.factory)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)
 	}


### PR DESCRIPTION
* Change prune to use the namespace of the current grouping object, instead of namespace from ApplyOptions (which comes from the kubeconfig file). Fixes error where prune/destroy did not work for non-default namespaces.
* Manually tested.

/sig cli
/priority important-soon

```release-note
NONE
```