### PR TITLE
Move hard-coded default namespace to proper constants

### DIFF
--- a/cmd/status/util.go
+++ b/cmd/status/util.go
@@ -5,6 +5,7 @@ package status
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -44,8 +45,8 @@ func (f *CaptureIdentifiersFilter) Filter(slice []*yaml.RNode) ([]*yaml.RNode,
 		}
 		var namespace string
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace &&
-			id.Namespace == "" {
-			namespace = "default"
+			id.Namespace == metav1.NamespaceNone {
+			namespace = metav1.NamespaceDefault
 		} else {
 			namespace = id.Namespace
 		}

--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
@@ -122,7 +123,7 @@ func packageNamespace(packageDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	namespace := "default"
+	namespace := metav1.NamespaceDefault
 	for _, node := range nodes {
 		rm, err := node.GetMeta()
 		if err != nil {

--- a/pkg/kstatus/polling/statusreaders/common.go
+++ b/pkg/kstatus/polling/statusreaders/common.go
@@ -189,8 +189,8 @@ func getNamespaceForNamespacedResource(object runtime.Object) string {
 		panic(err)
 	}
 	ns := acc.GetNamespace()
-	if ns == "" {
-		return "default"
+	if ns == metav1.NamespaceNone {
+		return metav1.NamespaceDefault
 	}
 	return ns
 }
@@ -198,8 +198,8 @@ func getNamespaceForNamespacedResource(object runtime.Object) string {
 // keyForNamespacedResource returns the object key for the given identifier. It makes
 // sure to set the namespace to default if it is not provided.
 func keyForNamespacedResource(identifier object.ObjMetadata) types.NamespacedName {
-	namespace := "default"
-	if identifier.Namespace != "" {
+	namespace := metav1.NamespaceDefault
+	if identifier.Namespace != metav1.NamespaceNone {
 		namespace = identifier.Namespace
 	}
 	return types.NamespacedName{


### PR DESCRIPTION
* Replaces hard-coded "default" namespace with const `metav1.NamespaceDefault`. Does the same with missing namespace and `metav1.NamespaceNone`. This PR does not address tests which hard-code default namespace.
* Ran unit tests

/sig cli
/priority important-soon

```release-note
NONE
```