### PR TITLE
cli-utils diff command with one directory argument

### DIFF
--- a/cmd/diff/cmddiff.go
+++ b/cmd/diff/cmddiff.go
@@ -6,10 +6,72 @@ package diff
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/apply"
 	"k8s.io/kubectl/pkg/cmd/diff"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 func NewCmdDiff(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	return diff.NewCmdDiff(f, ioStreams)
+	options := diff.NewDiffOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:                   "diff DIRECTORY",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Diff local config against cluster applied version"),
+		Args:                  cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(Initialize(options, f, args))
+			util.CheckErr(options.Run())
+		},
+	}
+
+	return cmd
+}
+
+// Initialize fills in the DiffOptions in preparation for DiffOptions.Run().
+// Returns error if there is an error filling in the options or if there
+// is not one argument that is a directory.
+func Initialize(o *diff.DiffOptions, f util.Factory, args []string) error {
+	var err error
+
+	// Validate the only argument is a (package) directory path.
+	filenameFlags, err := common.DemandOneDirectory(args)
+	if err != nil {
+		return err
+	}
+	o.FilenameOptions = filenameFlags.ToOptions()
+
+	o.OpenAPISchema, err = f.OpenAPISchema()
+	if err != nil {
+		return err
+	}
+
+	o.DiscoveryClient, err = f.ToDiscoveryClient()
+	if err != nil {
+		return err
+	}
+
+	o.DynamicClient, err = f.DynamicClient()
+	if err != nil {
+		return err
+	}
+
+	o.DryRunVerifier = &apply.DryRunVerifier{
+		Finder:        util.NewCRDFinder(util.CRDFromDynamic(o.DynamicClient)),
+		OpenAPIGetter: o.DiscoveryClient,
+	}
+
+	o.CmdNamespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.Builder = f.NewBuilder()
+
+	// We don't support server-side apply diffing yet.
+	o.ServerSideApply = false
+	o.ForceConflicts = false
+
+	return nil
 }

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/task"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -74,7 +75,7 @@ type Applier struct {
 // a cluster. This involves validating command line inputs and configuring
 // clients for communicating with the cluster.
 func (a *Applier) Initialize(cmd *cobra.Command, paths []string) error {
-	fileNameFlags, err := demandOneDirectory(paths)
+	fileNameFlags, err := common.DemandOneDirectory(paths)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
+	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 // NewDestroyer returns a new destroyer. It will set up the ApplyOptions and
@@ -47,7 +48,7 @@ type Destroyer struct {
 // a cluster. This involves validating command line inputs and configuring
 // clients for communicating with the cluster.
 func (d *Destroyer) Initialize(cmd *cobra.Command, paths []string) error {
-	fileNameFlags, err := demandOneDirectory(paths)
+	fileNameFlags, err := common.DemandOneDirectory(paths)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/path.go
+++ b/pkg/common/path.go
@@ -1,7 +1,7 @@
 // Copyright 2020 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package common
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ func processPaths(paths []string) genericclioptions.FileNameFlags {
 	return fileNameFlags
 }
 
-func demandOneDirectory(paths []string) (genericclioptions.FileNameFlags, error) {
+func DemandOneDirectory(paths []string) (genericclioptions.FileNameFlags, error) {
 	result := processPaths(paths)
 	// alas, the things called file names should have been called paths.
 	if len(*result.Filenames) != 1 {

--- a/pkg/common/path_test.go
+++ b/pkg/common/path_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package common
 
 import (
 	"testing"
@@ -54,7 +54,7 @@ func TestProcessPaths(t *testing.T) {
 			var err error
 			fileNameFlags := processPaths(tc.paths)
 			assert.DeepEqual(t, tc.expectedFileNameFlags, fileNameFlags)
-			fileNameFlags, err = demandOneDirectory(tc.paths)
+			fileNameFlags, err = DemandOneDirectory(tc.paths)
 			assert.DeepEqual(t, tc.expectedFileNameFlags, fileNameFlags)
 			if err != nil && err.Error() != tc.errFromDemandOneDirectory {
 				assert.Equal(t, err.Error(), tc.errFromDemandOneDirectory)


### PR DESCRIPTION
* cli-utils `diff` command with one directory argument, instead of default kubectl flags.
* Moves `path.go` and unit test to `pkg/common` directory and exports `DemandOneDirectory()` to make it reusable.
* Removes ability to do diff server-side--only client-side.
* Removes extraneous flags.
