### PR TITLE
Allow colons in object names

### DIFF
--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -91,7 +91,7 @@ func (o *ObjMetadata) Equals(other *ObjMetadata) bool {
 func (o *ObjMetadata) String() string {
 	return fmt.Sprintf("%s%s%s%s%s%s%s",
 		o.Namespace, fieldSeparator,
-		o.Name, fieldSeparator,
+		strings.ReplaceAll(o.Name, ":", "_"), fieldSeparator,
 		o.GroupKind.Group, fieldSeparator,
 		o.GroupKind.Kind)
 }

--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -37,6 +37,15 @@ func TestCreateObjMetadata(t *testing.T) {
 			expected: "test-namespace_test-name_apps_ReplicaSet",
 			isError:  false,
 		},
+		{
+			name: "psp:rook",
+			gk: schema.GroupKind{
+				Group: "rbac.authorization.k8s.io",
+				Kind:  "ClusterRole",
+			},
+			expected: "_psp_rook_rbac.authorization.k8s.io_ClusterRole",
+			isError:  false,
+		},
 		// Error with empty name.
 		{
 			namespace: "test-namespace ",


### PR DESCRIPTION
In most objects, kubernetes does not allow colons, but especially in
Roles and Bindings they are widely used. On the other hand, colons are
not allowed as keys of ConfigMaps. When we try to write e.g. a
ClusterRole named `psp:rook`, `ObjectMetadata.String` results in a name
like `_psp:rook_rbac.authorization.k8s.io_ClusterRole`, which
consequently is refused by the apiserver.

```
Fatal error: error when creating "generated": ConfigMap "inventory-b5237659" is invalid: data[_psp:rook_rbac.authorization.k8s.io_ClusterRole]: Invalid value: "_psp:rook_rbac.authorization.k8s.io_ClusterRole": a valid config key must consist of alphanumeric characters, '-', '_' or '.' (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')
```

The corresponding object:
```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: 'psp:rook'
rules:
- resources:
  - podsecuritypolicies
  apiGroups:
  - policy
  resourceNames:
  - rook-privileged
  verbs:
  - use
```

This PR translates the colon into a underscore, so that the result
of `ObjectMetadata.String` is
`_psp_rook_rbac.authorization.k8s.io_ClusterRole`.

