### PR TITLE
 Wait for CRDs to become established before applying CRs

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -1,0 +1,183 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// The solver package is responsible for constructing a
+// taskqueue based on the set of resources that should be
+// applied.
+// This involves setting up the appropriate sequence of
+// apply, wait and prune tasks so any dependencies between
+// resources doesn't cause a later apply operation to
+// fail.
+// Currently this package assumes that the resources have
+// already been sorted in the appropriate order. We might
+// want to consider moving the sorting functionality into
+// this package.
+package solver
+
+import (
+	"time"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/prune"
+	"sigs.k8s.io/cli-utils/pkg/apply/task"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+type TaskQueueSolver struct {
+	ApplyOptions *apply.ApplyOptions
+	PruneOptions *prune.PruneOptions
+}
+
+type Options struct {
+	WaitForReconcile        bool
+	WaitForReconcileTimeout time.Duration
+	Prune                   bool
+}
+
+// BuildTaskQueue takes a set of resources in the form of info objects
+// and constructs the task queue. The options parameter allows
+// customization of how the task queue are built.
+func (t *TaskQueueSolver) BuildTaskQueue(infos []*resource.Info,
+	o Options) chan taskrunner.Task {
+	var tasks []taskrunner.Task
+	remainingInfos := infos
+
+	crdSplitRes, hasCRDs := splitAfterCRDs(remainingInfos)
+	if hasCRDs {
+		tasks = append(tasks, &task.ApplyTask{
+			Objects:      append(crdSplitRes.before, crdSplitRes.crds...),
+			ApplyOptions: t.ApplyOptions,
+		},
+			taskrunner.NewWaitTask(
+				object.InfosToObjMetas(crdSplitRes.crds),
+				taskrunner.AllCurrent,
+				1*time.Minute),
+		)
+		remainingInfos = crdSplitRes.after
+	}
+
+	tasks = append(tasks,
+		&task.ApplyTask{
+			Objects:      remainingInfos,
+			ApplyOptions: t.ApplyOptions,
+		},
+		&task.SendEventTask{
+			Event: event.Event{
+				Type: event.ApplyType,
+				ApplyEvent: event.ApplyEvent{
+					Type: event.ApplyEventCompleted,
+				},
+			},
+		},
+	)
+
+	if o.WaitForReconcile {
+		tasks = append(tasks,
+			taskrunner.NewWaitTask(
+				object.InfosToObjMetas(infos),
+				taskrunner.AllCurrent,
+				o.WaitForReconcileTimeout),
+			&task.SendEventTask{
+				Event: event.Event{
+					Type: event.StatusType,
+					StatusEvent: pollevent.Event{
+						EventType: pollevent.CompletedEvent,
+					},
+				},
+			},
+		)
+	}
+
+	if o.Prune {
+		tasks = append(tasks,
+			&task.PruneTask{
+				Objects:      infos,
+				PruneOptions: t.PruneOptions,
+			},
+			&task.SendEventTask{
+				Event: event.Event{
+					Type: event.PruneType,
+					PruneEvent: event.PruneEvent{
+						Type: event.PruneEventCompleted,
+					},
+				},
+			},
+		)
+	}
+
+	return tasksToQueue(tasks)
+}
+
+func tasksToQueue(tasks []taskrunner.Task) chan taskrunner.Task {
+	taskQueue := make(chan taskrunner.Task, len(tasks))
+	for _, t := range tasks {
+		taskQueue <- t
+	}
+	return taskQueue
+}
+
+type crdSplitResult struct {
+	before []*resource.Info
+	after  []*resource.Info
+	crds   []*resource.Info
+}
+
+// splitAfterCRDs takes a sorted slice of infos and splits it into
+// three parts; resources before CRDs, the CRDs themselves, and finally
+// all the resources after the CRDs.
+// The function returns the three different sets of resources and
+// a boolean that tells whether there were any CRDs in the set of
+// resources.
+func splitAfterCRDs(infos []*resource.Info) (crdSplitResult, bool) {
+	var before []*resource.Info
+	var after []*resource.Info
+
+	var crds []*resource.Info
+	for _, info := range infos {
+		if isCRD(info) {
+			crds = append(crds, info)
+			continue
+		}
+
+		if len(crds) > 0 {
+			after = append(after, info)
+		} else {
+			before = append(before, info)
+		}
+	}
+	return crdSplitResult{
+		before: before,
+		after:  after,
+		crds:   crds,
+	}, len(crds) > 0
+}
+
+func isCRD(info *resource.Info) bool {
+	gvk, found := toGVK(info)
+	if !found {
+		return false
+	}
+	if (gvk.Group == v1.SchemeGroupVersion.Group ||
+		gvk.Group == v1beta1.SchemeGroupVersion.Group) &&
+		gvk.Kind == "CustomResourceDefinition" {
+		return true
+	}
+	return false
+}
+
+func toGVK(info *resource.Info) (schema.GroupVersionKind, bool) {
+	if mapping := info.ResourceMapping(); mapping != nil {
+		return mapping.GroupVersionKind, true
+	}
+	if info.Object != nil {
+		return info.Object.GetObjectKind().GroupVersionKind(), true
+	}
+	return schema.GroupVersionKind{}, false
+}

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -1,0 +1,233 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package solver
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/prune"
+	"sigs.k8s.io/cli-utils/pkg/apply/task"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+var (
+	applyOptions = &apply.ApplyOptions{}
+	pruneOptions = &prune.PruneOptions{}
+
+	depInfo    = createInfo("apps/v1", "Deployment", "foo", "bar")
+	customInfo = createInfo("custom.io/v1", "Custom", "Foo", "")
+	crdInfo    = createInfo("apiextensions.k8s.io/v1", "CustomResourceDefinition", "CRD", "")
+)
+
+func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
+	testCases := map[string]struct {
+		infos         []*resource.Info
+		options       Options
+		expectedTasks []taskrunner.Task
+	}{
+		"no resources": {
+			infos:   []*resource.Info{},
+			options: Options{},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{},
+				&task.SendEventTask{},
+			},
+		},
+		"single resource": {
+			infos: []*resource.Info{
+				depInfo,
+			},
+			options: Options{},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+					},
+				},
+				&task.SendEventTask{},
+			},
+		},
+		"multiple resources with wait": {
+			infos: []*resource.Info{
+				depInfo,
+				customInfo,
+			},
+			options: Options{
+				WaitForReconcile: true,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+						customInfo,
+					},
+				},
+				&task.SendEventTask{},
+				taskrunner.NewWaitTask(
+					[]object.ObjMetadata{
+						object.InfoToObjMeta(depInfo),
+						object.InfoToObjMeta(customInfo),
+					},
+					taskrunner.AllCurrent, 1*time.Second),
+				&task.SendEventTask{},
+			},
+		},
+		"multiple resources with wait and prune": {
+			infos: []*resource.Info{
+				depInfo,
+				customInfo,
+			},
+			options: Options{
+				WaitForReconcile: true,
+				Prune:            true,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+						customInfo,
+					},
+				},
+				&task.SendEventTask{},
+				taskrunner.NewWaitTask(
+					[]object.ObjMetadata{
+						object.InfoToObjMeta(depInfo),
+						object.InfoToObjMeta(customInfo),
+					},
+					taskrunner.AllCurrent, 1*time.Second),
+				&task.SendEventTask{},
+				&task.PruneTask{},
+				&task.SendEventTask{},
+			},
+		},
+		"multiple resources including CRD": {
+			infos: []*resource.Info{
+				crdInfo,
+				depInfo,
+			},
+			options: Options{
+				WaitForReconcile: true,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						crdInfo,
+					},
+				},
+				taskrunner.NewWaitTask(
+					[]object.ObjMetadata{
+						object.InfoToObjMeta(crdInfo),
+					},
+					taskrunner.AllCurrent, 1*time.Second),
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+					},
+				},
+				&task.SendEventTask{},
+				taskrunner.NewWaitTask(
+					[]object.ObjMetadata{
+						object.InfoToObjMeta(crdInfo),
+						object.InfoToObjMeta(depInfo),
+					},
+					taskrunner.AllCurrent, 1*time.Second),
+				&task.SendEventTask{},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tqs := TaskQueueSolver{
+				ApplyOptions: applyOptions,
+				PruneOptions: pruneOptions,
+			}
+
+			tq := tqs.BuildTaskQueue(tc.infos, tc.options)
+
+			tasks := queueToSlice(tq)
+
+			assert.Equal(t, len(tc.expectedTasks), len(tasks))
+			for i, expTask := range tc.expectedTasks {
+				actualTask := tasks[i]
+				assert.Equal(t, getType(expTask), getType(actualTask))
+
+				switch expTsk := expTask.(type) {
+				case *task.ApplyTask:
+					actApplyTask := toApplyTask(t, actualTask)
+					assert.Equal(t, len(expTsk.Objects), len(actApplyTask.Objects))
+					for j, obj := range expTsk.Objects {
+						actObj := actApplyTask.Objects[j]
+						assert.Equal(t, object.InfoToObjMeta(obj), object.InfoToObjMeta(actObj))
+					}
+				case *taskrunner.WaitTask:
+					actWaitTask := toWaitTask(t, actualTask)
+					assert.Equal(t, len(expTsk.Identifiers), len(actWaitTask.Identifiers))
+					for j, id := range expTsk.Identifiers {
+						actID := actWaitTask.Identifiers[j]
+						assert.Equal(t, id, actID)
+					}
+				}
+			}
+		})
+	}
+}
+
+func toWaitTask(t *testing.T, task taskrunner.Task) *taskrunner.WaitTask {
+	switch tsk := task.(type) {
+	case *taskrunner.WaitTask:
+		return tsk
+	default:
+		t.Fatalf("expected type *WaitTask, but got %s", reflect.TypeOf(task).String())
+		return nil
+	}
+}
+
+func toApplyTask(t *testing.T, aTask taskrunner.Task) *task.ApplyTask {
+	switch tsk := aTask.(type) {
+	case *task.ApplyTask:
+		return tsk
+	default:
+		t.Fatalf("expected type *ApplyTask, but got %s", reflect.TypeOf(aTask).String())
+		return nil
+	}
+}
+
+func createInfo(apiVersion, kind, name, namespace string) *resource.Info {
+	return &resource.Info{
+		Object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": apiVersion,
+				"kind":       kind,
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": namespace,
+				},
+			},
+		},
+	}
+}
+
+func queueToSlice(tq chan taskrunner.Task) []taskrunner.Task {
+	var tasks []taskrunner.Task
+	for {
+		select {
+		case t := <-tq:
+			tasks = append(tasks, t)
+		default:
+			return tasks
+		}
+	}
+}
+
+func getType(task taskrunner.Task) reflect.Type {
+	return reflect.TypeOf(task)
+}

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -106,3 +106,14 @@ func InfoToObjMeta(info *resource.Info) ObjMetadata {
 		Namespace: u.GetNamespace(),
 	}
 }
+
+// infosToObjMetas takes a slice of infos and extract the
+// GroupKind, name and namespace for each resource and returns
+// it as a slice of ObjMetadata.
+func InfosToObjMetas(infos []*resource.Info) []ObjMetadata {
+	var objMetas []ObjMetadata
+	for _, info := range infos {
+		objMetas = append(objMetas, InfoToObjMeta(info))
+	}
+	return objMetas
+}


### PR DESCRIPTION
This PR moves the logic for building the taskqueue into a separate solver module. Currently it only accounts for CRDs to make sure that we wait for CRDs become `established` before it continues to apply other resources. Eventually we need to support other resources.

@seans3 @monopole 

/hold