### PR TITLE
Fix issue where dry-run ends up making changes

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -57,6 +57,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(infos []*resource.Info,
 		tasks = append(tasks, &task.ApplyTask{
 			Objects:      append(crdSplitRes.before, crdSplitRes.crds...),
 			ApplyOptions: t.ApplyOptions,
+			DryRun:       o.DryRun,
 		},
 			taskrunner.NewWaitTask(
 				object.InfosToObjMetas(crdSplitRes.crds),
@@ -70,6 +71,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(infos []*resource.Info,
 		&task.ApplyTask{
 			Objects:      remainingInfos,
 			ApplyOptions: t.ApplyOptions,
+			DryRun:       o.DryRun,
 		},
 		&task.SendEventTask{
 			Event: event.Event{
@@ -104,6 +106,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(infos []*resource.Info,
 				Objects:           infos,
 				PruneOptions:      t.PruneOptions,
 				PropagationPolicy: o.PrunePropagationPolicy,
+				DryRun:            o.DryRun,
 			},
 			&task.SendEventTask{
 				Event: event.Event{


### PR DESCRIPTION
This is a serious bug where the `dry-run` flag doesn't have the desired effect because it is not wired all the way through. This was introduced in #148 

@seans3 