### PR TITLE
Handle dryrun when applying CRDs

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -67,12 +67,14 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			ApplyOptions: t.ApplyOptions,
 			DryRun:       o.DryRun,
 			InfoHelper:   t.InfoHelper,
-		},
-			taskrunner.NewWaitTask(
+		})
+		if !o.DryRun {
+			tasks = append(tasks, taskrunner.NewWaitTask(
 				object.InfosToObjMetas(crdSplitRes.crds),
 				taskrunner.AllCurrent,
 				1*time.Minute),
-		)
+			)
+		}
 		remainingInfos = crdSplitRes.after
 	}
 
@@ -93,7 +95,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 		},
 	)
 
-	if o.ReconcileTimeout != time.Duration(0) {
+	if !o.DryRun && o.ReconcileTimeout != time.Duration(0) {
 		tasks = append(tasks,
 			taskrunner.NewWaitTask(
 				ro.IdsForApply(),
@@ -128,7 +130,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			},
 		)
 
-		if o.PruneTimeout != time.Duration(0) {
+		if !o.DryRun && o.PruneTimeout != time.Duration(0) {
 			tasks = append(tasks,
 				taskrunner.NewWaitTask(
 					ro.IdsForPrune(),

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -108,6 +108,28 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 				&task.SendEventTask{},
 			},
 		},
+		"multiple resources with wait, prune and dryrun": {
+			infos: []*resource.Info{
+				depInfo,
+				customInfo,
+			},
+			options: Options{
+				ReconcileTimeout: time.Minute,
+				Prune:            true,
+				DryRun:           true,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+						customInfo,
+					},
+				},
+				&task.SendEventTask{},
+				&task.PruneTask{},
+				&task.SendEventTask{},
+			},
+		},
 		"multiple resources including CRD": {
 			infos: []*resource.Info{
 				crdInfo,
@@ -139,6 +161,29 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 						object.InfoToObjMeta(depInfo),
 					},
 					taskrunner.AllCurrent, 1*time.Second),
+				&task.SendEventTask{},
+			},
+		},
+		"no wait with CRDs if it is a dryrun": {
+			infos: []*resource.Info{
+				crdInfo,
+				depInfo,
+			},
+			options: Options{
+				ReconcileTimeout: time.Minute,
+				DryRun:           true,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						crdInfo,
+					},
+				},
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+					},
+				},
 				&task.SendEventTask{},
 			},
 		},


### PR DESCRIPTION
This fixes an issue in the solver where it is possible that WaitTasks are created, even with `DryRun = true`. This causes kpt preview to wait forever. 
This just prevents the command from waiting forever. Running preview on a set of resources that includes both a CRD and a CR will still not work.