### PR TITLE
Separate reading manifests into Info objects from the apply logic

### DIFF
--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -1,0 +1,116 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/apply/solver"
+)
+
+// ManifestReader defines the interface for reading a set
+// of manifests into info objects.
+type ManifestReader interface {
+	Read() ([]*resource.Info, error)
+}
+
+// ReaderOptions defines the shared inputs for the different
+// implementations of the ManifestReader interface.
+type ReaderOptions struct {
+	Factory          util.Factory
+	Validate         bool
+	Namespace        string
+	EnforceNamespace bool
+}
+
+// setNamespaces verifies that every namespaced resource has the namespace
+// set, and if one does not, it will set the namespace to the provided
+// defaultNamespace.
+// This implementation will check each resource (that doesn't already have
+// the namespace set) on whether it is namespace or cluster scoped. It does
+// this by first checking the RESTMapper, and it there is not match there,
+// it will look for CRDs in the provided Infos.
+func setNamespaces(factory util.Factory, infos []*resource.Info,
+	defaultNamespace string, enforceNamespace bool) error {
+	mapper, err := factory.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	var crdInfos []*resource.Info
+
+	// find any crds in the set of resources.
+	for _, inf := range infos {
+		if solver.IsCRD(inf) {
+			crdInfos = append(crdInfos, inf)
+		}
+	}
+
+	for _, inf := range infos {
+		accessor, _ := meta.Accessor(inf.Object)
+		// if the resource already has the namespace set, we don't
+		// need to do anything
+		if ns := accessor.GetNamespace(); ns != "" {
+			if enforceNamespace && ns != defaultNamespace {
+				return fmt.Errorf("the namespace from the provided object %q "+
+					"does not match the namespace %q. You must pass '--namespace=%s' to perform this operation",
+					ns, defaultNamespace, ns)
+			}
+			continue
+		}
+
+		gk := inf.Object.GetObjectKind().GroupVersionKind().GroupKind()
+		mapping, err := mapper.RESTMapping(gk)
+
+		if err != nil && !meta.IsNoMatchError(err) {
+			return err
+		}
+
+		if err == nil {
+			// If we find a mapping for the resource type in the RESTMapper,
+			// we just use it.
+			if mapping.Scope == meta.RESTScopeNamespace {
+				// This means the resource does not have the namespace set,
+				// but it is a namespaced resource. So we set the namespace
+				// to the provided default value.
+				inf.Namespace = defaultNamespace
+				accessor.SetNamespace(defaultNamespace)
+			}
+			continue
+		}
+
+		// If we get here, it means the resource does not have the namespace
+		// set and we didn't find the resource type in the RESTMapper. As
+		// a last try, we look at all the CRDS that are part of the set and
+		// see if we get a match on the resource type. If so, we can determine
+		// from the CRD whether the resource type is cluster-scoped or
+		// namespace-scoped. If it is the latter, we set the namespace
+		// to the provided default.
+		var scope string
+		for _, crdInf := range crdInfos {
+			u, _ := crdInf.Object.(*unstructured.Unstructured)
+			group, _, _ := unstructured.NestedString(u.Object, "spec", "group")
+			kind, _, _ := unstructured.NestedString(u.Object, "spec", "names", "kind")
+			if gk.Kind == kind && gk.Group == group {
+				scope, _, _ = unstructured.NestedString(u.Object, "spec", "scope")
+			}
+		}
+
+		switch scope {
+		case "":
+			return fmt.Errorf("can't find scope for resource %s %s", gk.String(), accessor.GetName())
+		case "Cluster":
+			continue
+		case "Namespaced":
+			inf.Namespace = defaultNamespace
+			accessor.SetNamespace(defaultNamespace)
+		}
+	}
+
+	return nil
+}

--- a/pkg/manifestreader/common_test.go
+++ b/pkg/manifestreader/common_test.go
@@ -1,0 +1,189 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+func TestSetNamespaces(t *testing.T) {
+	// We need the RESTMapper in the testFactory to contain the CRD
+	// types, so add them to the scheme here.
+	_ = apiextv1.AddToScheme(scheme.Scheme)
+
+	testCases := map[string]struct {
+		infos            []*resource.Info
+		defaultNamspace  string
+		enforceNamespace bool
+
+		expectedNamespaces []string
+		expectedErrText    string
+	}{
+		"resources already have namespace": {
+			infos: []*resource.Info{
+				toInfo(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				}, "default"),
+				toInfo(schema.GroupVersionKind{
+					Group:   "policy",
+					Version: "v1beta1",
+					Kind:    "PodDisruptionBudget",
+				}, "default"),
+			},
+			defaultNamspace:  "foo",
+			enforceNamespace: false,
+			expectedNamespaces: []string{
+				"default",
+				"default",
+			},
+		},
+		"resources without namespace and mapping in RESTMapper": {
+			infos: []*resource.Info{
+				toInfo(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				}, ""),
+			},
+			defaultNamspace:    "foo",
+			enforceNamespace:   false,
+			expectedNamespaces: []string{"foo"},
+		},
+		"resource with namespace that does match enforced ns": {
+			infos: []*resource.Info{
+				toInfo(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				}, "bar"),
+			},
+			defaultNamspace:    "bar",
+			enforceNamespace:   true,
+			expectedNamespaces: []string{"bar"},
+		},
+		"resource with namespace that doesn't match enforced ns": {
+			infos: []*resource.Info{
+				toInfo(schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				}, "foo"),
+			},
+			defaultNamspace:  "bar",
+			enforceNamespace: true,
+			expectedErrText:  "does not match the namespace",
+		},
+		"cluster-scoped CR with CRD": {
+			infos: []*resource.Info{
+				toInfo(schema.GroupVersionKind{
+					Group:   "custom.io",
+					Version: "v1",
+					Kind:    "Custom",
+				}, ""),
+				toCRDInfo(schema.GroupVersionKind{
+					Group:   "apiextensions.k8s.io",
+					Version: "v1",
+					Kind:    "CustomResourceDefinition",
+				}, schema.GroupKind{
+					Group: "custom.io",
+					Kind:  "Custom",
+				}, "Cluster"),
+			},
+			defaultNamspace:    "bar",
+			enforceNamespace:   true,
+			expectedNamespaces: []string{"", ""},
+		},
+		"namespace-scoped CR with CRD": {
+			infos: []*resource.Info{
+				toCRDInfo(schema.GroupVersionKind{
+					Group:   "apiextensions.k8s.io",
+					Version: "v1",
+					Kind:    "CustomResourceDefinition",
+				}, schema.GroupKind{
+					Group: "custom.io",
+					Kind:  "Custom",
+				}, "Namespaced"),
+				toInfo(schema.GroupVersionKind{
+					Group:   "custom.io",
+					Version: "v1",
+					Kind:    "Custom",
+				}, ""),
+			},
+			defaultNamspace:    "bar",
+			enforceNamespace:   true,
+			expectedNamespaces: []string{"", "bar"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("namespace")
+			defer tf.Cleanup()
+
+			err := setNamespaces(tf, tc.infos, tc.defaultNamspace, tc.enforceNamespace)
+
+			if tc.expectedErrText != "" {
+				if err == nil {
+					t.Errorf("expected error %s, but not nil", tc.expectedErrText)
+				}
+				assert.Contains(t, err.Error(), tc.expectedErrText)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			for i, inf := range tc.infos {
+				expectedNs := tc.expectedNamespaces[i]
+				assert.Equal(t, expectedNs, inf.Namespace)
+				accessor, _ := meta.Accessor(inf.Object)
+				assert.Equal(t, expectedNs, accessor.GetNamespace())
+			}
+		})
+	}
+}
+
+func toInfo(gvk schema.GroupVersionKind, namespace string) *resource.Info {
+	return &resource.Info{
+		Namespace: namespace,
+		Object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": gvk.GroupVersion().String(),
+				"kind":       gvk.Kind,
+				"metadata": map[string]interface{}{
+					"namespace": namespace,
+				},
+			},
+		},
+	}
+}
+
+func toCRDInfo(gvk schema.GroupVersionKind, gk schema.GroupKind,
+	scope string) *resource.Info {
+	return &resource.Info{
+		Object: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": gvk.GroupVersion().String(),
+				"kind":       gvk.Kind,
+				"spec": map[string]interface{}{
+					"group": gk.Group,
+					"names": map[string]interface{}{
+						"kind": gk.Kind,
+					},
+					"scope": scope,
+				},
+			},
+		},
+	}
+}

--- a/pkg/manifestreader/path.go
+++ b/pkg/manifestreader/path.go
@@ -1,0 +1,54 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// PathManifestReader reads manifests from the provided path
+// and returns them as Info objects. The returned Infos will not have
+// client or mapping set.
+type PathManifestReader struct {
+	Path string
+
+	ReaderOptions
+}
+
+// Read reads the manifests and returns them as Info objects.
+func (p *PathManifestReader) Read() ([]*resource.Info, error) {
+	validator, err := p.Factory.Validator(p.Validate)
+	if err != nil {
+		return nil, err
+	}
+
+	fileNameOptions := &resource.FilenameOptions{
+		Filenames: []string{p.Path},
+		Recursive: true,
+	}
+
+	enforceNamespace := false
+	result := p.Factory.NewBuilder().
+		Local().
+		Unstructured().
+		Schema(validator).
+		ContinueOnError().
+		FilenameParam(enforceNamespace, fileNameOptions).
+		Flatten().
+		Do()
+
+	if err := result.Err(); err != nil {
+		return nil, err
+	}
+	infos, err := result.Infos()
+	if err != nil {
+		return nil, err
+	}
+
+	err = setNamespaces(p.Factory, infos, p.Namespace, p.EnforceNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return infos, nil
+}

--- a/pkg/manifestreader/path_test.go
+++ b/pkg/manifestreader/path_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestPathManifestReader_Read(t *testing.T) {
+	testCases := map[string]struct {
+		manifests        map[string]string
+		namespace        string
+		enforceNamespace bool
+		validate         bool
+
+		infosCount int
+		namespaces []string
+	}{
+		"namespace should be set if not already present": {
+			manifests: map[string]string{
+				"dep.yaml": depManifest,
+			},
+			namespace:        "foo",
+			enforceNamespace: true,
+
+			infosCount: 1,
+			namespaces: []string{"foo"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+			defer tf.Cleanup()
+
+			dir, err := ioutil.TempDir("", "path-reader-test")
+			assert.NoError(t, err)
+			for filename, content := range tc.manifests {
+				p := filepath.Join(dir, filename)
+				err := ioutil.WriteFile(p, []byte(content), 0600)
+				assert.NoError(t, err)
+			}
+
+			infos, err := (&PathManifestReader{
+				Path: dir,
+				ReaderOptions: ReaderOptions{
+					Factory:          tf,
+					Namespace:        tc.namespace,
+					EnforceNamespace: tc.enforceNamespace,
+					Validate:         tc.validate,
+				},
+			}).Read()
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(infos), tc.infosCount)
+
+			for i, info := range infos {
+				assert.Equal(t, tc.namespaces[i], info.Namespace)
+			}
+		})
+	}
+}

--- a/pkg/manifestreader/stream.go
+++ b/pkg/manifestreader/stream.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"io"
+
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+// StreamManifestReader reads manifest from the provided io.Reader
+// and returns them as Info objects. The returned Infos will not have
+// client or mapping set.
+type StreamManifestReader struct {
+	ReaderName string
+	Reader     io.Reader
+
+	ReaderOptions
+}
+
+// Read reads the manifests and returns them as Info objects.
+func (r *StreamManifestReader) Read() ([]*resource.Info, error) {
+	validator, err := r.Factory.Validator(r.Validate)
+	if err != nil {
+		return nil, err
+	}
+
+	result := r.Factory.NewBuilder().
+		Local().
+		Unstructured().
+		Schema(validator).
+		ContinueOnError().
+		Stream(r.Reader, r.ReaderName).
+		Flatten().
+		Do()
+
+	if err := result.Err(); err != nil {
+		return nil, err
+	}
+	infos, err := result.Infos()
+	if err != nil {
+		return nil, err
+	}
+
+	err = setNamespaces(r.Factory, infos, r.Namespace, r.EnforceNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return infos, nil
+}

--- a/pkg/manifestreader/stream_test.go
+++ b/pkg/manifestreader/stream_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+var (
+	depManifest = `
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: foo
+spec:
+  replicas: 1
+`
+)
+
+func TestStreamManifestReader_Read(t *testing.T) {
+	testCases := map[string]struct {
+		manifests        string
+		namespace        string
+		enforceNamespace bool
+		validate         bool
+
+		infosCount int
+		namespaces []string
+	}{
+		"namespace should be set if not already present": {
+			manifests:        depManifest,
+			namespace:        "foo",
+			enforceNamespace: true,
+
+			infosCount: 1,
+			namespaces: []string{"foo"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+			defer tf.Cleanup()
+
+			stringReader := strings.NewReader(tc.manifests)
+
+			infos, err := (&StreamManifestReader{
+				ReaderName: "testReader",
+				Reader:     stringReader,
+				ReaderOptions: ReaderOptions{
+					Factory:          tf,
+					Namespace:        tc.namespace,
+					EnforceNamespace: tc.enforceNamespace,
+					Validate:         tc.validate,
+				},
+			}).Read()
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(infos), tc.infosCount)
+
+			for i, info := range infos {
+				assert.Equal(t, tc.namespaces[i], info.Namespace)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This separates the logic from reading manifests from the applier. This should simplify the `Applier`, provide better separation of concerns and make it easier to use the Applier as a library. 