### PR TITLE
Update no grouping object error message

### DIFF
--- a/pkg/apply/prune/no_grouping_error.go
+++ b/pkg/apply/prune/no_grouping_error.go
@@ -6,30 +6,12 @@
 
 package prune
 
-const noGroupingErrorStr = `
+const noGroupingErrorStr = `Package uninitialized. Please run "init" command.
 
-The grouping object template was not found while applying. kpt
-live commands require the grouping object template to define
-the set of "grouped" objects. An example of a grouping object
-template is:
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: grouping
-  labels:
-    "cli-utils.sigs.k8s.io/inventory-id": "my-app"
-
-The two requirements for a grouping object template are:
-
-1. It must be a ConfigMap
-2. It must contain the "grouping" label:
-
-  cli-utils.sigs.k8s.io/inventory-id: <GROUP-NAME>
-
-When the grouping object template is applied, a specific
-grouping object is created, storing the inventory of object
-metadata of all objects applied.
+The package needs to be initialized to generate the template
+which will store state for grouped resources. This state is
+necessary to perform functionality such as deleting an entire
+package or automatically deleting omitted resources (pruning).
 `
 
 type NoGroupingObjError struct{}


### PR DESCRIPTION
* Updates `no grouping object` error message to point to `init` command.
* Manually tested.

/sig cli
/priority important-soon

```release-note
NONE
```