### PR TITLE
Fixes validation problem with invalid label values

### DIFF
--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -145,7 +145,10 @@ func (i *InitOptions) defaultGroupName() string {
 	return fmt.Sprintf("%s-%06d", filepath.Base(i.Dir), r)
 }
 
-const groupNameRegexp = `^[a-zA-Z0-9-_\.]+$`
+// Must begin and end with an alphanumeric character ([a-z0-9A-Z])
+// with dashes (-), underscores (_), dots (.), and alphanumerics
+// between.
+const groupNameRegexp = `^[a-zA-Z0-9][a-zA-Z0-9\-\_\.]+[a-zA-Z0-9]$`
 
 // validateGroupName returns true of the passed group name is a
 // valid label value; false otherwise. The valid label values

--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -88,7 +88,7 @@ func TestValidateGroupName(t *testing.T) {
 			groupName: "",
 			isValid:   false,
 		},
-		"Too large Groupname fails": {
+		"Groupname greater than sixty-three chars fails": {
 			groupName: "88888888888888888888888888888888888888888888888888888888888888888",
 			isValid:   false,
 		},
@@ -96,8 +96,36 @@ func TestValidateGroupName(t *testing.T) {
 			groupName: "&foo",
 			isValid:   false,
 		},
-		"Allowed characters succeeds": {
+		"Initial dot fails": {
+			groupName: ".foo",
+			isValid:   false,
+		},
+		"Initial dash fails": {
+			groupName: "-foo",
+			isValid:   false,
+		},
+		"Initial underscore fails": {
+			groupName: "_foo",
+			isValid:   false,
+		},
+		"Trailing dot fails": {
+			groupName: "foo.",
+			isValid:   false,
+		},
+		"Trailing dash fails": {
+			groupName: "foo-",
+			isValid:   false,
+		},
+		"Trailing underscore fails": {
+			groupName: "foo_",
+			isValid:   false,
+		},
+		"Initial digit succeeds": {
 			groupName: "90-foo.bar_test",
+			isValid:   true,
+		},
+		"Allowed characters succeed": {
+			groupName: "f_oo90bar-t.est90",
 			isValid:   true,
 		},
 	}


### PR DESCRIPTION
* Fixes validation error in grouping label values. Label values must not begin or end with dot (.), dash (-), or underscore (_). Changed regular expression in validation. Added unit tests to prove correctness.
* Ran unit tests

/sig cli
/priority important-soon

```release-note
NONE
```