### PR TITLE
Simplify the InfoHelper and ApplyTask

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -291,11 +291,18 @@ func (a *Applier) Run(ctx context.Context, objects []*resource.Info, options Opt
 			return
 		}
 
+		mapper, err := a.factory.ToRESTMapper()
+		if err != nil {
+			handleError(eventChannel, err)
+			return
+		}
+
 		// Fetch the queue (channel) of tasks that should be executed.
 		taskQueue := (&solver.TaskQueueSolver{
 			ApplyOptions: a.ApplyOptions,
 			PruneOptions: a.PruneOptions,
 			InfoHelper:   a.infoHelperFactoryFunc(),
+			Mapper:       mapper,
 		}).BuildTaskQueue(resourceObjects, solver.Options{
 			ReconcileTimeout:       options.ReconcileTimeout,
 			Prune:                  !options.NoPrune,

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -801,11 +801,3 @@ func (f *fakeInfoHelper) getClient(gv schema.GroupVersion) (resource.RESTClient,
 	}
 	return f.factory.Client, nil
 }
-
-func (f *fakeInfoHelper) ResetRESTMapper() error {
-	return nil
-}
-
-func (f *fakeInfoHelper) ToRESTMapper() (meta.RESTMapper, error) {
-	return f.factory.ToRESTMapper()
-}

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -4,14 +4,10 @@
 package info
 
 import (
-	"fmt"
-	"reflect"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/kubectl/pkg/cmd/util"
 )
 
@@ -21,13 +17,6 @@ type InfoHelper interface {
 	// objects. This must be called at a time when all needed resource
 	// types are available in the RESTMapper.
 	UpdateInfos(infos []*resource.Info) error
-
-	// ResetRESTMapper resets the state of the RESTMapper so any
-	// added resource types in the cluster will be picked up.
-	ResetRESTMapper() error
-
-	// ToRESTMapper returns a RESTMapper
-	ToRESTMapper() (meta.RESTMapper, error)
 }
 
 func NewInfoHelper(factory util.Factory, namespace string) *infoHelper {
@@ -66,20 +55,6 @@ func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {
 
 func (ih *infoHelper) ToRESTMapper() (meta.RESTMapper, error) {
 	return ih.factory.ToRESTMapper()
-}
-
-func (ih *infoHelper) ResetRESTMapper() error {
-	mapper, err := ih.factory.ToRESTMapper()
-	if err != nil {
-		return err
-	}
-	fv := reflect.ValueOf(mapper).FieldByName("RESTMapper")
-	ddRESTMapper, ok := fv.Interface().(*restmapper.DeferredDiscoveryRESTMapper)
-	if !ok {
-		return fmt.Errorf("unexpected RESTMapper type")
-	}
-	ddRESTMapper.Reset()
-	return nil
 }
 
 func (ih *infoHelper) getClient(gv schema.GroupVersion) (*rest.RESTClient, error) {

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/task"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
 var (
@@ -149,6 +150,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 						object.InfoToObjMeta(crdInfo),
 					},
 					taskrunner.AllCurrent, 1*time.Second),
+				&task.ResetRESTMapperTask{},
 				&task.ApplyTask{
 					Objects: []*resource.Info{
 						depInfo,
@@ -194,6 +196,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 			tqs := TaskQueueSolver{
 				ApplyOptions: applyOptions,
 				PruneOptions: pruneOptions,
+				Mapper:       testutil.NewFakeRESTMapper(),
 			}
 
 			tq := tqs.BuildTaskQueue(&fakeResourceObjects{

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -231,11 +230,10 @@ func TestApplyTask_DryRun(t *testing.T) {
 			applyTask := &ApplyTask{
 				ApplyOptions: applyOptions,
 				Objects:      tc.infos,
-				InfoHelper: &fakeInfoHelper{
-					restMapper: restMapper,
-				},
-				DryRun: true,
-				CRDs:   tc.crds,
+				InfoHelper:   &fakeInfoHelper{},
+				Mapper:       restMapper,
+				DryRun:       true,
+				CRDs:         tc.crds,
 			}
 
 			var events []event.Event
@@ -307,18 +305,8 @@ func (f *fakeApplyOptions) SetObjects(objects []*resource.Info) {
 	f.objects = objects
 }
 
-type fakeInfoHelper struct {
-	restMapper meta.RESTMapper
-}
+type fakeInfoHelper struct{}
 
 func (f *fakeInfoHelper) UpdateInfos([]*resource.Info) error {
 	return nil
-}
-
-func (f *fakeInfoHelper) ResetRESTMapper() error {
-	return nil
-}
-
-func (f *fakeInfoHelper) ToRESTMapper() (meta.RESTMapper, error) {
-	return f.restMapper, nil
 }

--- a/pkg/apply/task/resetmapper_task.go
+++ b/pkg/apply/task/resetmapper_task.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+)
+
+// ResetRESTMapperTask resets the provided RESTMapper.
+type ResetRESTMapperTask struct {
+	Mapper meta.RESTMapper
+}
+
+// Start creates a new goroutine that will unwrap the provided RESTMapper
+// to get the underlying DeferredDiscoveryRESTMapper and then reset it. It
+// will send a TaskResult on the taskChannel to signal that the task has
+// been completed.
+func (r *ResetRESTMapperTask) Start(taskContext *taskrunner.TaskContext) {
+	go func() {
+		ddRESTMapper, err := extractDeferredDiscoveryRESTMapper(r.Mapper)
+		if err != nil {
+			r.sendTaskResult(taskContext, err)
+			return
+		}
+		ddRESTMapper.Reset()
+		r.sendTaskResult(taskContext, nil)
+	}()
+}
+
+// extractDeferredDiscoveryRESTMapper unwraps the provided RESTMapper
+// interface to get access to the underlying DeferredDiscoveryRESTMapper
+// that can be reset.
+func extractDeferredDiscoveryRESTMapper(mapper meta.RESTMapper) (*restmapper.DeferredDiscoveryRESTMapper,
+	error) {
+	val := reflect.ValueOf(mapper)
+	if val.Type().Kind() != reflect.Struct {
+		return nil, fmt.Errorf("unexpected RESTMapper type: %s", val.Type().String())
+	}
+	fv := val.FieldByName("RESTMapper")
+	ddRESTMapper, ok := fv.Interface().(*restmapper.DeferredDiscoveryRESTMapper)
+	if !ok {
+		return nil, fmt.Errorf("unexpected RESTMapper type")
+	}
+	return ddRESTMapper, nil
+}
+
+func (r *ResetRESTMapperTask) sendTaskResult(taskContext *taskrunner.TaskContext, err error) {
+	taskContext.TaskChannel() <- taskrunner.TaskResult{
+		Err: err,
+	}
+}
+
+// ClearTimeout doesn't do anything as ResetRESTMapperTask doesn't support
+// timeouts.
+func (r *ResetRESTMapperTask) ClearTimeout() {}

--- a/pkg/apply/task/resetmapper_task_test.go
+++ b/pkg/apply/task/resetmapper_task_test.go
@@ -1,0 +1,79 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestResetRESTMapperTask(t *testing.T) {
+	testCases := map[string]struct {
+		toRESTMapper       func() (meta.RESTMapper, *fakeCachedDiscoveryClient)
+		expectErr          bool
+		expectedErrMessage string
+	}{
+		"correct wrapped RESTMapper": {
+			toRESTMapper: func() (meta.RESTMapper, *fakeCachedDiscoveryClient) {
+				discoveryClient := &fakeCachedDiscoveryClient{}
+				ddRESTMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+				return restmapper.NewShortcutExpander(ddRESTMapper, discoveryClient), discoveryClient
+			},
+			expectErr: false,
+		},
+		"incorrect wrapped RESTMapper": {
+			toRESTMapper: func() (meta.RESTMapper, *fakeCachedDiscoveryClient) {
+				return testutil.NewFakeRESTMapper(), nil
+			},
+			expectErr:          true,
+			expectedErrMessage: "unexpected RESTMapper type",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			eventChannel := make(chan event.Event)
+			defer close(eventChannel)
+			taskContext := taskrunner.NewTaskContext(eventChannel)
+
+			mapper, discoveryClient := tc.toRESTMapper()
+
+			resetRESTMapperTask := &ResetRESTMapperTask{
+				Mapper: mapper,
+			}
+
+			resetRESTMapperTask.Start(taskContext)
+
+			result := <-taskContext.TaskChannel()
+
+			if tc.expectErr {
+				assert.Error(t, result.Err)
+				assert.Contains(t, result.Err.Error(), tc.expectedErrMessage)
+				return
+			}
+
+			assert.True(t, discoveryClient.invalidated)
+		})
+	}
+}
+
+type fakeCachedDiscoveryClient struct {
+	discovery.DiscoveryInterface
+	invalidated bool
+}
+
+func (d *fakeCachedDiscoveryClient) Fresh() bool {
+	return true
+}
+
+func (d *fakeCachedDiscoveryClient) Invalidate() {
+	d.invalidated = true
+}


### PR DESCRIPTION
First step in breaking up the InfoHelper. This also makes sure we only reset the RESTMapper after we apply CRDs instead of after every ApplyTask completes.

@seans3 @phanimarupaka @jijiew