### PR TITLE
Renames grouping.go to inventory.go

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -161,7 +161,7 @@ func (a *Applier) readAndPrepareObjects() ([]*resource.Info, error) {
 		}
 	}
 
-	groupingObject, err := prune.CreateGroupingObj(gots[0], resources)
+	groupingObject, err := prune.CreateInventoryObj(gots[0], resources)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apply/prune/inventory_test.go
+++ b/pkg/apply/prune/inventory_test.go
@@ -207,7 +207,7 @@ func TestIsInventoryObject(t *testing.T) {
 	}
 }
 
-func TestCreateGroupingObject(t *testing.T) {
+func TestCreateInventoryObject(t *testing.T) {
 	testCases := map[string]struct {
 		groupingObjectTemplate *resource.Info
 		resources              []*resource.Info
@@ -282,7 +282,7 @@ func TestCreateGroupingObject(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			groupingObj, err := CreateGroupingObj(tc.groupingObjectTemplate,
+			groupingObj, err := CreateInventoryObj(tc.groupingObjectTemplate,
 				tc.resources)
 
 			if tc.expectedError {


### PR DESCRIPTION
* Renames `grouping.go` and `grouping_test.go` to `inventory.go` and `inventory_test.go`, since we've renamed the grouping object to inventory object.
* Renames `CreateGroupingObj()` to `CreateInventoryObj()`.
* Updates some `grouping object` comments to `inventory object`.
* More cleanups in future PRs