### PR TITLE
Propagate kubeconfig flags to subcommands

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,7 @@ var cmd = &cobra.Command{
 
 func main() {
 	// configure kubectl dependencies and flags
-	flags := cmd.Flags()
+	flags := cmd.PersistentFlags()
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := util.NewMatchVersionFlags(kubeConfigFlags)


### PR DESCRIPTION
`kapply --help` -> shows kubeconfig flags
`kapply apply --help` -> does not show kubeconfig flags

* Propagates kubeconfig flags to subcommands; fixes the above problem.