### PR TITLE
Polling library should send update when resource gen changes

### DIFF
--- a/pkg/kstatus/polling/engine/engine.go
+++ b/pkg/kstatus/polling/engine/engine.go
@@ -264,5 +264,5 @@ func (r *statusPollerRunner) isUpdatedResourceStatus(resourceStatus *event.Resou
 	if !found {
 		return true
 	}
-	return !event.ResourceStatusChanged(resourceStatus, oldResourceStatus)
+	return !event.ResourceStatusEqual(resourceStatus, oldResourceStatus)
 }

--- a/pkg/kstatus/polling/event/event_test.go
+++ b/pkg/kstatus/polling/event/event_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -29,6 +30,13 @@ func TestDeepEqual(t *testing.T) {
 					Namespace: "default",
 					Name:      "Foo",
 				},
+				Resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"generation": int64(1),
+						},
+					},
+				},
 				Status:  status.UnknownStatus,
 				Message: "Some message",
 			},
@@ -41,10 +49,17 @@ func TestDeepEqual(t *testing.T) {
 					Namespace: "default",
 					Name:      "Foo",
 				},
+				Resource: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"generation": int64(2),
+						},
+					},
+				},
 				Status:  status.UnknownStatus,
 				Message: "Some message",
 			},
-			equal: true,
+			equal: false,
 		},
 		"different resources with only name different": {
 			actual: ResourceStatus{
@@ -268,7 +283,7 @@ func TestDeepEqual(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			res := ResourceStatusChanged(&tc.actual, &tc.expected)
+			res := ResourceStatusEqual(&tc.actual, &tc.expected)
 
 			assert.Equal(t, tc.equal, res)
 		})


### PR DESCRIPTION
Currently the check in the polling library for whether a status update should be sent does not look at the spec of resources. This can lead to surprising results where an update might make changes that doesn't impact status at all (like adding a new label). This updates the logic to also send a status update for the resource whenever the generation of the resource is updated.

This is important for a follow-up PR that will leverage the generation of resources to make sure we always have an updated version of the resource when computing status.

@seans3 @monopole 