### PR TITLE
Move the printer adapter into the ApplyTask

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -413,12 +413,6 @@ func (a *Applier) Run(ctx context.Context, options Options) <-chan event.Event {
 
 	go func() {
 		defer close(eventChannel)
-		adapter := &KubectlPrinterAdapter{
-			ch: eventChannel,
-		}
-		// The adapter is used to intercept what is meant to be printing
-		// in the ApplyOptions, and instead turn those into events.
-		a.ApplyOptions.ToPrinter = adapter.toPrinterFunc()
 
 		// This provides us with a slice of all the objects that will be
 		// applied to the cluster. This takes care of ordering resources

--- a/pkg/apply/task/printer_adapter.go
+++ b/pkg/apply/task/printer_adapter.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package task
 
 import (
 	"fmt"

--- a/pkg/apply/task/printer_adapter_test.go
+++ b/pkg/apply/task/printer_adapter_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package task
 
 import (
 	"bytes"


### PR DESCRIPTION
Small cleanup. The adapter is only used for the Apply operations, we so we can do this in the ApplyTask.

@seans3 