### PR TITLE
Update sorting of resources in Applier

### DIFF
--- a/pkg/apply/prune/no_grouping_error.go
+++ b/pkg/apply/prune/no_grouping_error.go
@@ -6,6 +6,8 @@
 
 package prune
 
+import "k8s.io/cli-runtime/pkg/resource"
+
 const noGroupingErrorStr = `Package uninitialized. Please run "init" command.
 
 The package needs to be initialized to generate the template
@@ -14,8 +16,21 @@ necessary to perform functionality such as deleting an entire
 package or automatically deleting omitted resources (pruning).
 `
 
+const multipleGroupingErrorStr = `Package has multiple grouping object templates.
+
+The package should have one and only one grouping object template.
+`
+
 type NoGroupingObjError struct{}
 
 func (g NoGroupingObjError) Error() string {
 	return noGroupingErrorStr
+}
+
+type MultipleGroupingObjError struct {
+	GroupingObjectTemplates []*resource.Info
+}
+
+func (g MultipleGroupingObjError) Error() string {
+	return multipleGroupingErrorStr
 }


### PR DESCRIPTION
This moves handling of the grouping object template and ordering of resources into the same flow. This fixes the issue where we first sort the resources and then handle the grouping object, which can lead to incorrect ordering.

@seans3 