### PR TITLE
Move CachingRESTClientGetter into its own package

### DIFF
--- a/pkg/util/factory/clientgetter.go
+++ b/pkg/util/factory/clientgetter.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package factory
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// CachingRESTClientGetter caches the RESTMapper so every call to
+// ToRESTMapper will get a reference to the same mapper.
+type CachingRESTClientGetter struct {
+	once     sync.Once
+	Delegate genericclioptions.RESTClientGetter
+
+	mapper meta.RESTMapper
+}
+
+func (c *CachingRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return c.Delegate.ToRESTConfig()
+}
+
+func (c *CachingRESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return c.Delegate.ToDiscoveryClient()
+}
+
+func (c *CachingRESTClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	var err error
+	c.once.Do(func() {
+		c.mapper, err = c.Delegate.ToRESTMapper()
+	})
+	return c.mapper, err
+}
+
+func (c *CachingRESTClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return c.Delegate.ToRawKubeConfigLoader()
+}


### PR DESCRIPTION
We need to use this to set up the Factory in kpt as well, so we need this in a separate package.

@seans3 