### PR TITLE
Handle CRDs and CRs in the same set of resources

### DIFF
--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -1,0 +1,91 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package info
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+// InfoHelper provides functions for interacting with Info objects.
+type InfoHelper interface {
+	// UpdateInfos sets the mapping and client for the provided Info
+	// objects. This must be called at a time when all needed resource
+	// types are available in the RESTMapper.
+	UpdateInfos(infos []*resource.Info) error
+
+	// ResetRESTMapper resets the state of the RESTMapper so any
+	// added resource types in the cluster will be picked up.
+	ResetRESTMapper() error
+}
+
+func NewInfoHelper(factory util.Factory, namespace string) *infoHelper {
+	return &infoHelper{
+		factory:          factory,
+		defaultNamespace: namespace,
+	}
+}
+
+type infoHelper struct {
+	factory          util.Factory
+	defaultNamespace string
+}
+
+func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {
+	mapper, err := ih.factory.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+	for _, info := range infos {
+		gvk := info.Object.GetObjectKind().GroupVersionKind()
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return err
+		}
+		info.Mapping = mapping
+
+		c, err := ih.getClient(gvk.GroupVersion())
+		if err != nil {
+			return err
+		}
+		info.Client = c
+	}
+	return nil
+}
+
+func (ih *infoHelper) ResetRESTMapper() error {
+	mapper, err := ih.factory.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+	fv := reflect.ValueOf(mapper).FieldByName("RESTMapper")
+	ddRESTMapper, ok := fv.Interface().(*restmapper.DeferredDiscoveryRESTMapper)
+	if !ok {
+		return fmt.Errorf("unexpected RESTMapper type")
+	}
+	ddRESTMapper.Reset()
+	return nil
+}
+
+func (ih *infoHelper) getClient(gv schema.GroupVersion) (*rest.RESTClient, error) {
+	cfg, err := ih.factory.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.ContentConfig = resource.UnstructuredPlusDefaultContentConfig()
+	cfg.GroupVersion = &gv
+	if len(gv.Group) == 0 {
+		cfg.APIPath = "/api"
+	} else {
+		cfg.APIPath = "/apis"
+	}
+
+	return rest.RESTClientFor(cfg)
+}

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
-type info struct {
+type resourceInfo struct {
 	group      string
 	apiVersion string
 	kind       string
@@ -26,10 +26,10 @@ type info struct {
 
 func TestApplyTask_FetchGeneration(t *testing.T) {
 	testCases := map[string]struct {
-		infos []info
+		infos []resourceInfo
 	}{
 		"single namespaced resource": {
-			infos: []info{
+			infos: []resourceInfo{
 				{
 					group:      "apps",
 					apiVersion: "apps/v1",
@@ -41,7 +41,7 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 			},
 		},
 		"multiple clusterscoped resources": {
-			infos: []info{
+			infos: []resourceInfo{
 				{
 					group:      "custom.io",
 					apiVersion: "custom.io/v1beta1",
@@ -89,6 +89,7 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 			applyTask := &ApplyTask{
 				ApplyOptions: applyOptions,
 				Objects:      infos,
+				InfoHelper:   &fakeInfoHelper{},
 			}
 
 			applyTask.Start(taskContext)
@@ -118,3 +119,13 @@ func (f *fakeApplyOptions) Run() error {
 }
 
 func (f *fakeApplyOptions) SetObjects([]*resource.Info) {}
+
+type fakeInfoHelper struct{}
+
+func (f *fakeInfoHelper) UpdateInfos(infos []*resource.Info) error {
+	return nil
+}
+
+func (f *fakeInfoHelper) ResetRESTMapper() error {
+	return nil
+}

--- a/pkg/kstatus/polling/engine/engine.go
+++ b/pkg/kstatus/polling/engine/engine.go
@@ -103,6 +103,11 @@ func (s *PollerEngine) validateIdentifiers(identifiers []object.ObjMetadata) err
 	for _, id := range identifiers {
 		mapping, err := s.Mapper.RESTMapping(id.GroupKind)
 		if err != nil {
+			// If we can't find a match, just keep going. This can happen
+			// if CRDs and CRs are applied at the same time.
+			if meta.IsNoMatchError(err) {
+				continue
+			}
 			return err
 		}
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && id.Namespace == "" {


### PR DESCRIPTION
POC on how we can be able to read manifests with the Builder, even when there are both CRDs and CRs among the set of resources. This uses the local setting on the Builder to get info objects that doesn't have a mapping or a client. We can then create the appropriate tasks for the queue and update the infos for CRs only when we have already applied the CRDs.

This still needs cleanup and tests before it is merged, but wanted to get feedback on whether this approach could work.

@seans3 @phanimarupaka @monopole 