### PR TITLE
Fix hidden wait flag

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -119,7 +119,7 @@ func (a *Applier) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")
 	_ = cmd.Flags().MarkHidden("timeout")
-	_ = cmd.Flags().MarkHidden("Wait")
+	_ = cmd.Flags().MarkHidden("wait")
 	a.StatusOptions.AddFlags(cmd)
 	a.ApplyOptions.Overwrite = true
 	return nil

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -142,7 +142,7 @@ func (d *Destroyer) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("force")
 	_ = cmd.Flags().MarkHidden("grace-period")
 	_ = cmd.Flags().MarkHidden("timeout")
-	_ = cmd.Flags().MarkHidden("Wait")
+	_ = cmd.Flags().MarkHidden("wait")
 	d.ApplyOptions.Overwrite = true
 	return nil
 }


### PR DESCRIPTION
In a previous refactoring, the flag ended up being capitalized and therefore no longer hidden.

@seans3 