### PR TITLE
Use resource generation in status decisions

### DIFF
--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -4,26 +4,50 @@
 package task
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/kubectl/pkg/cmd/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // ApplyTask applies the given Objects to the cluster
 // by using the ApplyOptions.
 type ApplyTask struct {
-	ApplyOptions *apply.ApplyOptions
+	ApplyOptions applyOptions
 	Objects      []*resource.Info
+}
+
+// applyOptions defines the two key functions on the ApplyOptions
+// struct that is used by the ApplyTask.
+type applyOptions interface {
+
+	// Run applies the resource set with the SetObjects function
+	// to the cluster.
+	Run() error
+
+	// SetObjects sets the slice of resource (in the form form info objects)
+	// that will be applied upon invoking the Run function.
+	SetObjects([]*resource.Info)
 }
 
 // Start creates a new goroutine that will invoke
 // the Run function on the ApplyOptions to update
 // the cluster. It will push a TaskResult on the taskChannel
 // to signal to the taskrunner that the task has completed (or failed).
+// It will also fetch the Generation from each of the applied resources
+// after the Run function has completed. This information is then added
+// to the taskContext. The generation is increased every time
+// the desired state of a resource is changed.
 func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		a.ApplyOptions.SetObjects(a.Objects)
 		err := a.ApplyOptions.Run()
+		for _, info := range a.Objects {
+			id := object.InfoToObjMeta(info)
+			acc, _ := meta.Accessor(info.Object)
+			gen := acc.GetGeneration()
+			taskContext.ResourceApplied(id, gen)
+		}
 		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,
 		}

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -1,0 +1,120 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+type info struct {
+	group      string
+	apiVersion string
+	kind       string
+	name       string
+	namespace  string
+	generation int64
+}
+
+func TestApplyTask_FetchGeneration(t *testing.T) {
+	testCases := map[string]struct {
+		infos []info
+	}{
+		"single namespaced resource": {
+			infos: []info{
+				{
+					group:      "apps",
+					apiVersion: "apps/v1",
+					kind:       "Deployment",
+					name:       "foo",
+					namespace:  "default",
+					generation: int64(42),
+				},
+			},
+		},
+		"multiple clusterscoped resources": {
+			infos: []info{
+				{
+					group:      "custom.io",
+					apiVersion: "custom.io/v1beta1",
+					kind:       "Custom",
+					name:       "bar",
+					generation: int64(32),
+				},
+				{
+					group:      "custom2.io",
+					apiVersion: "custom2.io/v1",
+					kind:       "Custom2",
+					name:       "foo",
+					generation: int64(1),
+				},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			eventChannel := make(chan event.Event)
+			defer close(eventChannel)
+			taskContext := taskrunner.NewTaskContext(eventChannel)
+
+			var infos []*resource.Info
+
+			for _, info := range tc.infos {
+				infos = append(infos, &resource.Info{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": info.apiVersion,
+							"kind":       info.kind,
+							"metadata": map[string]interface{}{
+								"name":       info.name,
+								"namespace":  info.namespace,
+								"generation": info.generation,
+							},
+						},
+					},
+				})
+			}
+
+			applyOptions := &fakeApplyOptions{}
+
+			applyTask := &ApplyTask{
+				ApplyOptions: applyOptions,
+				Objects:      infos,
+			}
+
+			applyTask.Start(taskContext)
+
+			<-taskContext.TaskChannel()
+
+			for _, info := range tc.infos {
+				id := object.ObjMetadata{
+					GroupKind: schema.GroupKind{
+						Group: info.group,
+						Kind:  info.kind,
+					},
+					Name:      info.name,
+					Namespace: info.namespace,
+				}
+				gen := taskContext.ResourceGeneration(id)
+				assert.Equal(t, info.generation, gen)
+			}
+		})
+	}
+}
+
+type fakeApplyOptions struct{}
+
+func (f *fakeApplyOptions) Run() error {
+	return nil
+}
+
+func (f *fakeApplyOptions) SetObjects([]*resource.Info) {}

--- a/pkg/apply/taskrunner/collector_test.go
+++ b/pkg/apply/taskrunner/collector_test.go
@@ -1,0 +1,138 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestCollector_ConditionMet(t *testing.T) {
+	identifiers := map[string]object.ObjMetadata{
+		"dep": {
+			GroupKind: schema.GroupKind{
+				Group: "apps",
+				Kind:  "Deployment",
+			},
+			Name:      "Foo",
+			Namespace: "default",
+		},
+		"custom": {
+			GroupKind: schema.GroupKind{
+				Group: "custom.io",
+				Kind:  "Custom",
+			},
+			Name: "Foo",
+		},
+	}
+
+	testCases := map[string]struct {
+		collectorState map[object.ObjMetadata]resourceStatus
+		waitTaskData   []resourceWaitData
+		condition      condition
+		expectedResult bool
+	}{
+		"single resource with current status": {
+			collectorState: map[object.ObjMetadata]resourceStatus{
+				identifiers["dep"]: {
+					Identifier:    identifiers["dep"],
+					CurrentStatus: status.CurrentStatus,
+					Generation:    int64(42),
+				},
+			},
+			waitTaskData: []resourceWaitData{
+				{
+					identifier: identifiers["dep"],
+					generation: int64(42),
+				},
+			},
+			condition:      AllCurrent,
+			expectedResult: true,
+		},
+		"single resource with current status and old generation": {
+			collectorState: map[object.ObjMetadata]resourceStatus{
+				identifiers["dep"]: {
+					Identifier:    identifiers["dep"],
+					CurrentStatus: status.CurrentStatus,
+					Generation:    int64(41),
+				},
+			},
+			waitTaskData: []resourceWaitData{
+				{
+					identifier: identifiers["dep"],
+					generation: int64(42),
+				},
+			},
+			condition:      AllCurrent,
+			expectedResult: false,
+		},
+		"multiple resources not all current": {
+			collectorState: map[object.ObjMetadata]resourceStatus{
+				identifiers["dep"]: {
+					Identifier:    identifiers["dep"],
+					CurrentStatus: status.CurrentStatus,
+					Generation:    int64(41),
+				},
+				identifiers["custom"]: {
+					Identifier:    identifiers["custom"],
+					CurrentStatus: status.InProgressStatus,
+					Generation:    int64(0),
+				},
+			},
+			waitTaskData: []resourceWaitData{
+				{
+					identifier: identifiers["dep"],
+					generation: int64(42),
+				},
+				{
+					identifier: identifiers["custom"],
+					generation: int64(0),
+				},
+			},
+			condition:      AllCurrent,
+			expectedResult: false,
+		},
+		"multiple resources single with old generation": {
+			collectorState: map[object.ObjMetadata]resourceStatus{
+				identifiers["dep"]: {
+					Identifier:    identifiers["dep"],
+					CurrentStatus: status.CurrentStatus,
+					Generation:    int64(42),
+				},
+				identifiers["custom"]: {
+					Identifier:    identifiers["custom"],
+					CurrentStatus: status.CurrentStatus,
+					Generation:    int64(4),
+				},
+			},
+			waitTaskData: []resourceWaitData{
+				{
+					identifier: identifiers["dep"],
+					generation: int64(42),
+				},
+				{
+					identifier: identifiers["custom"],
+					generation: int64(5),
+				},
+			},
+			condition:      AllCurrent,
+			expectedResult: false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			rsc := newResourceStatusCollector([]object.ObjMetadata{})
+			rsc.resourceMap = tc.collectorState
+
+			res := rsc.conditionMet(tc.waitTaskData, tc.condition)
+
+			assert.Equal(t, tc.expectedResult, res)
+		})
+	}
+}

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -5,13 +5,15 @@ package taskrunner
 
 import (
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // NewTaskContext returns a new TaskContext
 func NewTaskContext(eventChannel chan event.Event) *TaskContext {
 	return &TaskContext{
-		taskChannel:  make(chan TaskResult),
-		eventChannel: eventChannel,
+		taskChannel:      make(chan TaskResult),
+		eventChannel:     eventChannel,
+		appliedResources: make(map[object.ObjMetadata]applyInfo),
 	}
 }
 
@@ -21,6 +23,8 @@ type TaskContext struct {
 	taskChannel chan TaskResult
 
 	eventChannel chan event.Event
+
+	appliedResources map[object.ObjMetadata]applyInfo
 }
 
 func (tc *TaskContext) TaskChannel() chan TaskResult {
@@ -29,4 +33,34 @@ func (tc *TaskContext) TaskChannel() chan TaskResult {
 
 func (tc *TaskContext) EventChannel() chan event.Event {
 	return tc.eventChannel
+}
+
+// ResourceApplied updates the context with information about the
+// resource identified by the provided id. Currently, we keep information
+// about the generation of the resource after the apply operation completed.
+func (tc *TaskContext) ResourceApplied(id object.ObjMetadata, gen int64) {
+	tc.appliedResources[id] = applyInfo{
+		generation: gen,
+	}
+}
+
+// ResourceGeneration looks up the generation of the given resource
+// after it was applied.
+func (tc *TaskContext) ResourceGeneration(id object.ObjMetadata) int64 {
+	ai, found := tc.appliedResources[id]
+	if !found {
+		return 0
+	}
+	return ai.generation
+}
+
+// applyInfo captures information about resources that have been
+// applied. This is captured in the TaskContext so other tasks
+// running later might use this information.
+type applyInfo struct {
+	// generation captures the "version" of the resource after it
+	// has been applied. Generation is a monotonically increasing number
+	// that the APIServer increases every time the desired state of a
+	// resource changes.
+	generation int64
 }

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -188,12 +188,11 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 			// The collector needs to keep track of the latest status
 			// for all resources so we can check whether wait task conditions
 			// has been met.
-			b.collector.resourceStatus(statusEvent.Resource.Identifier,
-				statusEvent.Resource.Status)
+			b.collector.resourceStatus(statusEvent.Resource)
 			// If the current task is a wait task, we check whether
 			// the condition has been met. If so, we complete the task.
 			if wt, ok := currentTask.(*WaitTask); ok {
-				if b.collector.conditionMet(wt.Identifiers, wt.Condition) {
+				if wt.checkCondition(taskContext, b.collector) {
 					completeIfWaitTask(currentTask, taskContext)
 				}
 			}
@@ -258,10 +257,10 @@ func (b *baseRunner) nextTask(taskQueue chan Task,
 		// starting a new wait task, we check if the condition is already
 		// met. Without this check, a task might end up waiting for
 		// status events when the condition is in fact already met.
-		if b.collector.conditionMet(st.Identifiers, st.Condition) {
+		if st.checkCondition(taskContext, b.collector) {
 			st.startAndComplete(taskContext)
 		} else {
-			tsk.Start(taskContext)
+			st.Start(taskContext)
 		}
 	default:
 		tsk.Start(taskContext)

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
 )
 
 // Separates inventory fields. This string is allowable as a
@@ -92,4 +94,15 @@ func (o *ObjMetadata) String() string {
 		o.Name, fieldSeparator,
 		o.GroupKind.Group, fieldSeparator,
 		o.GroupKind.Kind)
+}
+
+// InfoToObjMeta takes information from the provided info and
+// returns an ObjMetadata that identifies the resource.
+func InfoToObjMeta(info *resource.Info) ObjMetadata {
+	u := info.Object.(*unstructured.Unstructured)
+	return ObjMetadata{
+		GroupKind: u.GroupVersionKind().GroupKind(),
+		Name:      u.GetName(),
+		Namespace: u.GetNamespace(),
+	}
 }


### PR DESCRIPTION
This PR will address an issue where wait tasks in the task queue might make decisions based on stale data. 
The problem is that since we do continuous polling throughout the process of apply, wait for reconcile and prune, there is a chance that after applying resources, the wait task might look at status for resources that were computed based on the pre-apply state. 
This PR updates the `applyTask` to collect the generation of all the resources after the apply operation has completed and then stores that in the context. The wait task will then use this information to make sure the status it is seeing is based on the state of the resources of the correct (or later) generation. 

This ends up being somewhat similar to the previous discussion around keeping UIDs between apply and prune. So this adds a data structure to the context, but does not add any synchronization as it shouldn't be needed. Since we use channels to complete tasks, there isn't a visibility problem for data written in different tasks.
I'm open to suggestions for other ways of doing this.

@seans3 @monopole @phanimarupaka 