### PR TITLE
Only send status events if we are waiting for reconcile

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -68,7 +68,11 @@ func (r *ApplyRunner) Run(cmd *cobra.Command, args []string) {
 
 	// Run the applier. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	ch := r.applier.Run(context.Background())
+	ch := r.applier.Run(context.Background(), apply.Options{
+		// If we are not waiting for status, tell the applier to not
+		// emit the events.
+		EmitStatusEvents: r.applier.StatusOptions.Wait,
+	})
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -45,7 +45,9 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 
 				// Run the applier. It will return a channel where we can receive updates
 				// to keep track of progress and any issues.
-				ch = applier.Run(ctx)
+				ch = applier.Run(ctx, apply.Options{
+					EmitStatusEvents: false,
+				})
 			} else {
 				ch = destroyer.Run()
 			}

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -118,7 +118,7 @@ func (a *Applier) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")
 	_ = cmd.Flags().MarkHidden("timeout")
-	_ = cmd.Flags().MarkHidden("wait")
+	_ = cmd.Flags().MarkHidden("Wait")
 	a.StatusOptions.AddFlags(cmd)
 	a.ApplyOptions.Overwrite = true
 	return nil
@@ -220,10 +220,10 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 		},
 	}
 
-	if a.StatusOptions.wait {
+	if a.StatusOptions.Wait {
 		tasks = append(tasks,
-			// The wait task declares that after applying the resources,
-			// we should wait for all of them to reach the Current status
+			// The Wait task declares that after applying the resources,
+			// we should Wait for all of them to reach the Current status
 			// before continuing.
 			taskrunner.NewWaitTask(identifiers, taskrunner.AllCurrent,
 				a.StatusOptions.Timeout),
@@ -271,13 +271,13 @@ func (a *Applier) buildTaskQueue(infos []*resource.Info, identifiers []object.Ob
 
 // Run performs the Apply step. This happens asynchronously with updates
 // on progress and any errors are reported back on the event channel.
-// Cancelling the operation or setting timeout on how long to wait
+// Cancelling the operation or setting timeout on how long to Wait
 // for it complete can be done with the passed in context.
 // Note: There sn't currently any way to interrupt the operation
 // before all the given resources have been applied to the cluster. Any
-// cancellation or timeout will only affect how long we wait for the
+// cancellation or timeout will only affect how long we Wait for the
 // resources to become current.
-func (a *Applier) Run(ctx context.Context) <-chan event.Event {
+func (a *Applier) Run(ctx context.Context, options Options) <-chan event.Event {
 	eventChannel := make(chan event.Event)
 
 	go func() {
@@ -324,15 +324,20 @@ func (a *Applier) Run(ctx context.Context) <-chan event.Event {
 
 		// Create a new TaskStatusRunner to execute the taskQueue.
 		runner := taskrunner.NewTaskStatusRunner(identifiers, a.statusPoller)
-		err = runner.Run(ctx, taskQueue, eventChannel, taskrunner.PollingOptions{
-			PollInterval: a.StatusOptions.period,
-			UseCache:     true,
+		err = runner.Run(ctx, taskQueue, eventChannel, taskrunner.Options{
+			PollInterval:     a.StatusOptions.period,
+			UseCache:         true,
+			EmitStatusEvents: options.EmitStatusEvents,
 		})
 		if err != nil {
 			handleError(eventChannel, err)
 		}
 	}()
 	return eventChannel
+}
+
+type Options struct {
+	EmitStatusEvents bool
 }
 
 func handleError(eventChannel chan event.Event, err error) {

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -234,7 +234,7 @@ func TestApplier(t *testing.T) {
 			applier := NewApplier(tf, ioStreams)
 
 			applier.StatusOptions.period = 2 * time.Second
-			applier.StatusOptions.wait = tc.status
+			applier.StatusOptions.Wait = tc.status
 			applier.NoPrune = !tc.prune
 
 			cmd := &cobra.Command{}
@@ -254,7 +254,9 @@ func TestApplier(t *testing.T) {
 			applier.statusPoller = poller
 
 			ctx := context.Background()
-			eventChannel := applier.Run(ctx)
+			eventChannel := applier.Run(ctx, Options{
+				EmitStatusEvents: true,
+			})
 
 			var events []event.Event
 			for e := range eventChannel {

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -141,7 +141,7 @@ func (d *Destroyer) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")
 	_ = cmd.Flags().MarkHidden("timeout")
-	_ = cmd.Flags().MarkHidden("wait")
+	_ = cmd.Flags().MarkHidden("Wait")
 	d.ApplyOptions.Overwrite = true
 	return nil
 }

--- a/pkg/apply/status.go
+++ b/pkg/apply/status.go
@@ -11,20 +11,20 @@ import (
 
 func NewStatusOptions() *StatusOptions {
 	return &StatusOptions{
-		wait:    false,
+		Wait:    false,
 		period:  2 * time.Second,
 		Timeout: time.Minute,
 	}
 }
 
 type StatusOptions struct {
-	wait    bool
+	Wait    bool
 	period  time.Duration
 	Timeout time.Duration
 }
 
 func (s *StatusOptions) AddFlags(c *cobra.Command) {
-	c.Flags().BoolVar(&s.wait, "wait-for-reconcile", s.wait, "Wait for all applied resources to reach the Current status.")
+	c.Flags().BoolVar(&s.Wait, "wait-for-reconcile", s.Wait, "Wait for all applied resources to reach the Current status.")
 	c.Flags().DurationVar(&s.period, "wait-polling-period", s.period, "Polling period for resource statuses.")
 	c.Flags().DurationVar(&s.Timeout, "wait-timeout", s.Timeout, "Timeout threshold for waiting for all resources to reach the Current status.")
 }

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -162,7 +162,8 @@ func TestBaseRunner(t *testing.T) {
 				}
 			}()
 
-			err := runner.run(context.Background(), taskQueue, statusChannel, eventChannel)
+			err := runner.run(context.Background(), taskQueue, statusChannel,
+				eventChannel, baseOptions{emitStatusEvents: true})
 			close(statusChannel)
 			close(eventChannel)
 			wg.Wait()
@@ -319,7 +320,8 @@ func TestBaseRunnerCancellation(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
 			defer cancel()
-			err := runner.run(ctx, taskQueue, statusChannel, eventChannel)
+			err := runner.run(ctx, taskQueue, statusChannel, eventChannel,
+				baseOptions{emitStatusEvents: false})
 			close(statusChannel)
 			close(eventChannel)
 			wg.Wait()


### PR DESCRIPTION
This makes it configurable whether the `taskRunner` should forward status events on the `eventChannel`. In this change we set this flag based on whether we should wait for reconcile. We might want to separate these two decisions at some point, but this fits the current behavior.

Fixes: #124 

@seans3 