### PR TITLE
Grouping object to inventory object cleanup

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -532,7 +532,7 @@ func TestReadAndPrepareObjects(t *testing.T) {
 					"expected first item to be grouping object, but it wasn't")
 			}
 
-			pastObjs, err := prune.RetrieveInventoryFromGroupingObj(
+			pastObjs, err := prune.RetrieveObjsFromInventory(
 				[]*resource.Info{inventoryObj})
 			if err != nil {
 				t.Error(err)

--- a/pkg/apply/prune/inventory_test.go
+++ b/pkg/apply/prune/inventory_test.go
@@ -309,7 +309,7 @@ func TestCreateInventoryObject(t *testing.T) {
 				t.Errorf("expected info and unstructured to have the same namespace, but they didn't")
 			}
 
-			inv, err := RetrieveInventoryFromGroupingObj(
+			inv, err := RetrieveObjsFromInventory(
 				[]*resource.Info{groupingObj})
 			if err != nil {
 				t.Error(err)
@@ -375,7 +375,7 @@ func TestFindInventoryObj(t *testing.T) {
 	}
 }
 
-func TestAddRetrieveInventoryToFromGroupingObject(t *testing.T) {
+func TestAddRetrieveObjsToFromInventory(t *testing.T) {
 	tests := []struct {
 		infos    []*resource.Info
 		expected []*object.ObjMetadata
@@ -539,7 +539,7 @@ func TestAddRetrieveInventoryToFromGroupingObject(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := AddInventoryToGroupingObj(test.infos)
+		err := addObjsToInventory(test.infos)
 		if test.isError && err == nil {
 			t.Errorf("Should have produced an error, but returned none.")
 		}
@@ -547,7 +547,7 @@ func TestAddRetrieveInventoryToFromGroupingObject(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Received error when expecting none (%s)\n", err)
 			}
-			retrieved, err := RetrieveInventoryFromGroupingObj(test.infos)
+			retrieved, err := RetrieveObjsFromInventory(test.infos)
 			if err != nil {
 				t.Fatalf("Error retrieving inventory: %s\n", err)
 			}
@@ -689,7 +689,7 @@ func TestClearInventoryObject(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Received unexpected error: %#v", err)
 				}
-				objMetadata, err := RetrieveInventoryFromGroupingObj(tc.infos)
+				objMetadata, err := RetrieveObjsFromInventory(tc.infos)
 				if err != nil {
 					t.Fatalf("Received unexpected error: %#v", err)
 				}

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -169,7 +169,7 @@ func infoToObjMetadata(info *resource.Info) (*object.ObjMetadata, error) {
 func unionPastObjs(infos []*resource.Info) ([]object.ObjMetadata, error) {
 	objSet := map[string]object.ObjMetadata{}
 	for _, info := range infos {
-		objs, err := RetrieveInventoryFromGroupingObj([]*resource.Info{info})
+		objs, err := RetrieveObjsFromInventory([]*resource.Info{info})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -114,7 +114,7 @@ func createGroupingInfo(name string, children ...*resource.Info) *resource.Info 
 	}
 	infos := []*resource.Info{groupingInfo}
 	infos = append(infos, children...)
-	_ = AddInventoryToGroupingObj(infos)
+	_ = addObjsToInventory(infos)
 	return groupingInfo
 }
 


### PR DESCRIPTION
* Renames `AddInventoryToGroupingObj()` to `addObjsToInventory()`
* Renames `RetrieveInventoryFromGroupingObj()` to `RetrieveObjsFromInventory()`
* Renames `buildInventoryMap()` to `buildObjMap()`
* Renames `grouping` comments to `inventory`
* Renames some `inventory` naming to `objs`