### PR TITLE
Add StdIn as an acceptable argument for apply, preview, destroy, and diff commands

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -23,9 +23,9 @@ func GetApplyRunner(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *A
 		ioStreams: ioStreams,
 	}
 	cmd := &cobra.Command{
-		Use:                   "apply DIRECTORY",
+		Use:                   "apply (DIRECTORY | STDIN)",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Apply a configuration to a resource by filename or stdin"),
+		Short:                 i18n.T("Apply a configuration to a resource by package directory or stdin"),
 		Run:                   r.Run,
 	}
 

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -20,7 +20,7 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "destroy DIRECTORY",
+		Use:                   "destroy (DIRECTORY | STDIN)",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Destroy all the resources related to configuration"),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/diff/cmddiff.go
+++ b/cmd/diff/cmddiff.go
@@ -19,7 +19,7 @@ import (
 func NewCmdDiff(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	options := diff.NewDiffOptions(ioStreams)
 	cmd := &cobra.Command{
-		Use:                   "diff DIRECTORY",
+		Use:                   "diff (DIRECTORY | STDIN)",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Diff local config against cluster applied version"),
 		Args:                  cobra.MaximumNArgs(1),

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -24,7 +24,7 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "preview DIRECTORY",
+		Use:                   "preview (DIRECTORY | STDIN)",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Preview the apply of a configuration"),
 		Args:                  cobra.MaximumNArgs(1),


### PR DESCRIPTION
* Adds StdIn as an acceptable argument to the following commands: `apply`, `preview`, `destroy`, and `diff`.
* Updates `Use:` in command
* Adds unit tests
* Tested manually