### PR TITLE
Adds klog to kapply; initial log statements in prune

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/logs"
 	"sigs.k8s.io/cli-utils/cmd/apply"
 	"sigs.k8s.io/cli-utils/cmd/destroy"
 	"sigs.k8s.io/cli-utils/cmd/diff"
@@ -60,6 +61,9 @@ func main() {
 	updateHelp(names, statusCmd)
 
 	cmd.AddCommand(initCmd, applyCmd, diffCmd, destroyCmd, previewCmd, statusCmd)
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
 
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/cli-runtime v0.17.2
 	k8s.io/client-go v0.17.2
+	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
 	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/controller-runtime v0.4.0


### PR DESCRIPTION
* Adds `klog` logging package to `kapply`, along with flags.
* Adds initial debug log statements to the `prune` operation.
* Manually verified.

Sample Output:
```
$ kapply -v=4 apply ~/testdata/testdata-1
configmap/inventory-1e5824fb created
namespace/test-namespace unchanged
pod/pod-a unchanged
pod/pod-b unchanged
pod/pod-c unchanged
5 resource(s) applied. 1 created, 4 unchanged, 0 configured
I0505 14:21:31.805942   27150 prune.go:134] prune inventory object fetch: test-namespace/cli-utils.sigs.k8s.io/inventory-id=eecafa8e-2b2f-4fcf-9a4b-f91b14e216ae
I0505 14:21:31.872561   27150 prune.go:151] prune 2 inventory objects found
I0505 14:21:31.872635   27150 prune.go:223] prune 5 currently applied objects
I0505 14:21:31.872659   27150 prune.go:224] prune 4 previously applied objects
pod/pod-d pruned
configmap/inventory-aa61e798 pruned
2 resource(s) pruned, 0 skipped
```