### PR TITLE
Implement the applier as a queue of tasks

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -59,12 +59,9 @@ type ApplyRunner struct {
 func (r *ApplyRunner) Run(cmd *cobra.Command, args []string) {
 	cmdutil.CheckErr(r.applier.Initialize(cmd, args))
 
-	// Create a context with the provided timout from the cobra parameter.
-	ctx, cancel := context.WithTimeout(context.Background(), r.applier.StatusOptions.Timeout)
-	defer cancel()
 	// Run the applier. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	ch := r.applier.Run(ctx)
+	ch := r.applier.Run(context.Background())
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.

--- a/pkg/apply/poller/poller.go
+++ b/pkg/apply/poller/poller.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package poller
+
+import (
+	"context"
+
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// Poller defines the interface the applier needs to poll for status of resources.
+// The context is the preferred way to shut down the poller.
+// The identifiers defines the resources which the poller should poll and
+// compute status for.
+// The options allows callers to override some of the settings of the poller,
+// like the polling frequency and the caching strategy.
+type Poller interface {
+	Poll(ctx context.Context, identifiers []object.ObjMetadata, options polling.Options) <-chan pollevent.Event
+}

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+)
+
+// ApplyTask applies the given Objects to the cluster
+// by using the ApplyOptions.
+type ApplyTask struct {
+	ApplyOptions *apply.ApplyOptions
+	Objects      []*resource.Info
+}
+
+// Start creates a new goroutine that will invoke
+// the Run function on the ApplyOptions to update
+// the cluster. It will push a TaskResult on the taskChannel
+// to signal to the taskrunner that the task has completed (or failed).
+func (a *ApplyTask) Start(taskChannel chan taskrunner.TaskResult) {
+	go func() {
+		a.ApplyOptions.SetObjects(a.Objects)
+		err := a.ApplyOptions.Run()
+		taskChannel <- taskrunner.TaskResult{
+			Err: err,
+		}
+	}()
+}
+
+// ClearTimeout is not supported by the ApplyTask.
+func (a *ApplyTask) ClearTimeout() {}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -1,0 +1,36 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/prune"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+)
+
+// PruneTask prunes objects from the cluster
+// by using the PruneOptions. The provided Objects is the
+// set of resources that have just been applied.
+type PruneTask struct {
+	PruneOptions *prune.PruneOptions
+	EventChannel chan event.Event
+	Objects      []*resource.Info
+}
+
+// Start creates a new goroutine that will invoke
+// the Run function on the PruneOptions to update
+// the cluster. It will push a TaskResult on the taskChannel
+// to signal to the taskrunner that the task has completed (or failed).
+func (p *PruneTask) Start(taskChannel chan taskrunner.TaskResult) {
+	go func() {
+		err := p.PruneOptions.Prune(p.Objects, p.EventChannel)
+		taskChannel <- taskrunner.TaskResult{
+			Err: err,
+		}
+	}()
+}
+
+// ClearTimeout is not supported by the PruneTask.
+func (p *PruneTask) ClearTimeout() {}

--- a/pkg/apply/task/send_event_task.go
+++ b/pkg/apply/task/send_event_task.go
@@ -1,0 +1,31 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+)
+
+// SendEventTask is an implementation of the Task interface
+// that will send the provided event on the eventChannel when
+// executed.
+type SendEventTask struct {
+	EventChannel chan event.Event
+	Event        event.Event
+}
+
+// Start start a separate goroutine that will send the
+// event and then push a TaskResult on the taskChannel to
+// signal to the taskrunner that the task is completed.
+func (s *SendEventTask) Start(taskChannel chan taskrunner.TaskResult) {
+	go func() {
+		s.EventChannel <- s.Event
+		taskChannel <- taskrunner.TaskResult{}
+	}()
+}
+
+// ClearTimeout doesn't do anything as SendEventTask doesn't support
+// timeouts.
+func (s *SendEventTask) ClearTimeout() {}

--- a/pkg/apply/taskrunner/collector.go
+++ b/pkg/apply/taskrunner/collector.go
@@ -1,0 +1,97 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// newResourceStatusCollector returns a new resourceStatusCollector
+// that will keep track of the status of the provided resources.
+func newResourceStatusCollector(identifiers []object.ObjMetadata) *resourceStatusCollector {
+	rm := make(map[object.ObjMetadata]resourceStatus)
+
+	for _, obj := range identifiers {
+		rm[obj] = resourceStatus{
+			Identifier:    obj,
+			CurrentStatus: status.UnknownStatus,
+		}
+	}
+	return &resourceStatusCollector{
+		resourceMap: rm,
+	}
+}
+
+// resourceStatusCollector keeps track of the latest seen status for all the
+// resources that is of interest during the operation.
+type resourceStatusCollector struct {
+	resourceMap map[object.ObjMetadata]resourceStatus
+}
+
+// resoureStatus contains the latest status for a given
+// resource as identified by the Identifier.
+type resourceStatus struct {
+	Identifier    object.ObjMetadata
+	CurrentStatus status.Status
+}
+
+// resourceStatus updates the collector with the latest
+// seen status for the given resource.
+func (a *resourceStatusCollector) resourceStatus(identifier object.ObjMetadata, s status.Status) {
+	if ri, found := a.resourceMap[identifier]; found {
+		ri.CurrentStatus = s
+		a.resourceMap[identifier] = ri
+	}
+}
+
+// conditionMet tests whether the provided Condition holds true for
+// all resources given by the list of Identifiers.
+func (a *resourceStatusCollector) conditionMet(identifiers []object.ObjMetadata, c condition) bool {
+	switch c {
+	case AllCurrent:
+		return a.allMatchStatus(identifiers, status.CurrentStatus)
+	case AllNotFound:
+		return a.allMatchStatus(identifiers, status.NotFoundStatus)
+	default:
+		return a.noneMatchStatus(identifiers, status.UnknownStatus)
+	}
+}
+
+// allMatchStatus checks whether all resources given by the
+// Identifiers parameter has the provided status.
+func (a *resourceStatusCollector) allMatchStatus(identifiers []object.ObjMetadata, s status.Status) bool {
+	for id, ri := range a.resourceMap {
+		if contains(identifiers, id) {
+			if ri.CurrentStatus != s {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// noneMatchStatus checks whether none of the resources given
+// by the Identifiers parameters has the provided status.
+func (a *resourceStatusCollector) noneMatchStatus(identifiers []object.ObjMetadata, s status.Status) bool {
+	for id, ri := range a.resourceMap {
+		if contains(identifiers, id) {
+			if ri.CurrentStatus == s {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// contains checks whether the given id exists in the given slice
+// of Identifiers.
+func contains(identifiers []object.ObjMetadata, id object.ObjMetadata) bool {
+	for _, identifier := range identifiers {
+		if identifier.Equals(&id) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -1,0 +1,287 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/poller"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// NewTaskStatusRunner returns a new TaskStatusRunner.
+func NewTaskStatusRunner(identifiers []object.ObjMetadata, statusPoller poller.Poller) *taskStatusRunner {
+	return &taskStatusRunner{
+		identifiers:  identifiers,
+		statusPoller: statusPoller,
+
+		baseRunner: newBaseRunner(newResourceStatusCollector(identifiers)),
+	}
+}
+
+// taskStatusRunner is a taskRunner that executes a set of
+// tasks while at the same time uses the statusPoller to
+// keep track of the status of the resources.
+type taskStatusRunner struct {
+	identifiers  []object.ObjMetadata
+	statusPoller poller.Poller
+
+	baseRunner *baseRunner
+}
+
+// PollingOptions defines properties that is passed along to
+// the statusPoller.
+type PollingOptions struct {
+	PollInterval time.Duration
+	UseCache     bool
+}
+
+// Run starts the execution of the taskqueue. It will start the
+// statusPoller and then pass the statusChannel to the baseRunner
+// that does most of the work.
+func (tsr *taskStatusRunner) Run(ctx context.Context, taskQueue chan Task,
+	eventChannel chan event.Event, pollingOptions PollingOptions) error {
+	statusCtx, cancelFunc := context.WithCancel(context.Background())
+	statusChannel := tsr.statusPoller.Poll(statusCtx, tsr.identifiers, polling.Options{
+		PollUntilCancelled: true,
+		PollInterval:       pollingOptions.PollInterval,
+		UseCache:           pollingOptions.UseCache,
+		// Not actually in use since we use a separate collector to keep
+		// track of the status for each resource.
+		//TODO(mortent): Remove the aggregator from the polling engine
+		// and implement it as a wrapper instead.
+		DesiredStatus: status.CurrentStatus,
+	})
+
+	err := tsr.baseRunner.run(ctx, taskQueue, statusChannel, eventChannel)
+	// cancel the statusPoller by cancelling the context.
+	cancelFunc()
+	// drain the statusChannel to make sure the lack of a consumer
+	// doesn't block the shutdown of the statusPoller.
+	for range statusChannel {
+	}
+	return err
+}
+
+// NewTaskRunner returns a new taskRunner. It can process taskqueues
+// that does not contain any wait tasks.
+func NewTaskRunner() *taskRunner {
+	collector := newResourceStatusCollector([]object.ObjMetadata{})
+	return &taskRunner{
+		baseRunner: newBaseRunner(collector),
+	}
+}
+
+// taskRunner is a simplified taskRunner that does not support
+// wait tasks and does not provide any status updates for the
+// resources. This is useful in situations where we are not interested
+// in status, for example during dry-run.
+type taskRunner struct {
+	baseRunner *baseRunner
+}
+
+// Run starts the execution of the task queue. It delegates the
+// work to the baseRunner, but gives it as nil channel as the statusChannel.
+func (tr *taskRunner) Run(ctx context.Context, taskQueue chan Task,
+	eventChannel chan event.Event) error {
+	var nilStatusChannel chan pollevent.Event
+	return tr.baseRunner.run(ctx, taskQueue, nilStatusChannel, eventChannel)
+}
+
+// newBaseRunner returns a new baseRunner using the given collector.
+func newBaseRunner(collector *resourceStatusCollector) *baseRunner {
+	return &baseRunner{
+		collector: collector,
+	}
+}
+
+// baseRunner provides the basic task runner functionality. It needs
+// a channel that provides resource status updates in order to support
+// wait tasks, but it can also be used with a nil statusChannel for
+// cases where polling and waiting for status is not needed.
+// This is not meant to be used directly. It is used by the
+// taskRunner and the taskStatusRunner.
+type baseRunner struct {
+	collector *resourceStatusCollector
+}
+
+// run is the main function that implements the processing of
+// tasks in the taskqueue. It sets up a loop where a single goroutine
+// will process events from three different channels.
+func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
+	statusChannel <-chan pollevent.Event, eventChannel chan event.Event) error {
+	// taskChannel is used by tasks running in a separate goroutine
+	// to signal back to the main loop that the task is either finished
+	// or it has failed.
+	taskChannel := make(chan TaskResult)
+
+	// Find and start the first task in the queue.
+	currentTask, done := b.nextTask(taskQueue, taskChannel)
+	if done {
+		return nil
+	}
+
+	// abort is used to signal that something has failed, and
+	// the task processing should end as soon as is possible. Only
+	// wait tasks can be interrupted, so for all other tasks we need
+	// to wait for the currently running one to finish before we can
+	// exit.
+	abort := false
+	var abortReason error
+
+	// We do this so we can set the doneCh to a nil channel after
+	// it has been closed. This is needed to avoid a busy loop.
+	doneCh := ctx.Done()
+
+	for {
+		select {
+		// This processes status events from a channel, most likely
+		// driven by the StatusPoller. All normal resource status update
+		// events are passed through to the eventChannel. This means
+		// that listeners of the eventChannel will get updates on status
+		// even while other tasks (like apply tasks) are running.
+		case statusEvent, ok := <-statusChannel:
+			// If the statusChannel has closed or we are preparing
+			// to abort the task processing, we just ignore all
+			// statusEvents.
+			//TODO(mortent): Check if a losed statusChannel might
+			// create a busy loop here.
+			if !ok || abort {
+				continue
+			}
+
+			// An error event on the statusChannel means the StatusPoller
+			// has encountered a problem so it can't continue. This means
+			// the statusChannel will be closed soon.
+			if statusEvent.EventType == pollevent.ErrorEvent {
+				abort = true
+				abortReason = fmt.Errorf("polling for status failed: %v",
+					statusEvent.Error)
+				// If the current task is a wait task, we just set it
+				// to complete so we can exit the loop as soon as possible.
+				completeIfWaitTask(currentTask, taskChannel)
+				continue
+			}
+
+			// Forward all normal events to the eventChannel
+			eventChannel <- event.Event{
+				Type:        event.StatusType,
+				StatusEvent: statusEvent,
+			}
+
+			// The collector needs to keep track of the latest status
+			// for all resources so we can check whether wait task conditions
+			// has been met.
+			b.collector.resourceStatus(statusEvent.Resource.Identifier,
+				statusEvent.Resource.Status)
+			// If the current task is a wait task, we check whether
+			// the condition has been met. If so, we complete the task.
+			if wt, ok := currentTask.(*WaitTask); ok {
+				if b.collector.conditionMet(wt.Identifiers, wt.Condition) {
+					completeIfWaitTask(currentTask, taskChannel)
+				}
+			}
+		// A message on the taskChannel means that the current task
+		// has either completed or failed. If it has failed, we return
+		// the error. If the abort flag is true, which means something
+		// else has gone wrong and we are waiting for the current task to
+		// finish, we exit.
+		// If everything is ok, we fetch and start the next task.
+		case msg := <-taskChannel:
+			currentTask.ClearTimeout()
+			if msg.Err != nil {
+				return msg.Err
+			}
+			if abort {
+				return abortReason
+			}
+			currentTask, done = b.nextTask(taskQueue, taskChannel)
+			// If there are no more tasks, we are done. So just
+			// return.
+			if done {
+				return nil
+			}
+		// The doneCh will be closed if the passed in context is cancelled.
+		// If so, we just set the abort flag and wait for the currently running
+		// task to complete before we exit.
+		case <-doneCh:
+			doneCh = nil // Set doneCh to nil so we don't enter a busy loop.
+			abort = true
+			completeIfWaitTask(currentTask, taskChannel)
+		}
+	}
+}
+
+// completeIfWaitTask checks if the current task is a wait task. If so,
+// we invoke the complete function to complete it.
+func completeIfWaitTask(currentTask Task, taskChannel chan TaskResult) {
+	if wt, ok := currentTask.(*WaitTask); ok {
+		wt.complete(taskChannel)
+	}
+}
+
+// nextTask fetches the latest task from the taskQueue and
+// starts it. If the taskQueue is empty, it the second
+// return value will be true.
+func (b *baseRunner) nextTask(taskQueue chan Task,
+	taskChannel chan TaskResult) (Task, bool) {
+	var tsk Task
+	select {
+	// If there is any tasks left in the queue, this
+	// case statement will be executed.
+	case t := <-taskQueue:
+		tsk = t
+	default:
+		// Only happens when the channel is empty.
+		return nil, true
+	}
+
+	switch st := tsk.(type) {
+	case *WaitTask:
+		// The wait tasks need to be handled specifically here. Before
+		// starting a new wait task, we check if the condition is already
+		// met. Without this check, a task might end up waiting for
+		// status events when the condition is in fact already met.
+		if b.collector.conditionMet(st.Identifiers, st.Condition) {
+			st.complete(taskChannel)
+		} else {
+			tsk.Start(taskChannel)
+		}
+	default:
+		tsk.Start(taskChannel)
+	}
+	return tsk, false
+}
+
+// TaskResult is the type returned from tasks once they have completed
+// or failed. If it has failed or timed out, the Err property will be
+// set.
+type TaskResult struct {
+	Err error
+}
+
+// timeoutError is a special error used by tasks when they have
+// timed out.
+type timeoutError struct {
+	message string
+}
+
+func (te timeoutError) Error() string {
+	return te.message
+}
+
+// IsTimeoutError checks whether a given error is
+// a timeoutError.
+func IsTimeoutError(err error) bool {
+	if _, ok := err.(timeoutError); ok {
+		return true
+	}
+	return false
+}

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -1,0 +1,366 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+var (
+	depID = object.ObjMetadata{
+		GroupKind: schema.GroupKind{
+			Group: "apps",
+			Kind:  "Deployment",
+		},
+		Namespace: "default",
+		Name:      "dep",
+	}
+	cmID = object.ObjMetadata{
+		GroupKind: schema.GroupKind{
+			Group: "",
+			Kind:  "ConfigMap",
+		},
+		Namespace: "default",
+		Name:      "cm",
+	}
+)
+
+func TestBaseRunner(t *testing.T) {
+	testCases := map[string]struct {
+		identifiers        []object.ObjMetadata
+		tasks              []Task
+		statusEventsDelay  time.Duration
+		statusEvents       []pollevent.Event
+		expectedEventTypes []event.Type
+	}{
+		"wait task runs until condition is met": {
+			identifiers: []object.ObjMetadata{depID, cmID},
+			tasks: []Task{
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.ApplyType,
+					},
+					duration: 3 * time.Second,
+				},
+				NewWaitTask([]object.ObjMetadata{depID, cmID}, AllCurrent,
+					1*time.Minute),
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 2 * time.Second,
+				},
+			},
+			statusEventsDelay: 5 * time.Second,
+			statusEvents: []pollevent.Event{
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: cmID,
+						Status:     status.CurrentStatus,
+					},
+				},
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: depID,
+						Status:     status.CurrentStatus,
+					},
+				},
+			},
+			expectedEventTypes: []event.Type{
+				event.ApplyType,
+				event.StatusType,
+				event.StatusType,
+				event.PruneType,
+			},
+		},
+		"tasks run in order": {
+			identifiers: []object.ObjMetadata{},
+			tasks: []Task{
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.ApplyType,
+					},
+					duration: 1 * time.Second,
+				},
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 1 * time.Second,
+				},
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.ApplyType,
+					},
+					duration: 1 * time.Second,
+				},
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 1 * time.Second,
+				},
+			},
+			statusEventsDelay: 1 * time.Second,
+			statusEvents:      []pollevent.Event{},
+			expectedEventTypes: []event.Type{
+				event.ApplyType,
+				event.PruneType,
+				event.ApplyType,
+				event.PruneType,
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			runner := newBaseRunner(newResourceStatusCollector(tc.identifiers))
+			eventChannel := make(chan event.Event)
+			taskQueue := make(chan Task, len(tc.tasks))
+			for _, tsk := range tc.tasks {
+				if bt, ok := tsk.(*busyTask); ok {
+					bt.eventChannel = eventChannel
+				}
+				taskQueue <- tsk
+			}
+
+			// Use a WaitGroup to make sure changes in the goroutines
+			// are visible to the main goroutine.
+			var wg sync.WaitGroup
+
+			statusChannel := make(chan pollevent.Event)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				<-time.NewTimer(tc.statusEventsDelay).C
+				for _, se := range tc.statusEvents {
+					statusChannel <- se
+				}
+			}()
+
+			var events []event.Event
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for msg := range eventChannel {
+					events = append(events, msg)
+				}
+			}()
+
+			err := runner.run(context.Background(), taskQueue, statusChannel, eventChannel)
+			close(statusChannel)
+			close(eventChannel)
+			wg.Wait()
+
+			if err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+
+			if want, got := len(tc.expectedEventTypes), len(events); want != got {
+				t.Errorf("expected %d events, but got %d", want, got)
+			}
+			for i, e := range events {
+				expectedEventType := tc.expectedEventTypes[i]
+				if want, got := expectedEventType, e.Type; want != got {
+					t.Errorf("expected event type %s, but got %s",
+						want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBaseRunnerCancellation(t *testing.T) {
+	testError := fmt.Errorf("this is a test error")
+
+	testCases := map[string]struct {
+		identifiers        []object.ObjMetadata
+		tasks              []Task
+		statusEventsDelay  time.Duration
+		statusEvents       []pollevent.Event
+		contextTimeout     time.Duration
+		expectedError      error
+		expectedEventTypes []event.Type
+	}{
+		"cancellation while custom task is running": {
+			identifiers: []object.ObjMetadata{depID},
+			tasks: []Task{
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.ApplyType,
+					},
+					duration: 4 * time.Second,
+				},
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 2 * time.Second,
+				},
+			},
+			contextTimeout: 2 * time.Second,
+			expectedEventTypes: []event.Type{
+				event.ApplyType,
+			},
+		},
+		"cancellation while wait task is running": {
+			identifiers: []object.ObjMetadata{depID},
+			tasks: []Task{
+				NewWaitTask([]object.ObjMetadata{depID}, AllCurrent, 20*time.Second),
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 2 * time.Second,
+				},
+			},
+			contextTimeout:     2 * time.Second,
+			expectedEventTypes: []event.Type{},
+		},
+		"error while custom task is running": {
+			identifiers: []object.ObjMetadata{depID},
+			tasks: []Task{
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.ApplyType,
+					},
+					duration: 2 * time.Second,
+					err:      testError,
+				},
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 2 * time.Second,
+				},
+			},
+			contextTimeout: 30 * time.Second,
+			expectedError:  testError,
+			expectedEventTypes: []event.Type{
+				event.ApplyType,
+			},
+		},
+		"error from status poller while wait task is running": {
+			identifiers: []object.ObjMetadata{depID},
+			tasks: []Task{
+				NewWaitTask([]object.ObjMetadata{depID}, AllCurrent, 20*time.Second),
+				&busyTask{
+					resultEvent: event.Event{
+						Type: event.PruneType,
+					},
+					duration: 2 * time.Second,
+				},
+			},
+			statusEventsDelay: 2 * time.Second,
+			statusEvents: []pollevent.Event{
+				{
+					EventType: pollevent.ErrorEvent,
+					Error:     testError,
+				},
+			},
+			contextTimeout:     30 * time.Second,
+			expectedError:      testError,
+			expectedEventTypes: []event.Type{},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			runner := newBaseRunner(newResourceStatusCollector(tc.identifiers))
+			eventChannel := make(chan event.Event)
+
+			taskQueue := make(chan Task, len(tc.tasks))
+			for _, tsk := range tc.tasks {
+				if bt, ok := tsk.(*busyTask); ok {
+					bt.eventChannel = eventChannel
+				}
+				taskQueue <- tsk
+			}
+
+			// Use a WaitGroup to make sure changes in the goroutines
+			// are visible to the main goroutine.
+			var wg sync.WaitGroup
+
+			statusChannel := make(chan pollevent.Event)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				<-time.NewTimer(tc.statusEventsDelay).C
+				for _, se := range tc.statusEvents {
+					statusChannel <- se
+				}
+			}()
+
+			var events []event.Event
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for msg := range eventChannel {
+					events = append(events, msg)
+				}
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
+			defer cancel()
+			err := runner.run(ctx, taskQueue, statusChannel, eventChannel)
+			close(statusChannel)
+			close(eventChannel)
+			wg.Wait()
+
+			if tc.expectedError == nil && err != nil {
+				t.Errorf("expected no error, but got %v", err)
+			}
+
+			if tc.expectedError != nil && err == nil {
+				t.Errorf("expected error %v, but didn't get one", tc.expectedError)
+			}
+
+			if want, got := len(tc.expectedEventTypes), len(events); want != got {
+				t.Errorf("expected %d events, but got %d", want, got)
+			}
+			for i, e := range events {
+				expectedEventType := tc.expectedEventTypes[i]
+				if want, got := expectedEventType, e.Type; want != got {
+					t.Errorf("expected event type %s, but got %s",
+						want, got)
+				}
+			}
+		})
+	}
+}
+
+type busyTask struct {
+	eventChannel chan event.Event
+	resultEvent  event.Event
+	duration     time.Duration
+	err          error
+}
+
+func (b *busyTask) Start(taskChannel chan TaskResult) {
+	go func() {
+		<-time.NewTimer(b.duration).C
+		b.eventChannel <- b.resultEvent
+		taskChannel <- TaskResult{
+			Err: b.err,
+		}
+	}()
+}
+
+func (b *busyTask) ClearTimeout() {}

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// Task is the interface that must be implemented by
+// all tasks that will be executed by the taskrunner.
+type Task interface {
+	Start(taskChannel chan TaskResult)
+	ClearTimeout()
+}
+
+// NewWaitTask creates a new wait task where we will wait until
+// the resources specifies by ids all meet the specified condition.
+func NewWaitTask(ids []object.ObjMetadata, cond condition, timeout time.Duration) *WaitTask {
+	// Create the token channel and only add one item.
+	tokenChannel := make(chan struct{}, 1)
+	tokenChannel <- struct{}{}
+
+	return &WaitTask{
+		Identifiers: ids,
+		Condition:   cond,
+		Timeout:     timeout,
+
+		token: tokenChannel,
+	}
+}
+
+// WaitTask is an implementation of the Task interface that is used
+// to wait for a set of resources (identified by a slice of ObjMetadata)
+// will all meet the condition specified. It also specifies a timeout
+// for how long we are willing to wait for this to happen.
+// Unlike other implementations of the Task interface, the wait task
+// is handled in a special way to the taskrunner and is a part of the core
+// package.
+type WaitTask struct {
+	// Identifiers is the list of resources that we are waiting for.
+	Identifiers []object.ObjMetadata
+	// Condition defines the status we want all resources to reach
+	Condition condition
+	// Timeout defines how long we are willing to wait for the condition
+	// to be met.
+	Timeout time.Duration
+
+	// cancelFunc is a function that will cancel the timeout timer
+	// on the task.
+	cancelFunc func()
+
+	// token is a channel that is provided a single item when the
+	// task is created. Goroutines are only allowed to write to the
+	// taskChannel if they are able to get the item from the channel.
+	// This makes sure that the task only results in one message on the
+	// taskChannel, even if the condition is met and the task times out
+	// at the same time.
+	token chan struct{}
+}
+
+// Start kicks off the task. For the wait task, this just means
+// setting up the timeout timer.
+func (w *WaitTask) Start(taskChannel chan TaskResult) {
+	timer := time.NewTimer(w.Timeout)
+	go func() {
+		//TODO(mortent): See if there is a better way to do this. This
+		// solution will cause the goroutine to hang forever if the
+		// Timeout is cancelled.
+		<-timer.C
+		select {
+		// We only send the taskResult if no one has gotten
+		// to the token first.
+		case <-w.token:
+			taskChannel <- TaskResult{
+				Err: timeoutError{
+					message: fmt.Sprintf("timeout after %.0f seconds waiting for %d resources to reach condition %s",
+						w.Timeout.Seconds(), len(w.Identifiers), w.Condition),
+				},
+			}
+		default:
+			return
+		}
+	}()
+	w.cancelFunc = func() {
+		timer.Stop()
+	}
+}
+
+// complete is invoked by the taskrunner when all the conditions
+// for the task has been met, or something has failed so the task
+// need to be stopped.
+func (w *WaitTask) complete(taskChannel chan TaskResult) {
+	select {
+	// Only do something if we can get the token.
+	case <-w.token:
+		go func() {
+			taskChannel <- TaskResult{}
+		}()
+	default:
+		return
+	}
+}
+
+// ClearTimeout cancels the timeout for the wait task.
+func (w *WaitTask) ClearTimeout() {
+	w.cancelFunc()
+}
+
+// Condition is a type that defines the types of conditions
+// which a WaitTask can use.
+type condition string
+
+const (
+	// AllCurrent Condition means all the provided resources
+	// has reached (and remains in) the Current status.
+	AllCurrent condition = "AllCurrent"
+
+	// AllNotFound Condition means all the provided resources
+	// has reached the NotFound status, i.e. they are all deleted
+	// from the cluster.
+	AllNotFound condition = "AllNotFound"
+)

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestWaitTask_TimeoutTriggered(t *testing.T) {
+	task := NewWaitTask([]object.ObjMetadata{}, AllCurrent, 2*time.Second)
+
+	taskChannel := make(chan TaskResult)
+	defer close(taskChannel)
+
+	task.Start(taskChannel)
+
+	timer := time.NewTimer(3 * time.Second)
+
+	select {
+	case res := <-taskChannel:
+		if res.Err == nil || !IsTimeoutError(res.Err) {
+			t.Errorf("expected timeout error, but got %v", res.Err)
+		}
+		return
+	case <-timer.C:
+		t.Errorf("expected timeout to trigger, but it didn't")
+	}
+}
+
+func TestWaitTask_TimeoutCancelled(t *testing.T) {
+	task := NewWaitTask([]object.ObjMetadata{}, AllCurrent, 2*time.Second)
+
+	taskChannel := make(chan TaskResult)
+	defer close(taskChannel)
+
+	task.Start(taskChannel)
+	task.ClearTimeout()
+	timer := time.NewTimer(3 * time.Second)
+
+	select {
+	case res := <-taskChannel:
+		t.Errorf("didn't expect timeout error, but got %v", res.Err)
+	case <-timer.C:
+		return
+	}
+}
+
+func TestWaitTask_SingleTaskResult(t *testing.T) {
+	task := NewWaitTask([]object.ObjMetadata{}, AllCurrent, 2*time.Second)
+
+	taskChannel := make(chan TaskResult, 10)
+
+	var completeWg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		completeWg.Add(1)
+		go func() {
+			defer completeWg.Done()
+			task.complete(taskChannel)
+		}()
+	}
+	completeWg.Wait()
+	close(taskChannel)
+
+	resultCount := 0
+	for range taskChannel {
+		resultCount++
+	}
+	if resultCount != 1 {
+		t.Errorf("expected 1 result, but got %d", resultCount)
+	}
+}


### PR DESCRIPTION
This approach should be pretty flexible to support different workflows where we might need to run multiple wait operations in between the apply operations. But this PR is focused on just reproducing the existing functionality.

@seans3 @monopole @knverey