### PR TITLE
Add TaskContext to be passed between tasks

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -198,8 +198,8 @@ func splitInfos(infos []*resource.Info) ([]*resource.Info, []*resource.Info) {
 
 // buildTaskQueue takes the slice of infos and object identifiers, and
 // builds a queue of tasks that needs to be executed.
-func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.ObjMetadata,
-	eventChannel chan event.Event) chan taskrunner.Task {
+func (a *Applier) buildTaskQueue(infos []*resource.Info,
+	identifiers []object.ObjMetadata) chan taskrunner.Task {
 	tasks := []taskrunner.Task{
 		// This taks is responsible for applying all the resources
 		// in the infos slice.
@@ -217,7 +217,6 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 					Type: event.ApplyEventCompleted,
 				},
 			},
-			EventChannel: eventChannel,
 		},
 	}
 
@@ -237,7 +236,6 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 						EventType: pollevent.CompletedEvent,
 					},
 				},
-				EventChannel: eventChannel,
 			})
 	}
 
@@ -248,7 +246,6 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 			&task.PruneTask{
 				Objects:      infos,
 				PruneOptions: a.PruneOptions,
-				EventChannel: eventChannel,
 			},
 			// Once prune is completed, we send an event to notify
 			// the client.
@@ -259,7 +256,6 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 						Type: event.PruneEventCompleted,
 					},
 				},
-				EventChannel: eventChannel,
 			})
 	}
 
@@ -307,7 +303,7 @@ func (a *Applier) Run(ctx context.Context, options Options) <-chan event.Event {
 		identifiers := infosToObjMetas(infos)
 
 		// Fetch the queue (channel) of tasks that should be executed.
-		taskQueue := a.buildTaskQueue(infos, identifiers, eventChannel)
+		taskQueue := a.buildTaskQueue(infos, identifiers)
 
 		// Send event to inform the caller about the resources that
 		// will be applied/pruned.

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -20,11 +20,11 @@ type ApplyTask struct {
 // the Run function on the ApplyOptions to update
 // the cluster. It will push a TaskResult on the taskChannel
 // to signal to the taskrunner that the task has completed (or failed).
-func (a *ApplyTask) Start(taskChannel chan taskrunner.TaskResult) {
+func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		a.ApplyOptions.SetObjects(a.Objects)
 		err := a.ApplyOptions.Run()
-		taskChannel <- taskrunner.TaskResult{
+		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,
 		}
 	}()

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -5,7 +5,6 @@ package task
 
 import (
 	"k8s.io/cli-runtime/pkg/resource"
-	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 )
@@ -15,7 +14,6 @@ import (
 // set of resources that have just been applied.
 type PruneTask struct {
 	PruneOptions *prune.PruneOptions
-	EventChannel chan event.Event
 	Objects      []*resource.Info
 }
 
@@ -23,10 +21,10 @@ type PruneTask struct {
 // the Run function on the PruneOptions to update
 // the cluster. It will push a TaskResult on the taskChannel
 // to signal to the taskrunner that the task has completed (or failed).
-func (p *PruneTask) Start(taskChannel chan taskrunner.TaskResult) {
+func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		err := p.PruneOptions.Prune(p.Objects, p.EventChannel)
-		taskChannel <- taskrunner.TaskResult{
+		err := p.PruneOptions.Prune(p.Objects, taskContext.EventChannel())
+		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,
 		}
 	}()

--- a/pkg/apply/task/send_event_task.go
+++ b/pkg/apply/task/send_event_task.go
@@ -12,17 +12,16 @@ import (
 // that will send the provided event on the eventChannel when
 // executed.
 type SendEventTask struct {
-	EventChannel chan event.Event
-	Event        event.Event
+	Event event.Event
 }
 
 // Start start a separate goroutine that will send the
 // event and then push a TaskResult on the taskChannel to
 // signal to the taskrunner that the task is completed.
-func (s *SendEventTask) Start(taskChannel chan taskrunner.TaskResult) {
+func (s *SendEventTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		s.EventChannel <- s.Event
-		taskChannel <- taskrunner.TaskResult{}
+		taskContext.EventChannel() <- s.Event
+		taskContext.TaskChannel() <- taskrunner.TaskResult{}
 	}()
 }
 

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+)
+
+// NewTaskContext returns a new TaskContext
+func NewTaskContext(eventChannel chan event.Event) *TaskContext {
+	return &TaskContext{
+		taskChannel:  make(chan TaskResult),
+		eventChannel: eventChannel,
+	}
+}
+
+// TaskContext defines a context that is passed between all
+// the tasks that is in a taskqueue.
+type TaskContext struct {
+	taskChannel chan TaskResult
+
+	eventChannel chan event.Event
+}
+
+func (tc *TaskContext) TaskChannel() chan TaskResult {
+	return tc.taskChannel
+}
+
+func (tc *TaskContext) EventChannel() chan event.Event {
+	return tc.eventChannel
+}


### PR DESCRIPTION
The `TaskContext` encapsulates the `eventChannel` and `taskChannel` that was passed around as part of the task runner. It also includes a synchronized map to allow data to be passed between tasks in a safe way.

@seans3 @phanimarupaka @monopole 