### PR TITLE
Print more info on wait timeout

### DIFF
--- a/pkg/apply/taskrunner/collector.go
+++ b/pkg/apply/taskrunner/collector.go
@@ -61,7 +61,7 @@ func getGeneration(r *event.ResourceStatus) int64 {
 
 // conditionMet tests whether the provided Condition holds true for
 // all resources given by the list of Identifiers.
-func (a *resourceStatusCollector) conditionMet(rwd []resourceWaitData, c condition) bool {
+func (a *resourceStatusCollector) conditionMet(rwd []resourceWaitData, c Condition) bool {
 	switch c {
 	case AllCurrent:
 		return a.allMatchStatus(rwd, status.CurrentStatus)

--- a/pkg/apply/taskrunner/collector_test.go
+++ b/pkg/apply/taskrunner/collector_test.go
@@ -34,7 +34,7 @@ func TestCollector_ConditionMet(t *testing.T) {
 	testCases := map[string]struct {
 		collectorState map[object.ObjMetadata]resourceStatus
 		waitTaskData   []resourceWaitData
-		condition      condition
+		condition      Condition
 		expectedResult bool
 	}{
 		"single resource with current status": {

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -275,21 +275,30 @@ type TaskResult struct {
 	Err error
 }
 
-// timeoutError is a special error used by tasks when they have
+// TimeoutError is a special error used by tasks when they have
 // timed out.
-type timeoutError struct {
-	message string
+type TimeoutError struct {
+	// Identifiers contains the identifiers of all resources that the
+	// WaitTask was waiting for.
+	Identifiers []object.ObjMetadata
+
+	// Timeout is the amount of time it took before it timed out.
+	Timeout time.Duration
+
+	// Condition defines the criteria for which the task was waiting.
+	Condition Condition
 }
 
-func (te timeoutError) Error() string {
-	return te.message
+func (te TimeoutError) Error() string {
+	return fmt.Sprintf("timeout after %.0f seconds waiting for %d resources to reach condition %s",
+		te.Timeout.Seconds(), len(te.Identifiers), te.Condition)
 }
 
 // IsTimeoutError checks whether a given error is
-// a timeoutError.
-func IsTimeoutError(err error) bool {
-	if _, ok := err.(timeoutError); ok {
-		return true
+// a TimeoutError.
+func IsTimeoutError(err error) (TimeoutError, bool) {
+	if e, ok := err.(TimeoutError); ok {
+		return e, true
 	}
-	return false
+	return TimeoutError{}, false
 }

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -25,7 +25,7 @@ func TestWaitTask_TimeoutTriggered(t *testing.T) {
 
 	select {
 	case res := <-taskContext.TaskChannel():
-		if res.Err == nil || !IsTimeoutError(res.Err) {
+		if _, ok := IsTimeoutError(res.Err); !ok {
 			t.Errorf("expected timeout error, but got %v", res.Err)
 		}
 		return

--- a/pkg/print/table/base.go
+++ b/pkg/print/table/base.go
@@ -60,10 +60,6 @@ func (t *BaseTablePrinter) PrintTable(rs ResourceStates,
 		t.eraseCurrentLine()
 	}
 
-	if rs.Error() != nil {
-		return t.printError(rs.Error())
-	}
-
 	linePrintCount := 0
 	for i, column := range t.Columns {
 		format := fmt.Sprintf("%%-%ds", column.Width())
@@ -93,6 +89,12 @@ func (t *BaseTablePrinter) PrintTable(rs ResourceStates,
 		}
 
 		linePrintCount += t.printSubTable(resource.SubResources(), "")
+	}
+
+	// If we have encountered an error, print that below the table.
+	if rs.Error() != nil {
+		lineCount := t.printError(rs.Error())
+		linePrintCount += lineCount
 	}
 
 	return linePrintCount
@@ -141,9 +143,12 @@ func (t *BaseTablePrinter) printSubTable(resources []Resource,
 	return linePrintCount
 }
 
+//TODO: This should be able to return the correct number of printed lines,
+// even if the error message has line breaks or is so long that it needs to
+// be wrapped over multiple lines.
 func (t *BaseTablePrinter) printError(err error) int {
-	t.printOrDie("Fatal error: %v\n", err)
-	return 1 // This is the number of lines printed.
+	t.printOrDie("\nFatal error: %v\n", err)
+	return 2 // This is the number of lines printed.
 }
 
 func (t *BaseTablePrinter) printOrDie(format string, a ...interface{}) {


### PR DESCRIPTION
This updates the error message printed after a wait timeout to include a list of the resources that failed to reach the desired status. This only covers the output for the table printer, I will do a separate PR to make sure the events printer also includes this information in the error message.

Ref: https://github.com/GoogleContainerTools/kpt/issues/582

@seans3 @phanimarupaka @monopole 