### PR TITLE
Cleanup grouping nomenclature as inventory

### DIFF
--- a/cmd/initcmd/cmdinit.go
+++ b/cmd/initcmd/cmdinit.go
@@ -12,13 +12,13 @@ import (
 )
 
 // NewCmdInit creates the `init` command, which generates the
-// grouping object template ConfigMap for a package.
+// inventory object template ConfigMap for a package.
 func NewCmdInit(ioStreams genericclioptions.IOStreams) *cobra.Command {
 	io := config.NewInitOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "init DIRECTORY",
 		DisableFlagsInUseLine: true,
-		Short:                 i18n.T("Create a prune manifest ConfigMap as a grouping object"),
+		Short:                 i18n.T("Create a prune manifest ConfigMap as a inventory object"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(io.Complete(args))
 			cmdutil.CheckErr(io.Run())

--- a/cmd/status/util.go
+++ b/cmd/status/util.go
@@ -51,9 +51,9 @@ func (f *CaptureIdentifiersFilter) Filter(slice []*yaml.RNode) ([]*yaml.RNode,
 			namespace = id.Namespace
 		}
 		// We only want to add yaml that actually represents Kubernetes resources.
-		// We also need to filter out grouping object templates, since there will
+		// We also need to filter out inventory object templates, since there will
 		// never be an actual resource with that name and namespace.
-		if isValidKubernetesResource(id) && !isGroupingObject(objectMeta.Labels) {
+		if isValidKubernetesResource(id) && !isInventoryObject(objectMeta.Labels) {
 			f.Identifiers = append(f.Identifiers, object.ObjMetadata{
 				Name:      id.Name,
 				Namespace: namespace,
@@ -73,9 +73,9 @@ func isValidKubernetesResource(id yaml.ResourceIdentifier) bool {
 	return id.GetKind() != "" && id.GetAPIVersion() != "" && id.GetName() != ""
 }
 
-// isGroupingObject checks if the provided map of labels contain the
+// isInventoryObject checks if the provided map of labels contain the
 // inventory object label key.
-func isGroupingObject(labels map[string]string) bool {
+func isInventoryObject(labels map[string]string) bool {
 	for key := range labels {
 		if key == common.InventoryLabel {
 			return true

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -85,7 +85,7 @@ func (d *Destroyer) Run() <-chan event.Event {
 			}
 			return
 		}
-		// Clear the data/inventory section of the grouping object configmap,
+		// Clear the data/inventory section of the inventory object configmap,
 		// so the prune will calculate the prune set as all the objects,
 		// deleting everything. We can ignore the error, since the Prune
 		// will catch the same problems.

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -31,7 +31,7 @@ const fieldSeparator = "_"
 
 // ObjMetadata organizes and stores the indentifying information
 // for an object. This struct (as a string) is stored in a
-// grouping object to keep track of sets of applied objects.
+// inventory object to keep track of sets of applied objects.
 type ObjMetadata struct {
 	Namespace string
 	Name      string


### PR DESCRIPTION
* Final `grouping` to `inventory` cleanup (I hope).
* Changes some comments from `grouping object` to `inventory object`.
* Changes function `isGroupingObject` to `isInventoryObject`