### PR TITLE
Add make target for running e2e tests on prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ all: generate license fix vet fmt test lint tidy
 prow-presubmit-check: \
 	test lint verify-license
 
+.PHONY: prow-presubmit-check-e2e
+prow-presubmit-check-e2e: \
+    verify-kapply-e2e
+
 fix:
 	go fix ./...
 


### PR DESCRIPTION
This adds a make target for e2e tests on prow. PR to set up the additional prow presubmit is https://github.com/kubernetes/test-infra/pull/16784

@monopole @seans3 