### PR TITLE
Fix issue that causes wait-for-reconcile to never finish

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -211,7 +211,7 @@ func (a *Applier) Run(ctx context.Context) <-chan event.Event {
 
 		if a.StatusOptions.wait {
 			statusChannel := a.statusPoller.Poll(ctx, infosToObjMetas(infos), polling.Options{
-				PollUntilCancelled: true,
+				PollUntilCancelled: false,
 				PollInterval:       a.StatusOptions.period,
 				UseCache:           true,
 				DesiredStatus:      status.CurrentStatus,


### PR DESCRIPTION
The `Poll` function is called with an incorrect parameter. This causes the `apply` command to never finish if using the `--wait-for-reconcile` flag.

@seans3 