### PR TITLE
Remove DryRun and NoPrune fields on Applier and PruneOptions

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -29,7 +29,7 @@ func GetApplyRunner(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *A
 		Run:                   r.Run,
 	}
 
-	cmd.Flags().BoolVar(&r.applier.NoPrune, "no-prune", r.applier.NoPrune, "If true, do not prune previously applied objects.")
+	cmd.Flags().BoolVar(&r.noPrune, "no-prune", r.noPrune, "If true, do not prune previously applied objects.")
 	cmdutil.CheckErr(r.applier.SetFlags(cmd))
 
 	// The following flags are added, but hidden because other code
@@ -72,6 +72,7 @@ type ApplyRunner struct {
 	wait    bool
 	period  time.Duration
 	timeout time.Duration
+	noPrune bool
 }
 
 func (r *ApplyRunner) Run(cmd *cobra.Command, args []string) {
@@ -86,6 +87,8 @@ func (r *ApplyRunner) Run(cmd *cobra.Command, args []string) {
 		// If we are not waiting for status, tell the applier to not
 		// emit the events.
 		EmitStatusEvents: r.wait,
+		NoPrune:          r.noPrune,
+		DryRun:           false,
 	})
 
 	// The printer will print updates from the channel. It will block

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -14,6 +14,10 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
+var (
+	noPrune = false
+)
+
 // NewCmdPreview creates the `preview` command
 func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	applier := apply.NewApplier(f, ioStreams)
@@ -34,9 +38,6 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 			// if destroy flag is set in preview, transmit it to destroyer DryRun flag
 			// and pivot execution to destroy with dry-run
 			if !destroyer.DryRun {
-				// Set DryRun option true before Initialize. DryRun is propagated to
-				// ApplyOptions and PruneOptions in Initialize.
-				applier.DryRun = true
 				cmdutil.CheckErr(applier.Initialize(cmd, args))
 
 				// Create a context
@@ -46,6 +47,8 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 				// to keep track of progress and any issues.
 				ch = applier.Run(ctx, apply.Options{
 					EmitStatusEvents: false,
+					NoPrune:          noPrune,
+					DryRun:           true,
 				})
 			} else {
 				ch = destroyer.Run()
@@ -57,7 +60,7 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 		},
 	}
 
-	cmd.Flags().BoolVar(&applier.NoPrune, "no-prune", applier.NoPrune, "If true, do not prune previously applied objects.")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", noPrune, "If true, do not prune previously applied objects.")
 	cmdutil.CheckErr(applier.SetFlags(cmd))
 
 	// The following flags are added, but hidden because other code

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -229,11 +229,12 @@ func TestApplier(t *testing.T) {
 
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
 			applier := NewApplier(tf, ioStreams)
-			applier.NoPrune = !tc.prune
 
 			cmd := &cobra.Command{}
 			_ = applier.SetFlags(cmd)
-			cmd.Flags().BoolVar(&applier.DryRun, "dry-run", applier.DryRun, "")
+			var notUsedFlag bool
+			// This flag needs to be set as there is a dependency on it.
+			cmd.Flags().BoolVar(&notUsedFlag, "dry-run", notUsedFlag, "")
 			cmdutil.AddValidateFlags(cmd)
 			cmdutil.AddServerSideApplyFlags(cmd)
 			err = applier.Initialize(cmd, []string{dirPath})
@@ -251,6 +252,7 @@ func TestApplier(t *testing.T) {
 			eventChannel := applier.Run(ctx, Options{
 				WaitForReconcile: tc.status,
 				EmitStatusEvents: true,
+				NoPrune:          !tc.prune,
 			})
 
 			var events []event.Event

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -64,7 +64,6 @@ func (d *Destroyer) Initialize(cmd *cobra.Command, paths []string) error {
 
 	// Propagate dry-run flags.
 	d.ApplyOptions.DryRun = d.DryRun
-	d.PruneOptions.DryRun = d.DryRun
 	return nil
 }
 
@@ -96,7 +95,9 @@ func (d *Destroyer) Run() <-chan event.Event {
 		// Events. That we use Prune to implement destroy is an
 		// implementation detail and the events should not be Prune events.
 		tempChannel, completedChannel := runPruneEventTransformer(ch)
-		err = d.PruneOptions.Prune(infos, tempChannel)
+		err = d.PruneOptions.Prune(infos, tempChannel, prune.Options{
+			DryRun: d.DryRun,
+		})
 		// Close the tempChannel to signal to the event transformer that
 		// it should terminate.
 		close(tempChannel)

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -229,7 +229,6 @@ func TestPrune(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			po := NewPruneOptions(populateObjectIds(tc.currentInfos, t))
-			po.DryRun = true
 			// Set up the previously applied objects.
 			pastGroupingInfo := createGroupingInfo("past-group", tc.pastInfos...)
 			po.pastGroupingObjects = []*resource.Info{pastGroupingInfo}
@@ -247,7 +246,9 @@ func TestPrune(t *testing.T) {
 			po.mapper = testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme,
 				scheme.Scheme.PrioritizedVersionsAllGroups()...)
 			// Run the prune and validate.
-			err := po.Prune(currentInfos, eventChannel)
+			err := po.Prune(currentInfos, eventChannel, Options{
+				DryRun: true,
+			})
 			if !tc.isError {
 				if err != nil {
 					t.Fatalf("Unexpected error during Prune(): %#v", err)

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -39,6 +39,7 @@ type Options struct {
 	WaitForReconcile        bool
 	WaitForReconcileTimeout time.Duration
 	Prune                   bool
+	DryRun                  bool
 }
 
 // BuildTaskQueue takes a set of resources in the form of info objects

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -6,6 +6,7 @@ package task
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -15,6 +16,7 @@ import (
 type ApplyTask struct {
 	ApplyOptions applyOptions
 	Objects      []*resource.Info
+	DryRun       bool
 }
 
 // applyOptions defines the two key functions on the ApplyOptions
@@ -40,6 +42,7 @@ type applyOptions interface {
 // the desired state of a resource is changed.
 func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
+		a.setDryRunField()
 		a.ApplyOptions.SetObjects(a.Objects)
 		err := a.ApplyOptions.Run()
 		for _, info := range a.Objects {
@@ -52,6 +55,12 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			Err: err,
 		}
 	}()
+}
+
+func (a *ApplyTask) setDryRunField() {
+	if ao, ok := a.ApplyOptions.(*apply.ApplyOptions); ok {
+		ao.DryRun = a.DryRun
+	}
 }
 
 // ClearTimeout is not supported by the ApplyTask.

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -15,6 +15,7 @@ import (
 type PruneTask struct {
 	PruneOptions *prune.PruneOptions
 	Objects      []*resource.Info
+	DryRun       bool
 }
 
 // Start creates a new goroutine that will invoke
@@ -23,7 +24,10 @@ type PruneTask struct {
 // to signal to the taskrunner that the task has completed (or failed).
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		err := p.PruneOptions.Prune(p.Objects, taskContext.EventChannel())
+		err := p.PruneOptions.Prune(p.Objects, taskContext.EventChannel(),
+			prune.Options{
+				DryRun: p.DryRun,
+			})
 		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,
 		}


### PR DESCRIPTION
This change removes the `DryRun` and `NoPrune` fields on the Applier and the `DryRun` field on PruneOptions. Instead, these values are passed in as part of a parameter object (called options) in the call to `Applier.Run` or `PruneOptions.Prune`. I think this makes the code easier to understand and it means we can let the Applier depend on the a Prune interface instead of the actual implementation, which should make testing easier.

@seans3 @phanimarupaka 