### PR TITLE
Support preview when resource set contains both CRD and CR

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -413,12 +413,6 @@ func (a *Applier) Run(ctx context.Context, options Options) <-chan event.Event {
 
 	go func() {
 		defer close(eventChannel)
-		adapter := &KubectlPrinterAdapter{
-			ch: eventChannel,
-		}
-		// The adapter is used to intercept what is meant to be printing
-		// in the ApplyOptions, and instead turn those into events.
-		a.ApplyOptions.ToPrinter = adapter.toPrinterFunc()
 
 		// This provides us with a slice of all the objects that will be
 		// applied to the cluster. This takes care of ordering resources

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -992,3 +992,7 @@ func (f *fakeInfoHelper) getClient(gv schema.GroupVersion) (resource.RESTClient,
 func (f *fakeInfoHelper) ResetRESTMapper() error {
 	return nil
 }
+
+func (f *fakeInfoHelper) ToRESTMapper() (meta.RESTMapper, error) {
+	return f.factory.ToRESTMapper()
+}

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
@@ -24,6 +25,9 @@ type InfoHelper interface {
 	// ResetRESTMapper resets the state of the RESTMapper so any
 	// added resource types in the cluster will be picked up.
 	ResetRESTMapper() error
+
+	// ToRESTMapper returns a RESTMapper
+	ToRESTMapper() (meta.RESTMapper, error)
 }
 
 func NewInfoHelper(factory util.Factory, namespace string) *infoHelper {
@@ -58,6 +62,10 @@ func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {
 		info.Client = c
 	}
 	return nil
+}
+
+func (ih *infoHelper) ToRESTMapper() (meta.RESTMapper, error) {
+	return ih.factory.ToRESTMapper()
 }
 
 func (ih *infoHelper) ResetRESTMapper() error {

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -64,6 +64,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 	if hasCRDs {
 		tasks = append(tasks, &task.ApplyTask{
 			Objects:      append(crdSplitRes.before, crdSplitRes.crds...),
+			CRDs:         crdSplitRes.crds,
 			ApplyOptions: t.ApplyOptions,
 			DryRun:       o.DryRun,
 			InfoHelper:   t.InfoHelper,
@@ -81,6 +82,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 	tasks = append(tasks,
 		&task.ApplyTask{
 			Objects:      remainingInfos,
+			CRDs:         crdSplitRes.crds,
 			ApplyOptions: t.ApplyOptions,
 			DryRun:       o.DryRun,
 			InfoHelper:   t.InfoHelper,

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -5,8 +5,10 @@ package task
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/util/slice"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
@@ -19,6 +21,7 @@ type ApplyTask struct {
 	ApplyOptions applyOptions
 	InfoHelper   info.InfoHelper
 	Objects      []*resource.Info
+	CRDs         []*resource.Info
 	DryRun       bool
 }
 
@@ -47,14 +50,55 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		// Update the dry-run field on the Applier.
 		a.setApplyOptionsFields(taskContext.EventChannel())
+
+		objects := a.Objects
+
+		// If this is a dry run, we need to handle situations where
+		// we have a CRD and a CR in the same resource set, but the CRD
+		// will not actually have been applied when we reach the CR.
+		if a.DryRun {
+			// Find all resources in the set that doesn't exist in the
+			// RESTMapper, but where we do have the CRD for the type in
+			// the resource set.
+			objs, objsWithCRD, err := a.filterCRsWithCRDInSet(objects)
+			if err != nil {
+				a.sendTaskResult(taskContext, err)
+				return
+			}
+
+			// Just send the apply event here. We know it must be a
+			// Created event since the type didn't already exist in the
+			// cluster.
+			for _, obj := range objsWithCRD {
+				taskContext.EventChannel() <- event.Event{
+					Type: event.ApplyType,
+					ApplyEvent: event.ApplyEvent{
+						Type:      event.ApplyEventResourceUpdate,
+						Operation: event.Created,
+						Object:    obj.Object,
+					},
+				}
+			}
+			// Update the resource set to no longer include the CRs.
+			objects = objs
+		}
+
+		// ApplyOptions doesn't allow an empty set of resources, so check
+		// for that here. It could happen if this is dry-run and we removed
+		// all resources in the previous step.
+		if len(objects) == 0 {
+			a.sendTaskResult(taskContext, nil)
+			return
+		}
+
 		// Set the client and mapping fields on the provided
 		// infos so they can be applied to the cluster.
-		err := a.InfoHelper.UpdateInfos(a.Objects)
+		err := a.InfoHelper.UpdateInfos(objects)
 		if err != nil {
 			a.sendTaskResult(taskContext, err)
 			return
 		}
-		a.ApplyOptions.SetObjects(a.Objects)
+		a.ApplyOptions.SetObjects(objects)
 		err = a.ApplyOptions.Run()
 		if err != nil {
 			a.sendTaskResult(taskContext, err)
@@ -62,7 +106,8 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 		}
 		// Fetch the Generation from all Infos after they have been
 		// applied.
-		for _, obj := range a.Objects {
+		//TODO: This isn't really needed if we are doing dry-run.
+		for _, obj := range objects {
 			id := object.InfoToObjMeta(obj)
 			acc, _ := meta.Accessor(obj.Object)
 			gen := acc.GetGeneration()
@@ -92,6 +137,94 @@ func (a *ApplyTask) setApplyOptionsFields(eventChannel chan event.Event) {
 		// The adapter is used to intercept what is meant to be printing
 		// in the ApplyOptions, and instead turn those into events.
 		ao.ToPrinter = adapter.toPrinterFunc()
+	}
+}
+
+// filterCRsWithCRDInSet loops through all the resources and filters out the
+// resources that doesn't exist in the RESTMapper, but where we do have a CRD
+// in the resource set that defines the needed type. It returns two slices,
+// the seconds contains the resources that meets the above criteria while the
+// first slice contains the remaining resources.
+func (a *ApplyTask) filterCRsWithCRDInSet(objects []*resource.Info) ([]*resource.Info, []*resource.Info, error) {
+	var objs []*resource.Info
+	var objsWithCRD []*resource.Info
+
+	mapper, err := a.InfoHelper.ToRESTMapper()
+	if err != nil {
+		return objs, objsWithCRD, err
+	}
+
+	crdsInfo := buildCRDsInfo(a.CRDs)
+	for _, obj := range objects {
+		gvk := obj.Object.GetObjectKind().GroupVersionKind()
+
+		// First check if we find the type in the RESTMapper.
+		//TODO: Maybe we do care if there is a new version of the CRD?
+		_, err := mapper.RESTMapping(gvk.GroupKind())
+		if err != nil && !meta.IsNoMatchError(err) {
+			return objs, objsWithCRD, err
+		}
+
+		// If we can't find the type in the RESTMapper, but we do have the
+		// CRD in the set of resources, filter out the object.
+		if meta.IsNoMatchError(err) && crdsInfo.includesCRDForCR(obj) {
+			objsWithCRD = append(objsWithCRD, obj)
+			continue
+		}
+
+		// If the resource is in the RESTMapper, or it is not there but we
+		// also don't have the CRD, just keep the resource.
+		objs = append(objs, obj)
+	}
+	return objs, objsWithCRD, nil
+}
+
+type crdsInfo struct {
+	crds []crdInfo
+}
+
+// includesCRDForCR checks if we have information about a CRD that defines
+// the types needed for the provided CR.
+func (c *crdsInfo) includesCRDForCR(cr *resource.Info) bool {
+	gvk := cr.Object.GetObjectKind().GroupVersionKind()
+	for _, crd := range c.crds {
+		if gvk.Group == crd.group &&
+			gvk.Kind == crd.kind &&
+			slice.ContainsString(crd.versions, gvk.Version, nil) {
+			return true
+		}
+	}
+	return false
+}
+
+type crdInfo struct {
+	group    string
+	kind     string
+	versions []string
+}
+
+func buildCRDsInfo(crds []*resource.Info) *crdsInfo {
+	var crdsInf []crdInfo
+	for _, crd := range crds {
+		u := crd.Object.(*unstructured.Unstructured)
+		group, _, _ := unstructured.NestedString(u.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(u.Object, "spec", "names", "kind")
+
+		var versions []string
+		crdVersions, _, _ := unstructured.NestedSlice(u.Object, "spec", "versions")
+		for _, ver := range crdVersions {
+			verObj := ver.(map[string]interface{})
+			version, _, _ := unstructured.NestedString(verObj, "name")
+			versions = append(versions, version)
+		}
+		crdsInf = append(crdsInf, crdInfo{
+			kind:     kind,
+			group:    group,
+			versions: versions,
+		})
+	}
+	return &crdsInfo{
+		crds: crdsInf,
 	}
 }
 

--- a/pkg/apply/task/printer_adapter.go
+++ b/pkg/apply/task/printer_adapter.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package task
 
 import (
 	"fmt"

--- a/pkg/apply/task/printer_adapter_test.go
+++ b/pkg/apply/task/printer_adapter_test.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package apply
+package task
 
 import (
 	"bytes"

--- a/pkg/kstatus/polling/clusterreader/caching_reader_test.go
+++ b/pkg/kstatus/polling/clusterreader/caching_reader_test.go
@@ -17,8 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/kstatus/polling/engine/engine_test.go
+++ b/pkg/kstatus/polling/engine/engine_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	fakemapper "sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -104,7 +105,7 @@ func TestStatusPollerRunner(t *testing.T) {
 
 			identifiers := tc.identifiers
 
-			fakeMapper := testutil.NewFakeRESTMapper(
+			fakeMapper := fakemapper.NewFakeRESTMapper(
 				appsv1.SchemeGroupVersion.WithKind("Deployment"),
 				v1.SchemeGroupVersion.WithKind("Service"),
 			)
@@ -196,7 +197,7 @@ func TestNewStatusPollerRunnerIdentifierValidation(t *testing.T) {
 	}
 
 	engine := PollerEngine{
-		Mapper: testutil.NewFakeRESTMapper(
+		Mapper: fakemapper.NewFakeRESTMapper(
 			appsv1.SchemeGroupVersion.WithKind("Deployment"),
 		),
 	}

--- a/pkg/kstatus/polling/statusreaders/common_test.go
+++ b/pkg/kstatus/polling/statusreaders/common_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	fakemapper "sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
 var (
@@ -72,7 +73,7 @@ func TestLookupResource(t *testing.T) {
 			fakeReader := &fakeClusterReader{
 				getErr: tc.readerErr,
 			}
-			fakeMapper := testutil.NewFakeRESTMapper(deploymentGVK)
+			fakeMapper := fakemapper.NewFakeRESTMapper(deploymentGVK)
 
 			statusReader := &baseStatusReader{
 				reader: fakeReader,
@@ -197,7 +198,7 @@ spec:
 				},
 				listErr: tc.listErr,
 			}
-			fakeMapper := testutil.NewFakeRESTMapper(rsGVK)
+			fakeMapper := fakemapper.NewFakeRESTMapper(rsGVK)
 			fakeStatusReader := &fakeStatusReader{}
 
 			object := testutil.YamlToUnstructured(t, tc.manifest)

--- a/pkg/kstatus/polling/statusreaders/generic_test.go
+++ b/pkg/kstatus/polling/statusreaders/generic_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	fakemapper "sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
 var (
@@ -59,7 +60,7 @@ func TestGenericStatusReader(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			fakeReader := testutil.NewNoopClusterReader()
-			fakeMapper := testutil.NewFakeRESTMapper()
+			fakeMapper := fakemapper.NewFakeRESTMapper()
 			resourceStatusReader := &genericStatusReader{
 				reader: fakeReader,
 				mapper: fakeMapper,

--- a/pkg/kstatus/polling/statusreaders/pod_controller_test.go
+++ b/pkg/kstatus/polling/statusreaders/pod_controller_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	fakemapper "sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
 func TestPodControllerStatusReader(t *testing.T) {
@@ -78,7 +79,7 @@ func TestPodControllerStatusReader(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			fakeReader := testutil.NewNoopClusterReader()
-			fakeMapper := testutil.NewFakeRESTMapper()
+			fakeMapper := fakemapper.NewFakeRESTMapper()
 			podControllerStatusReader := &podControllerStatusReader{
 				reader: fakeReader,
 				mapper: fakeMapper,

--- a/pkg/kstatus/polling/testutil/testing.go
+++ b/pkg/kstatus/polling/testutil/testing.go
@@ -8,10 +8,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -23,18 +21,6 @@ func YamlToUnstructured(t *testing.T, yml string) *unstructured.Unstructured {
 		return nil
 	}
 	return &unstructured.Unstructured{Object: m}
-}
-
-func NewFakeRESTMapper(gvks ...schema.GroupVersionKind) meta.RESTMapper {
-	var groupVersions []schema.GroupVersion
-	for _, gvk := range gvks {
-		groupVersions = append(groupVersions, gvk.GroupVersion())
-	}
-	mapper := meta.NewDefaultRESTMapper(groupVersions)
-	for _, gvk := range gvks {
-		mapper.Add(gvk, meta.RESTScopeNamespace)
-	}
-	return mapper
 }
 
 func NewNoopClusterReader() *NoopClusterReader {

--- a/pkg/testutil/restmapper.go
+++ b/pkg/testutil/restmapper.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func NewFakeRESTMapper(gvks ...schema.GroupVersionKind) meta.RESTMapper {
+	var groupVersions []schema.GroupVersion
+	for _, gvk := range gvks {
+		groupVersions = append(groupVersions, gvk.GroupVersion())
+	}
+	mapper := meta.NewDefaultRESTMapper(groupVersions)
+	for _, gvk := range gvks {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+	return mapper
+}


### PR DESCRIPTION
This PR updates the way we handle dry-run in the `ApplyTask`, so we can handle situations where a CRD and a CR is in the same resource set. 

There are some things I don't like in this PR, but I would like to address it in follow-up PRs as it requires larger changes.
- The `InfoHelper` doesn't really seem like the right place to get the `RESTMapper`. I want to rewrite the `InfoHelper` to separate the responsibility of updating Infos from what is needed to work with the `RESTMapper`.
- Tracking any CRDs and namespaces in the resource set is probably useful in multiple places, so we might want to do this somewhere else than in the `ApplyTask`.