### PR TITLE
Fixes grouping object namespace calculation

### DIFF
--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -52,17 +52,17 @@ func TestDefaultGroupName(t *testing.T) {
 		"Basic Seed/Dir": {
 			seed:     31,
 			dir:      "bar",
-			expected: "bar-851636",
+			expected: "bar-720851636",
 		},
 		"Hierarchical directory": {
 			seed:     31,
 			dir:      "foo/bar",
-			expected: "bar-851636",
+			expected: "bar-720851636",
 		},
 		"Absolute directory": {
 			seed:     31,
 			dir:      "/tmp/foo/bar",
-			expected: "bar-851636",
+			expected: "bar-720851636",
 		},
 	}
 


### PR DESCRIPTION
* Fixes grouping object namespace calculation that did not properly handle cluster-scoped objects when they were handled first. Only returns default namespace if there are no resources with a namespace.
* Adds better documentation.
* Increases the random suffix from six digits to nine digits for collision safety.
* Tested manually.

/sig cli
/priority important-soon

```release-note
NONE
```