### PR TITLE
Default grouping label is a UUID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-errors/errors v1.0.1
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
+	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0

--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -44,38 +45,16 @@ func TestComplete(t *testing.T) {
 }
 
 func TestDefaultGroupName(t *testing.T) {
-	tests := map[string]struct {
-		seed     int64
-		dir      string
-		expected string
-	}{
-		"Basic Seed/Dir": {
-			seed:     31,
-			dir:      "bar",
-			expected: "bar-720851636",
-		},
-		"Hierarchical directory": {
-			seed:     31,
-			dir:      "foo/bar",
-			expected: "bar-720851636",
-		},
-		"Absolute directory": {
-			seed:     31,
-			dir:      "/tmp/foo/bar",
-			expected: "bar-720851636",
-		},
+	io := NewInitOptions(ioStreams)
+	actual, err := io.defaultGroupName()
+	if err != nil {
+		t.Errorf("Unxpected error during UUID generation: %v", err)
 	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			io := NewInitOptions(ioStreams)
-			io.Seed = tc.seed
-			io.Dir = tc.dir
-			actual := io.defaultGroupName()
-			if tc.expected != actual {
-				t.Errorf("Expected group name (%s), got (%s)", tc.expected, actual)
-			}
-		})
+	// Example UUID: dd647113-a354-48fa-9b93-cc1b7a85aadb
+	var uuidRegexp = `^[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$`
+	re := regexp.MustCompile(uuidRegexp)
+	if !re.MatchString(actual) {
+		t.Errorf("Expected UUID; got (%s)", actual)
 	}
 }
 


### PR DESCRIPTION
* Changes the generation of the default grouping label value to be a UUID. Previously, it was the package directory name with a random number suffix. We really only care about uniqueness, so this implements a UUID generator. The user still has the ability to set the group label by using the `-g` flag when calling `kpt live init`.
* Updates a unit test.
* Tested manually.

/sig cli
/priority important-soon

```release-note
NONE
```