### PR TITLE
Handle errors better in table views

### DIFF
--- a/cmd/printers/table/printer.go
+++ b/cmd/printers/table/printer.go
@@ -30,7 +30,8 @@ func (t *Printer) Print(ch <-chan event.Event, _ bool) {
 		// Eventually we need a more graceful shutdown if
 		// this happens.
 		if e.Type == event.ErrorType {
-			panic(e.ErrorEvent.Err)
+			_, _ = fmt.Fprintf(t.IOStreams.Out, "Fatal error: %v\n", e.ErrorEvent.Err)
+			return
 		}
 	}
 	// Create a new collector and initialize it with the resources

--- a/cmd/status/printers/adapter.go
+++ b/cmd/status/printers/adapter.go
@@ -41,10 +41,15 @@ func (r *ResourceInfo) SubResources() []table.Resource {
 
 type ResourceState struct {
 	resources []table.Resource
+	err       error
 }
 
 func (rss *ResourceState) Resources() []table.Resource {
 	return rss.resources
+}
+
+func (rss *ResourceState) Error() error {
+	return rss.err
 }
 
 func (ca *CollectorAdapter) LatestStatus() *ResourceState {
@@ -57,5 +62,6 @@ func (ca *CollectorAdapter) LatestStatus() *ResourceState {
 	}
 	return &ResourceState{
 		resources: resources,
+		err:       observation.Error,
 	}
 }

--- a/pkg/print/table/base_test.go
+++ b/pkg/print/table/base_test.go
@@ -161,6 +161,10 @@ func (r *fakeResourceStates) Resources() []Resource {
 	return r.resources
 }
 
+func (r *fakeResourceStates) Error() error {
+	return nil
+}
+
 type fakeResource struct {
 	resourceStatus *pe.ResourceStatus
 }


### PR DESCRIPTION
Update the BaseTablePrinter with better error handling. It now prints them out properly instead of just calling panic.

@seans3 