### PR TITLE
Fix handling of clusterscoped resources in status poller

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -294,12 +294,7 @@ func (a *Applier) Run(ctx context.Context) <-chan event.Event {
 		// and handling the grouping object.
 		infos, err := a.readAndPrepareObjects()
 		if err != nil {
-			eventChannel <- event.Event{
-				Type: event.ErrorType,
-				ErrorEvent: event.ErrorEvent{
-					Err: errors.WrapPrefix(err, "error reading resources", 1),
-				},
-			}
+			handleError(eventChannel, err)
 			return
 		}
 
@@ -334,15 +329,19 @@ func (a *Applier) Run(ctx context.Context) <-chan event.Event {
 			UseCache:     true,
 		})
 		if err != nil {
-			eventChannel <- event.Event{
-				Type: event.ErrorType,
-				ErrorEvent: event.ErrorEvent{
-					Err: err,
-				},
-			}
+			handleError(eventChannel, err)
 		}
 	}()
 	return eventChannel
+}
+
+func handleError(eventChannel chan event.Event, err error) {
+	eventChannel <- event.Event{
+		Type: event.ErrorType,
+		ErrorEvent: event.ErrorEvent{
+			Err: err,
+		},
+	}
 }
 
 // infosToObjMetas takes a slice of infos and extract the

--- a/pkg/kstatus/polling/statusreaders/common.go
+++ b/pkg/kstatus/polling/statusreaders/common.go
@@ -80,12 +80,14 @@ func (b *baseStatusReader) lookupResource(ctx context.Context, identifier object
 
 	var u unstructured.Unstructured
 	u.SetGroupVersionKind(GVK)
-	key := keyForNamespacedResource(identifier)
+	key := types.NamespacedName{
+		Name:      identifier.Name,
+		Namespace: identifier.Namespace,
+	}
 	err = b.reader.Get(ctx, key, &u)
 	if err != nil {
 		return nil, err
 	}
-	u.SetNamespace(identifier.Namespace)
 	return &u, nil
 }
 
@@ -188,22 +190,5 @@ func getNamespaceForNamespacedResource(object runtime.Object) string {
 	if err != nil {
 		panic(err)
 	}
-	ns := acc.GetNamespace()
-	if ns == metav1.NamespaceNone {
-		return metav1.NamespaceDefault
-	}
-	return ns
-}
-
-// keyForNamespacedResource returns the object key for the given identifier. It makes
-// sure to set the namespace to default if it is not provided.
-func keyForNamespacedResource(identifier object.ObjMetadata) types.NamespacedName {
-	namespace := metav1.NamespaceDefault
-	if identifier.Namespace != metav1.NamespaceNone {
-		namespace = identifier.Namespace
-	}
-	return types.NamespacedName{
-		Name:      identifier.Name,
-		Namespace: namespace,
-	}
+	return acc.GetNamespace()
 }


### PR DESCRIPTION
This fixes an issue where clusterscoped resource was not handled correctly because the status poller defaulted the namespace to `default` without checking if a resource is clusterscoped. With this change, the poller engine will verify at the beginning that all namespaced resources do have their namespace set so we no longer need to handle this within the status readers.

Ref: https://github.com/GoogleContainerTools/kpt/issues/498

@seans3 @monopole