### PR TITLE
Initial move of Inventory to its own package

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -31,8 +31,8 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
-	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -512,8 +512,8 @@ func TestReadAndPrepareObjects(t *testing.T) {
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
 			applier := NewApplier(tf, ioStreams)
 
-			applier.previousInventoriesFunc = func(currentInv *resource.Info) ([]prune.Inventory, error) {
-				return []prune.Inventory{}, nil
+			applier.previousInventoriesFunc = func(currentInv *resource.Info) ([]inventory.Inventory, error) {
+				return []inventory.Inventory{}, nil
 			}
 
 			resourceObjects, err := applier.prepareObjects(tc.resources)
@@ -531,12 +531,12 @@ func TestReadAndPrepareObjects(t *testing.T) {
 			}
 
 			inventoryObj := resourceObjects.CurrentInventory
-			if !prune.IsInventoryObject(inventoryObj.Object) {
+			if !inventory.IsInventoryObject(inventoryObj.Object) {
 				t.Errorf(
 					"expected first item to be inventory object, but it wasn't")
 			}
 
-			pastObjs, err := prune.RetrieveObjsFromInventory(
+			pastObjs, err := inventory.RetrieveObjsFromInventory(
 				[]*resource.Info{inventoryObj})
 			if err != nil {
 				t.Error(err)

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
 
 // NewDestroyer returns a new destroyer. It will set up the ApplyOptions and
@@ -90,7 +91,7 @@ func (d *Destroyer) Run() <-chan event.Event {
 		// so the prune will calculate the prune set as all the objects,
 		// deleting everything. We can ignore the error, since the Prune
 		// will catch the same problems.
-		_ = prune.ClearInventoryObj(infos)
+		_ = inventory.ClearInventoryObj(infos)
 
 		// Start the event transformer goroutine so we can transform
 		// the Prune events emitted from the Prune function to Delete

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -9,7 +9,7 @@
 // objects, we can correctly prune and teardown sets
 // of resources.
 
-package prune
+package inventory
 
 import (
 	"fmt"
@@ -38,10 +38,10 @@ type Inventory interface {
 	GetObject() (*resource.Info, error)
 }
 
-// retrieveInventoryLabel returns the string value of the InventoryLabel
+// RetrieveInventoryLabel returns the string value of the InventoryLabel
 // for the passed object. Returns error if the passed object is nil or
 // is not a inventory object.
-func retrieveInventoryLabel(obj runtime.Object) (string, error) {
+func RetrieveInventoryLabel(obj runtime.Object) (string, error) {
 	var inventoryLabel string
 	if obj == nil {
 		return "", fmt.Errorf("inventory object is nil")
@@ -64,7 +64,7 @@ func IsInventoryObject(obj runtime.Object) bool {
 	if obj == nil {
 		return false
 	}
-	inventoryLabel, err := retrieveInventoryLabel(obj)
+	inventoryLabel, err := RetrieveInventoryLabel(obj)
 	if err == nil && len(inventoryLabel) > 0 {
 		return true
 	}
@@ -87,7 +87,7 @@ func FindInventoryObj(infos []*resource.Info) (*resource.Info, bool) {
 // exist, or we are unable to successfully add the metadata to
 // the inventory object; nil otherwise. Each object is in
 // unstructured.Unstructured format.
-func addObjsToInventory(infos []*resource.Info) error {
+func AddObjsToInventory(infos []*resource.Info) error {
 	var inventoryInfo *resource.Info
 	var inventoryObj *unstructured.Unstructured
 	objMap := map[string]string{}

--- a/pkg/inventory/inventory_error.go
+++ b/pkg/inventory/inventory_error.go
@@ -3,7 +3,7 @@
 //
 // Errors when applying inventory object templates.
 
-package prune
+package inventory
 
 import "k8s.io/cli-runtime/pkg/resource"
 

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -1,7 +1,7 @@
 // Copyright 2020 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package prune
+package inventory
 
 import (
 	"fmt"
@@ -162,7 +162,7 @@ func TestRetrieveInventoryLabel(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, err := retrieveInventoryLabel(test.obj)
+		actual, err := RetrieveInventoryLabel(test.obj)
 		if test.isError && err == nil {
 			t.Errorf("Did not receive expected error.\n")
 		}
@@ -537,7 +537,7 @@ func TestAddRetrieveObjsToFromInventory(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := addObjsToInventory(test.infos)
+		err := AddObjsToInventory(test.infos)
 		if test.isError && err == nil {
 			t.Errorf("Should have produced an error, but returned none.")
 		}

--- a/pkg/inventory/inventorycm.go
+++ b/pkg/inventory/inventorycm.go
@@ -6,7 +6,7 @@
 // ConfigMap resource which stores the set of inventory
 // (object metadata).
 
-package prune
+package inventory
 
 import (
 	"fmt"


### PR DESCRIPTION
* First step in making `Inventory` its own package.
* Moves `inventory.go` and associated files to `pkg/inventory`.
* Updates files which use `inventory` functionality to reference this new package.