### PR TITLE
New structure for the apply cmd

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -14,36 +14,20 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 )
 
-// NewCmdApply creates the `apply` command
-func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	applier := apply.NewApplier(f, ioStreams)
-	printer := &apply.BasicPrinter{
-		IOStreams: ioStreams,
+func GetApplyRunner(f util.Factory, ioStreams genericclioptions.IOStreams) *ApplyRunner {
+	r := &ApplyRunner{
+		applier:   apply.NewApplier(f, ioStreams),
+		ioStreams: ioStreams,
 	}
-
 	cmd := &cobra.Command{
 		Use:                   "apply DIRECTORY",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Apply a configuration to a resource by filename or stdin"),
-		Run: func(cmd *cobra.Command, args []string) {
-			paths := args
-			cmdutil.CheckErr(applier.Initialize(cmd, paths))
-
-			// Create a context with the provided timout from the cobra parameter.
-			ctx, cancel := context.WithTimeout(context.Background(), applier.StatusOptions.Timeout)
-			defer cancel()
-			// Run the applier. It will return a channel where we can receive updates
-			// to keep track of progress and any issues.
-			ch := applier.Run(ctx)
-
-			// The printer will print updates from the channel. It will block
-			// until the channel is closed.
-			printer.Print(ch, false)
-		},
+		Run:                   r.Run,
 	}
 
-	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
-	cmdutil.CheckErr(applier.SetFlags(cmd))
+	cmd.Flags().BoolVar(&r.applier.NoPrune, "no-prune", r.applier.NoPrune, "If true, do not prune previously applied objects.")
+	cmdutil.CheckErr(r.applier.SetFlags(cmd))
 
 	// The following flags are added, but hidden because other code
 	// depend on them when parsing flags. These flags are hidden and unused.
@@ -58,5 +42,34 @@ func NewCmdApply(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.C
 	_ = cmd.Flags().MarkHidden("force-conflicts")
 	_ = cmd.Flags().MarkHidden("field-manager")
 
-	return cmd
+	r.command = cmd
+	return r
+}
+
+func ApplyCommand(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	return GetApplyRunner(f, ioStreams).command
+}
+
+type ApplyRunner struct {
+	command   *cobra.Command
+	ioStreams genericclioptions.IOStreams
+	applier   *apply.Applier
+}
+
+func (r *ApplyRunner) Run(cmd *cobra.Command, args []string) {
+	cmdutil.CheckErr(r.applier.Initialize(cmd, args))
+
+	// Create a context with the provided timout from the cobra parameter.
+	ctx, cancel := context.WithTimeout(context.Background(), r.applier.StatusOptions.Timeout)
+	defer cancel()
+	// Run the applier. It will return a channel where we can receive updates
+	// to keep track of progress and any issues.
+	ch := r.applier.Run(ctx)
+
+	// The printer will print updates from the channel. It will block
+	// until the channel is closed.
+	printer := &apply.BasicPrinter{
+		IOStreams: r.ioStreams,
+	}
+	printer.Print(ch, false)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,7 @@ func main() {
 	names := []string{"init", "apply", "preview", "diff", "destroy"}
 	initCmd := initcmd.NewCmdInit(ioStreams)
 	updateHelp(names, initCmd)
-	applyCmd := apply.NewCmdApply(f, ioStreams)
+	applyCmd := apply.ApplyCommand(f, ioStreams)
 	updateHelp(names, applyCmd)
 	previewCmd := preview.NewCmdPreview(f, ioStreams)
 	updateHelp(names, previewCmd)


### PR DESCRIPTION
This changes the structure of the apply command to the pattern used in kpt. I like this pattern as it gives us a struct onto which we can bind the cobra flags. I ran into this limitation with the current structure when I wanted to add a `--output` flag to let the user select the output format. 

If we think this is a good structure, I can update the other commands as well.

@monopole @seans3 @pwittrock 