### PR TITLE
Exit with non-zero exit code on error

### DIFF
--- a/pkg/apply/basic_printer.go
+++ b/pkg/apply/basic_printer.go
@@ -5,6 +5,7 @@ package apply
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,6 +16,11 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+const (
+	defaultExitErrorCode int = 1
+	timeoutExitErrorCode int = -1
 )
 
 // BasicPrinter is a simple implementation that just prints the events
@@ -130,7 +136,9 @@ func (b *BasicPrinter) processErrorEvent(ee event.ErrorEvent, c *statusCollector
 			p("%s/%s %s %s", id.GroupKind.Kind,
 				id.Name, ls.Resource.Status, ls.Resource.Message)
 		}
+		os.Exit(timeoutExitErrorCode)
 	}
+	os.Exit(defaultExitErrorCode)
 }
 
 func (b *BasicPrinter) processApplyEvent(ae event.ApplyEvent, as *applyStats,


### PR DESCRIPTION
Hi 👋

A change in exit code behavior was introduced in #166, where printing an error used to also cause the application to exit with a non-zero exit code. As a result, errors in e.g. `kpt live apply` exits the process with a 0 exit code.

This change should bring it in line with how it works before, but I'm open to other solutions if there's a cleaner way to accomplish this without having an error log automatically mean that the application needs to exit.