### PR TITLE
Reduce the number of flags for apply and improve the naming

### DIFF
--- a/examples/alphaTestExamples/MultipleServices.md
+++ b/examples/alphaTestExamples/MultipleServices.md
@@ -71,7 +71,7 @@ kind create cluster
 Let's apply the mysql service
 <!-- @RunMysql @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE/mysql --wait-for-reconcile --wait-timeout=120s > $OUTPUT/status;
+kapply apply $BASE/mysql --reconcile-timeout=120s > $OUTPUT/status;
 
 expectedOutputLine "deployment.apps/mysql is Current: Deployment is available. Replicas: 1"
 
@@ -93,7 +93,7 @@ expectedOutputLine "0"
 And the apply the wordpress service
 <!-- @RunWordpress @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE/wordpress --wait-for-reconcile --wait-timeout=120s > $OUTPUT/status;
+kapply apply $BASE/wordpress --reconcile-timeout=120s > $OUTPUT/status;
 
 expectedOutputLine "configmap/inventory-2fbd5b91 is Current: Resource is always ready"
 

--- a/examples/alphaTestExamples/crds.md
+++ b/examples/alphaTestExamples/crds.md
@@ -122,7 +122,7 @@ expectedOutputLine "inventory-template.yaml"
 Use the `kapply` binary in `MYGOBIN` to apply both the CRD and the CR.
 <!-- @runApply @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE --wait-for-reconcile > $OUTPUT/status
+kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
 
 expectedOutputLine "customresourcedefinition.apiextensions.k8s.io/foos.custom.io is Current: Resource is current"
 

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -172,7 +172,7 @@ expectedOutputLine "No resources found in hellospace namespace."
 Use the `kapply` binary in `MYGOBIN` to apply a deployment and verify it is successful.
 <!-- @runHelloApp @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE --wait-for-reconcile > $OUTPUT/status
+kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
 
 expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
 
@@ -204,7 +204,7 @@ EOF
 
 rm $BASE/configMap.yaml
 
-kapply apply $BASE --wait-for-reconcile > $OUTPUT/status;
+kapply apply $BASE --reconcile-timeout=120s > $OUTPUT/status;
 
 expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
 

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -96,7 +97,7 @@ func TestApplier(t *testing.T) {
 		namespace          string
 		resources          []resourceInfo
 		handlers           []handler
-		status             bool
+		reconcileTimeout   time.Duration
 		prune              bool
 		statusEvents       []pollevent.Event
 		expectedEventTypes []expectedEvent
@@ -115,8 +116,8 @@ func TestApplier(t *testing.T) {
 					namespace:    "apply-test",
 				},
 			},
-			status: false,
-			prune:  false,
+			reconcileTimeout: time.Duration(0),
+			prune:            false,
 			expectedEventTypes: []expectedEvent{
 				{
 					eventType: event.InitType,
@@ -149,7 +150,7 @@ func TestApplier(t *testing.T) {
 					namespace:    "apply-test",
 				},
 			},
-			status: true,
+			reconcileTimeout: time.Minute,
 			statusEvents: []pollevent.Event{
 				{
 					EventType: pollevent.ResourceUpdateEvent,
@@ -258,7 +259,7 @@ func TestApplier(t *testing.T) {
 
 			ctx := context.Background()
 			eventChannel := applier.Run(ctx, Options{
-				WaitForReconcile: tc.status,
+				ReconcileTimeout: tc.reconcileTimeout,
 				EmitStatusEvents: true,
 				NoPrune:          !tc.prune,
 			})

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -39,13 +39,11 @@ type TaskQueueSolver struct {
 }
 
 type Options struct {
-	WaitForReconcile        bool
-	WaitForReconcileTimeout time.Duration
-	Prune                   bool
-	DryRun                  bool
-	PrunePropagationPolicy  metav1.DeletionPropagation
-	WaitForPrune            bool
-	WaitForPruneTimeout     time.Duration
+	ReconcileTimeout       time.Duration
+	Prune                  bool
+	DryRun                 bool
+	PrunePropagationPolicy metav1.DeletionPropagation
+	PruneTimeout           time.Duration
 }
 
 type resourceObjects interface {
@@ -95,12 +93,12 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 		},
 	)
 
-	if o.WaitForReconcile {
+	if o.ReconcileTimeout != time.Duration(0) {
 		tasks = append(tasks,
 			taskrunner.NewWaitTask(
 				ro.IdsForApply(),
 				taskrunner.AllCurrent,
-				o.WaitForReconcileTimeout),
+				o.ReconcileTimeout),
 			&task.SendEventTask{
 				Event: event.Event{
 					Type: event.StatusType,
@@ -130,12 +128,12 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			},
 		)
 
-		if o.WaitForPrune {
+		if o.PruneTimeout != time.Duration(0) {
 			tasks = append(tasks,
 				taskrunner.NewWaitTask(
 					ro.IdsForPrune(),
 					taskrunner.AllNotFound,
-					o.WaitForPruneTimeout),
+					o.PruneTimeout),
 				&task.SendEventTask{
 					Event: event.Event{
 						Type: event.StatusType,

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -61,7 +61,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 				customInfo,
 			},
 			options: Options{
-				WaitForReconcile: true,
+				ReconcileTimeout: time.Minute,
 			},
 			expectedTasks: []taskrunner.Task{
 				&task.ApplyTask{
@@ -86,7 +86,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 				customInfo,
 			},
 			options: Options{
-				WaitForReconcile: true,
+				ReconcileTimeout: time.Minute,
 				Prune:            true,
 			},
 			expectedTasks: []taskrunner.Task{
@@ -114,7 +114,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 				depInfo,
 			},
 			options: Options{
-				WaitForReconcile: true,
+				ReconcileTimeout: time.Minute,
 			},
 			expectedTasks: []taskrunner.Task{
 				&task.ApplyTask{


### PR DESCRIPTION
This makes the following changes to the flags for apply:

- Instead of `wait-for-reconcile` and `wait-timeout`, we only have `reconcile-timeout`
- Instead of `wait-for-prune` and `prune-timeout`, we only have `prune-timeout`
- Instead of `wait-polling-period` we have `status-polling-period`

@seans3 @phanimarupaka 