### PR TITLE
add json tag to Condition type

### DIFF
--- a/pkg/kstatus/status/status.go
+++ b/pkg/kstatus/status/status.go
@@ -76,13 +76,13 @@ type Result struct {
 // most (maybe all) follows this structure.
 type Condition struct {
 	// Type condition type
-	Type ConditionType
+	Type ConditionType `json:"type,omitempty"`
 	// Status String that describes the condition status
-	Status corev1.ConditionStatus
+	Status corev1.ConditionStatus `json:"status,omitempty"`
 	// Reason one work CamelCase reason
-	Reason string
+	Reason string `json:"reason,omitempty"`
 	// Message Human readable reason string
-	Message string
+	Message string `json:"message,omitempty"`
 }
 
 // Compute finds the status of a given unstructured resource. It does not


### PR DESCRIPTION
When building a CRD using kubebuilder, I used the `Condition` type in the status. It failed since there's no json tag.