### PR TITLE
Updates prune algorithm to use one inventory object

### DIFF
--- a/examples/alphaTestExamples/MultipleServices.md
+++ b/examples/alphaTestExamples/MultipleServices.md
@@ -59,6 +59,7 @@ the namespace and inventory id used by apply to create inventory objects.
 ```
 kapply init $BASE/mysql > $OUTPUT/status
 expectedOutputLine "namespace: default is used for inventory object"
+
 kapply init $BASE/wordpress > $OUTPUT/status
 expectedOutputLine "namespace: default is used for inventory object"
 ```
@@ -79,8 +80,6 @@ expectedOutputLine "deployment.apps/mysql is Current: Deployment is available. R
 
 expectedOutputLine "secret/mysql-pass is Current: Resource is always ready"
 
-expectedOutputLine "configmap/inventory-57005c71 is Current: Resource is always ready"
-
 expectedOutputLine "service/mysql is Current: Service is ready"
 
 # Verify that we have the mysql resources in the cluster.
@@ -96,8 +95,6 @@ And the apply the wordpress service
 <!-- @RunWordpress @testE2EAgainstLatestRelease -->
 ```
 kapply apply $BASE/wordpress --reconcile-timeout=120s > $OUTPUT/status;
-
-expectedOutputLine "configmap/inventory-2fbd5b91 is Current: Resource is always ready"
 
 expectedOutputLine "service/wordpress is Current: Service is ready"
 
@@ -116,8 +113,6 @@ kapply destroy $BASE/wordpress > $OUTPUT/status;
 expectedOutputLine "service/wordpress deleted"
 
 expectedOutputLine "deployment.apps/wordpress deleted"
-
-expectedOutputLine "configmap/inventory-2fbd5b91 deleted"
 
 # Verify that we still have the mysql resources in the cluster.
 kubectl get all --no-headers --selector=app=mysql | wc -l | xargs > $OUTPUT/status

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -162,7 +162,7 @@ Run preview to check which commands will be executed
 ```
 kapply preview $BASE > $OUTPUT/status
 
-expectedOutputLine "4 resource(s) applied. 4 created, 0 unchanged, 0 configured (preview)"
+expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured (preview)"
 
 # Verify that preview didn't create any resources.
 kubectl get all -n hellospace > $OUTPUT/status 2>&1
@@ -177,8 +177,6 @@ kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
 expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
 
 expectedOutputLine "service/the-service is Current: Service is ready"
-
-expectedOutputLine "configmap/inventory-5fe947f is Current: Resource is always ready"
 
 expectedOutputLine "configmap/the-map1 is Current: Resource is always ready"
 
@@ -210,13 +208,9 @@ expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is ava
 
 expectedOutputLine "service/the-service is Current: Service is ready"
 
-expectedOutputLine "configmap/inventory-db36ed56 is Current: Resource is always ready"
-
 expectedOutputLine "configmap/the-map2 is Current: Resource is always ready"
 
 expectedOutputLine "configmap/the-map1 pruned"
-
-expectedOutputLine "configmap/inventory-5fe947f pruned"
 
 # Verify that the new configmap has been created and the old one pruned.
 kubectl get cm -n hellospace --no-headers | awk '{print $1}' > $OUTPUT/status
@@ -235,12 +229,9 @@ expectedOutputLine "configmap/the-map2 deleted (preview)"
 
 expectedOutputLine "service/the-service deleted (preview)"
 
-expectedOutputLine "configmap/inventory-db36ed56 deleted (preview)"
-
 # Verify that preview all resources are still there after running preview.
 kubectl get --no-headers all -n hellospace | wc -l | xargs > $OUTPUT/status
 expectedOutputLine "6"
-
 
 kapply destroy $BASE > $OUTPUT/status;
 
@@ -249,8 +240,6 @@ expectedOutputLine "deployment.apps/the-deployment deleted"
 expectedOutputLine "configmap/the-map2 deleted"
 
 expectedOutputLine "service/the-service deleted"
-
-expectedOutputLine "configmap/inventory-db36ed56 deleted"
 
 kind delete cluster;
 ```

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,7 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+AfE52mFHOXVFnOSBJBRlzTHrOPLOIhE=
@@ -218,6 +219,7 @@ github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1a
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -50,6 +50,7 @@ type Options struct {
 
 type resourceObjects interface {
 	InfosForApply() []*resource.Info
+	InfosForPrune() []*resource.Info
 	IdsForApply() []object.ObjMetadata
 	IdsForPrune() []object.ObjMetadata
 }
@@ -73,8 +74,9 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			Mapper:       t.Mapper,
 		})
 		if !o.DryRun {
+			objs, _ := object.InfosToObjMetas(crdSplitRes.crds)
 			tasks = append(tasks, taskrunner.NewWaitTask(
-				object.InfosToObjMetas(crdSplitRes.crds),
+				objs,
 				taskrunner.AllCurrent,
 				1*time.Minute),
 				&task.ResetRESTMapperTask{
@@ -123,7 +125,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 	if o.Prune {
 		tasks = append(tasks,
 			&task.PruneTask{
-				Objects:           ro.InfosForApply(),
+				Objects:           ro.InfosForPrune(),
 				PruneOptions:      t.PruneOptions,
 				PropagationPolicy: o.PrunePropagationPolicy,
 				DryRun:            o.DryRun,

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -109,10 +109,18 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 		// applied.
 		//TODO: This isn't really needed if we are doing dry-run.
 		for _, obj := range objects {
-			id := object.InfoToObjMeta(obj)
-			acc, _ := meta.Accessor(obj.Object)
-			gen := acc.GetGeneration()
-			taskContext.ResourceApplied(id, gen)
+			id, err := object.InfoToObjMeta(obj)
+			if err != nil {
+				continue
+			}
+			if obj.Object != nil {
+				acc, err := meta.Accessor(obj.Object)
+				if err != nil {
+					continue
+				}
+				gen := acc.GetGeneration()
+				taskContext.ResourceApplied(id, gen)
+			}
 		}
 		a.sendTaskResult(taskContext, nil)
 	}()

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -253,7 +253,11 @@ func TestApplyTask_DryRun(t *testing.T) {
 
 			assert.Equal(t, len(tc.expectedObjects), len(applyOptions.objects))
 			for i, obj := range applyOptions.objects {
-				assert.Equal(t, tc.expectedObjects[i], object.InfoToObjMeta(obj))
+				actual, err := object.InfoToObjMeta(obj)
+				if err != nil {
+					continue
+				}
+				assert.Equal(t, tc.expectedObjects[i], actual)
 			}
 
 			assert.Equal(t, len(tc.expectedEvents), len(events))
@@ -277,6 +281,8 @@ func toInfos(rss []resourceInfo) []*resource.Info {
 
 	for _, rs := range rss {
 		infos = append(infos, &resource.Info{
+			Name:      rs.name,
+			Namespace: rs.namespace,
 			Object: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": rs.apiVersion,

--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,8 +19,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
-const manifestFilename = "inventory-template.yaml"
-
+const (
+	manifestFilename = "inventory-template.yaml"
+	maxRandInt       = 100000000
+)
 const configMapTemplate = `# NOTE: auto-generated. Some fields should NOT be modified.
 # Date: <DATETIME>
 #
@@ -48,7 +51,7 @@ metadata:
   # NOTE: The name of the inventory object does NOT have
   # any impact on group-related functionality such as
   # deletion or pruning.
-  name: inventory
+  name: inventory-<RANDOMSUFFIX>
   labels:
     # DANGER: Do not change the value of this label.
     # Changing this value will cause a loss of continuity
@@ -208,9 +211,13 @@ func fileExists(path string) bool {
 func (i *InitOptions) fillInValues() string {
 	now := time.Now()
 	nowStr := now.Format("2006-01-02 15:04:05 MST")
+	rand.Seed(time.Now().UTC().UnixNano())
+	randomInt := rand.Intn(maxRandInt)
+	randomSuffix := fmt.Sprintf("%08d", randomInt)
 	manifestStr := configMapTemplate
 	manifestStr = strings.ReplaceAll(manifestStr, "<DATETIME>", nowStr)
 	manifestStr = strings.ReplaceAll(manifestStr, "<NAMESPACE>", i.Namespace)
+	manifestStr = strings.ReplaceAll(manifestStr, "<RANDOMSUFFIX>", randomSuffix)
 	manifestStr = strings.ReplaceAll(manifestStr, "<INVENTORYID>", i.InventoryID)
 	return manifestStr
 }

--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -184,6 +184,13 @@ func TestFillInValues(t *testing.T) {
 			if !strings.Contains(actual, expectedNamespace) {
 				t.Errorf("\nExpected namespace (%s) not found in inventory object: %s\n", expectedNamespace, actual)
 			}
+			matched, err := regexp.MatchString(`name: inventory-\d{8}\n`, actual)
+			if err != nil {
+				t.Errorf("unexpected error parsing inventory name: %s", err)
+			}
+			if !matched {
+				t.Errorf("expected inventory name (e.g. inventory-12345678), got (%s)", actual)
+			}
 			if !strings.Contains(actual, "kind: ConfigMap") {
 				t.Errorf("\nExpected `kind: ConfigMap` not found in inventory object: %s\n", actual)
 			}

--- a/pkg/inventory/fake-builder.go
+++ b/pkg/inventory/fake-builder.go
@@ -1,0 +1,121 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	"k8s.io/client-go/restmapper"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+var (
+	codec       = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	cmPathRegex = regexp.MustCompile(`^/namespaces/([^/]+)/configmaps$`)
+)
+
+// FakeBuilder encapsulates a resource Builder which will hard-code the return
+// of an inventory object with the encoded past invObjs.
+type FakeBuilder struct {
+	invObjs []object.ObjMetadata
+}
+
+// SetInventoryObjs sets the objects which will be encoded in
+// an inventory object to be returned when queried for the cluster
+// inventory object.
+func (fb *FakeBuilder) SetInventoryObjs(objs []object.ObjMetadata) {
+	fb.invObjs = objs
+}
+
+// Returns the fake resource Builder with the fake client, test restmapper,
+// and the fake category expander.
+func (fb *FakeBuilder) GetBuilder() func() *resource.Builder {
+	return func() *resource.Builder {
+		return resource.NewFakeBuilder(
+			fakeClient(fb.invObjs),
+			func() (meta.RESTMapper, error) {
+				return testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme), nil
+			},
+			func() (restmapper.CategoryExpander, error) {
+				return resource.FakeCategoryExpander, nil
+			})
+	}
+}
+
+// fakeClient hard codes the return of an inventory object that encodes the passed
+// objects into the inventory object when a GET of configmaps is called.
+func fakeClient(objs []object.ObjMetadata) resource.FakeClientFunc {
+	return func(version schema.GroupVersion) (resource.RESTClient, error) {
+		return &fake.RESTClient{
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				if req.Method == "POST" && cmPathRegex.Match([]byte(req.URL.Path)) {
+					b, err := ioutil.ReadAll(req.Body)
+					if err != nil {
+						return nil, err
+					}
+					cm := corev1.ConfigMap{}
+					err = runtime.DecodeInto(codec, b, &cm)
+					if err != nil {
+						return nil, err
+					}
+					bodyRC := ioutil.NopCloser(bytes.NewReader(b))
+					return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+				}
+				if req.Method == "GET" && cmPathRegex.Match([]byte(req.URL.Path)) {
+					cmList := corev1.ConfigMapList{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "List",
+						},
+						Items: []corev1.ConfigMap{},
+					}
+					var cm = corev1.ConfigMap{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "inventory",
+							Namespace: "test-namespace",
+						},
+						Data: objMap(objs),
+					}
+					cmList.Items = append(cmList.Items, cm)
+					bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(&cmList)))
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+				}
+				return nil, nil
+			}),
+		}, nil
+	}
+}
+
+func toJSONBytes(obj runtime.Object) []byte {
+	objBytes, _ := runtime.Encode(unstructured.NewJSONFallbackEncoder(codec), obj)
+	return objBytes
+}
+
+func objMap(objs []object.ObjMetadata) map[string]string {
+	objMap := map[string]string{}
+	for _, obj := range objs {
+		objStr := obj.String()
+		objMap[objStr] = ""
+	}
+	return objMap
+}

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// FakeInventoryClient is a testing implementation of the InventoryClient interface.
+type FakeInventoryClient struct {
+	objs []object.ObjMetadata
+	err  error
+}
+
+var _ InventoryClient = &FakeInventoryClient{}
+
+// NewFakeInventoryClient returns a FakeInventoryClient.
+func NewFakeInventoryClient(initObjs []object.ObjMetadata) *FakeInventoryClient {
+	return &FakeInventoryClient{
+		objs: initObjs,
+		err:  nil,
+	}
+}
+
+// GetClusterObjs returns currently stored set of objects.
+func (fic *FakeInventoryClient) GetClusterObjs(inv *resource.Info) ([]object.ObjMetadata, error) {
+	if fic.err != nil {
+		return []object.ObjMetadata{}, fic.err
+	}
+	return fic.objs, nil
+}
+
+// Merge stores the passed objects with the current stored cluster inventory
+// objects. Returns the set difference of the current set of objects minus
+// the passed set of objects, or an error if one is set up.
+func (fic *FakeInventoryClient) Merge(inv *resource.Info, objs []object.ObjMetadata) ([]object.ObjMetadata, error) {
+	if fic.err != nil {
+		return []object.ObjMetadata{}, fic.err
+	}
+	diffObjs := object.SetDiff(fic.objs, objs)
+	fic.objs = object.Union(fic.objs, objs)
+	return diffObjs, nil
+}
+
+// Replace the stored cluster inventory objs with the passed obj, or an
+// error if one is set up.
+func (fic *FakeInventoryClient) Replace(inv *resource.Info, objs []object.ObjMetadata) error {
+	if fic.err != nil {
+		return fic.err
+	}
+	fic.objs = objs
+	return nil
+}
+
+// DeleteInventoryObj returns an error if one is forced; does nothing otherwise.
+func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
+	if fic.err != nil {
+		return fic.err
+	}
+	return nil
+}
+
+func (fic *FakeInventoryClient) SetDryRun(dryRun bool) {}
+
+// SetError forces an error on the subsequent client call if it returns an error.
+func (fic *FakeInventoryClient) SetError(err error) {
+	fic.err = err
+}
+
+// ClearError clears the force error
+func (fic *FakeInventoryClient) ClearError() {
+	fic.err = nil
+}

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -5,71 +5,54 @@ package inventory
 
 import (
 	"fmt"
+	"sort"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/klog"
-	"k8s.io/kubectl/pkg/cmd/util"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/validation"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/ordering"
 )
 
-// InventoryClient expresses an interface for retrieving Inventory
-// objects in the clus
+// InventoryClient expresses an interface for interacting with
+// objects which store references to objects (inventory objects).
 type InventoryClient interface {
-	// GetPreviousInventoryObjects returns the inventory objects (as *resource.Info)
-	// that are currently stored in the cluster, or an error if one occurred. Uses
-	// information from the current (recently) created inventory object to find
-	// the previously applied inventory object in the cluster.
-	GetPreviousInventoryObjects(currentInv *resource.Info) ([]*resource.Info, error)
-	// GetStoredObjRefs returns the set of previously applied objects as ObjMetadata,
+	// GetCluster returns the set of previously applied objects as ObjMetadata,
 	// or an error if one occurred. This set of previously applied object references
-	// is stored in the inventory objects living in the cluster. Uses information
-	// from the current inventory object to find the previously applied inventory
-	// objects.
-	GetStoredObjRefs(currentInv *resource.Info) ([]object.ObjMetadata, error)
-}
-
-// FakeInventoryClient is a testing implementation of the InventoryClient interface.
-type FakeInventoryClient struct {
-	prevInventories []*resource.Info
-}
-
-var _ InventoryClient = &FakeInventoryClient{}
-
-// NewFakeInventoryClient returns a FakeInventoryClient.
-func NewFakeInventoryClient(prevInventories []*resource.Info) *FakeInventoryClient {
-	return &FakeInventoryClient{prevInventories: prevInventories}
-}
-
-// GetPreviousInventoryObjects returns the hard-coded set of resource infos.
-// This function ensures the fake implements the InventoryClient interface.
-func (fic *FakeInventoryClient) GetPreviousInventoryObjects(currentInv *resource.Info) ([]*resource.Info, error) {
-	return fic.prevInventories, nil
-}
-
-// GetStoredObjRefs returns the union of hard-coded object references stored
-// in the prevInventories.
-func (fic *FakeInventoryClient) GetStoredObjRefs(currentInv *resource.Info) ([]object.ObjMetadata, error) {
-	return UnionPastObjs(fic.prevInventories)
+	// is stored in the inventory objects living in the cluster.
+	GetClusterObjs(inv *resource.Info) ([]object.ObjMetadata, error)
+	// Merge applies the union of the passed objects with the currently
+	// stored objects in the inventory object. Returns the slice of
+	// objects which are a set diff (objects to be pruned). Otherwise,
+	// returns an error if one happened.
+	Merge(inv *resource.Info, objs []object.ObjMetadata) ([]object.ObjMetadata, error)
+	// Replace replaces the set of objects stored in the inventory
+	// object with the passed set of objects, or an error if one occurs.
+	Replace(inv *resource.Info, objs []object.ObjMetadata) error
+	// DeleteInventoryObj deletes the passed inventory object from the APIServer.
+	DeleteInventoryObj(inv *resource.Info) error
+	// SetDryRun sets the boolean on whether this we actually mutate.
+	SetDryRun(dryRun bool)
 }
 
 // ClusterInventoryClient is a concrete implementation of the
 // InventoryClient interface.
 type ClusterInventoryClient struct {
-	builder                   *resource.Builder
-	mapper                    meta.RESTMapper
-	validator                 validation.Schema
-	pastInventoryObjects      []*resource.Info
-	retrievedInventoryObjects bool
+	builderFunc func() *resource.Builder
+	mapper      meta.RESTMapper
+	validator   validation.Schema
+	clientFunc  func(*meta.RESTMapping) (resource.RESTClient, error)
+	dryRun      bool
 }
 
 var _ InventoryClient = &ClusterInventoryClient{}
 
 // NewInventoryClient returns a concrete implementation of the
 // InventoryClient interface or an error.
-func NewInventoryClient(factory util.Factory) (*ClusterInventoryClient, error) {
+func NewInventoryClient(factory cmdutil.Factory) (*ClusterInventoryClient, error) {
 	var err error
 	mapper, err := factory.ToRESTMapper()
 	if err != nil {
@@ -79,79 +62,157 @@ func NewInventoryClient(factory util.Factory) (*ClusterInventoryClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	builder := factory.NewBuilder()
+	builderFunc := factory.NewBuilder
 	clusterInventoryClient := ClusterInventoryClient{
-		builder:                   builder,
-		mapper:                    mapper,
-		validator:                 validator,
-		pastInventoryObjects:      []*resource.Info{},
-		retrievedInventoryObjects: false,
+		builderFunc: builderFunc,
+		mapper:      mapper,
+		validator:   validator,
+		clientFunc:  factory.UnstructuredClientForMapping,
+		dryRun:      false,
 	}
 	return &clusterInventoryClient, nil
 }
 
-// GetStoredObjRefs returns the set of previously applied objects as ObjMetadata,
-// or an error if one occurred. This set of previously applied object references
-// is stored in the inventory objects living in the cluster. Uses information
-// from the current inventory object to find the previously applied inventory
-// objects.
-func (cic *ClusterInventoryClient) GetStoredObjRefs(currentInv *resource.Info) ([]object.ObjMetadata, error) {
-	prevInventories, err := cic.GetPreviousInventoryObjects(currentInv)
+// Merge stores the union of the passed objects with the objects currently
+// stored in the cluster inventory object. Retrieves and caches the cluster
+// inventory object. Returns the set differrence of the cluster inventory
+// objects and the currently applied objects. This is the set of objects
+// to prune. Creates the initial cluster inventory object storing the passed
+// objects if an inventory object does not exist. Returns an error if one
+// occurred.
+func (cic *ClusterInventoryClient) Merge(localInv *resource.Info, objs []object.ObjMetadata) ([]object.ObjMetadata, error) {
+	pruneIds := []object.ObjMetadata{}
+	clusterInv, err := cic.getClusterInventoryInfo(localInv)
 	if err != nil {
-		return nil, err
+		return pruneIds, err
 	}
-	return UnionPastObjs(prevInventories)
-}
-
-// GetPreviousInventoryObjects returns the set of inventory objects
-// that have the same label as the current inventory object. Removes
-// the current inventory object from this set. Returns an error
-// if there is a problem retrieving the inventory objects.
-func (cic *ClusterInventoryClient) GetPreviousInventoryObjects(currentInv *resource.Info) ([]*resource.Info, error) {
-	current, err := infoToObjMetadata(currentInv)
-	if err != nil {
-		return nil, err
-	}
-	label, err := retrieveInventoryLabel(currentInv.Object)
-	if err != nil {
-		return nil, err
-	}
-	prevInventoryObjs, err := cic.retrievePreviousInventoryObjects(current, label)
-	if err != nil {
-		return nil, err
-	}
-	// Remove the current inventory info from the previous inventory infos.
-	pastInventoryInfos := []*resource.Info{}
-	for _, pastInfo := range prevInventoryObjs {
-		past, err := infoToObjMetadata(pastInfo)
+	if clusterInv == nil {
+		// Wrap inventory object and store the inventory in it.
+		inv := WrapInventoryObj(localInv)
+		if err := inv.Store(objs); err != nil {
+			return nil, err
+		}
+		invInfo, err := inv.GetObject()
 		if err != nil {
 			return nil, err
 		}
-		if !current.Equals(past) {
-			pastInventoryInfos = append(pastInventoryInfos, pastInfo)
+		klog.V(4).Infof("creating initial inventory object with %d objects", len(objs))
+		if err := cic.createInventoryObj(invInfo); err != nil {
+			return nil, err
+		}
+	} else {
+		// Update existing cluster inventory with merged union of objects
+		clusterObjs, err := cic.GetClusterObjs(localInv)
+		if err != nil {
+			return pruneIds, err
+		}
+		if object.SetEquals(objs, clusterObjs) {
+			klog.V(4).Infof("applied objects same as cluster inventory: do nothing")
+			return pruneIds, nil
+		}
+		pruneIds = object.SetDiff(clusterObjs, objs)
+		unionObjs := object.Union(clusterObjs, objs)
+		klog.V(4).Infof("num objects to prune: %d", len(pruneIds))
+		klog.V(4).Infof("num merged objects to store in inventory: %d", len(unionObjs))
+		wrappedInv := WrapInventoryObj(clusterInv)
+		if err = wrappedInv.Store(unionObjs); err != nil {
+			return pruneIds, err
+		}
+		if !cic.dryRun {
+			clusterInv, err = wrappedInv.GetObject()
+			if err != nil {
+				return pruneIds, err
+			}
+			klog.V(4).Infof("update cluster inventory: %s/%s", clusterInv.Namespace, clusterInv.Name)
+			if err := cic.applyInventoryObj(clusterInv); err != nil {
+				return pruneIds, err
+			}
 		}
 	}
-	return pastInventoryInfos, nil
+
+	return pruneIds, nil
 }
 
-// retrievePreviousInventoryObjects requests the previous inventory objects
-// using the inventory label from the current inventory object. Sets
-// the field "pastInventoryObjects". Returns an error if the inventory
-// label doesn't exist for the current currentInventoryObject does not
-// exist or if the call to retrieve the past inventory objects fails.
-func (cic *ClusterInventoryClient) retrievePreviousInventoryObjects(current *object.ObjMetadata, label string) ([]*resource.Info, error) {
-	if cic.retrievedInventoryObjects {
-		return cic.pastInventoryObjects, nil
+// Replace stores the passed objects in the cluster inventory object, or
+// an error if one occurred.
+func (cic *ClusterInventoryClient) Replace(localInv *resource.Info, objs []object.ObjMetadata) error {
+	clusterObjs, err := cic.GetClusterObjs(localInv)
+	if err != nil {
+		return err
 	}
-	mapping, err := cic.mapper.RESTMapping(current.GroupKind)
+	if object.SetEquals(objs, clusterObjs) {
+		klog.V(4).Infof("applied objects same as cluster inventory: do nothing")
+		return nil
+	}
+	clusterInv, err := cic.getClusterInventoryInfo(localInv)
+	if err != nil {
+		return err
+	}
+	wrappedInv := WrapInventoryObj(clusterInv)
+	if err = wrappedInv.Store(objs); err != nil {
+		return err
+	}
+	if !cic.dryRun {
+		clusterInv, err = wrappedInv.GetObject()
+		if err != nil {
+			return err
+		}
+		klog.V(4).Infof("replace cluster inventory: %s/%s", clusterInv.Namespace, clusterInv.Name)
+		klog.V(4).Infof("replace cluster inventory %d objects", len(objs))
+		if err := cic.applyInventoryObj(clusterInv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetClusterObjs returns the objects stored in the cluster inventory object, or
+// an error if one occurred.
+func (cic *ClusterInventoryClient) GetClusterObjs(localInv *resource.Info) ([]object.ObjMetadata, error) {
+	var objs []object.ObjMetadata
+	clusterInv, err := cic.getClusterInventoryInfo(localInv)
+	if err != nil {
+		return objs, err
+	}
+	// First time; no inventory obj yet.
+	if clusterInv == nil {
+		return []object.ObjMetadata{}, nil
+	}
+	wrapped := WrapInventoryObj(clusterInv)
+	return wrapped.Load()
+}
+
+// getClusterInventoryObj returns a pointer to the cluster inventory object, or
+// an error if one occurred. Returns the cached cluster inventory object if it
+// has been previously retrieved. Uses the ResourceBuilder to retrieve the
+// inventory object in the cluster, using the namespace, group resource, and
+// inventory label. Merges multiple inventory objects into one if it retrieves
+// more than one (this should be very rare).
+//
+// TODO(seans3): Remove the special case code to merge multiple cluster inventory
+// objects once we've determined that this case is no longer possible.
+func (cic *ClusterInventoryClient) getClusterInventoryInfo(localInv *resource.Info) (*resource.Info, error) {
+	if localInv == nil {
+		return nil, fmt.Errorf("retrieving cluster inventory object with nil local inventory")
+	}
+	localObj, err := object.InfoToObjMeta(localInv)
+	if err != nil {
+		return nil, err
+	}
+	mapping, err := cic.mapper.RESTMapping(localObj.GroupKind)
 	if err != nil {
 		return nil, err
 	}
 	groupResource := mapping.Resource.GroupResource().String()
-	namespace := current.Namespace
+	namespace := localObj.Namespace
+	label, err := retrieveInventoryLabel(localInv)
+	if err != nil {
+		return nil, err
+	}
 	labelSelector := fmt.Sprintf("%s=%s", common.InventoryLabel, label)
 	klog.V(4).Infof("prune inventory object fetch: %s/%s/%s", groupResource, namespace, labelSelector)
-	retrievedInventoryInfos, err := cic.builder.
+	builder := cic.builderFunc()
+	retrievedInventoryInfos, err := builder.
 		Unstructured().
 		// TODO: Check if this validator is necessary.
 		Schema(cic.validator).
@@ -165,20 +226,158 @@ func (cic *ClusterInventoryClient) retrievePreviousInventoryObjects(current *obj
 	if err != nil {
 		return nil, err
 	}
-	cic.pastInventoryObjects = retrievedInventoryInfos
-	cic.retrievedInventoryObjects = true
-	klog.V(4).Infof("prune %d inventory objects found", len(cic.pastInventoryObjects))
-	return retrievedInventoryInfos, nil
+	var clusterInv *resource.Info
+	if len(retrievedInventoryInfos) == 1 {
+		clusterInv = retrievedInventoryInfos[0]
+	} else if len(retrievedInventoryInfos) > 1 {
+		clusterInv, err = cic.mergeClusterInventory(retrievedInventoryInfos)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return clusterInv, nil
 }
 
-// infoToObjMetadata transforms the object represented by the passed "info"
-// into its Inventory representation. Returns error if the passed Info
-// is nil, or the Object in the Info is empty.
-func infoToObjMetadata(info *resource.Info) (*object.ObjMetadata, error) {
-	if info == nil || info.Object == nil {
-		return nil, fmt.Errorf("empty resource.Info can not calculate as inventory")
+// mergeClusterInventory merges the inventory of multiple inventory objects
+// into one inventory object, and applies it. Deletes the remaining unnecessary
+// inventory objects. There should be only one inventory object stored in the
+// cluster after this function. This special case should be very rare.
+//
+// TODO(seans3): Remove this code once we're certain no customers have multiple
+// inventory objects in their clusters.
+func (cic *ClusterInventoryClient) mergeClusterInventory(invInfos []*resource.Info) (*resource.Info, error) {
+	if len(invInfos) == 0 {
+		return nil, nil
 	}
-	obj := info.Object
-	gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
-	return object.CreateObjMetadata(info.Namespace, info.Name, gk)
+	klog.V(4).Infof("merging %d inventory objects", len(invInfos))
+	// Make the selection of the retained inventory info deterministic,
+	// choosing the first inventory object as the one to retain.
+	sort.Sort(ordering.SortableInfos(invInfos))
+	retained := invInfos[0]
+	wrapRetained := WrapInventoryObj(retained)
+	retainedObjs, err := wrapRetained.Load()
+	if err != nil {
+		return nil, err
+	}
+	// Merge all the objects in the other inventory objects into
+	// the retained objects.
+	for i := 1; i < len(invInfos); i++ {
+		merge := invInfos[i]
+		wrapMerge := WrapInventoryObj(merge)
+		mergeObjs, err := wrapMerge.Load()
+		if err != nil {
+			return nil, err
+		}
+		retainedObjs = object.Union(retainedObjs, mergeObjs)
+	}
+	if err := wrapRetained.Store(retainedObjs); err != nil {
+		return nil, err
+	}
+	retainInfo, err := wrapRetained.GetObject()
+	if err != nil {
+		return nil, err
+	}
+	// Store the merged inventory into the one retained inventory
+	// object.
+	//
+	// IMPORTANT: This must happen BEFORE deleting the other
+	// inventory objects, in order to ensure we always have
+	// access to the union of the inventory.
+	if err := cic.applyInventoryObj(retainInfo); err != nil {
+		return nil, err
+	}
+	// Finally, delete the other inventory objects.
+	for i := 1; i < len(invInfos); i++ {
+		merge := invInfos[i]
+		if err := cic.DeleteInventoryObj(merge); err != nil {
+			return nil, err
+		}
+	}
+	return retainInfo, nil
+}
+
+// applyInventoryObj applies the passed inventory object to the APIServer.
+func (cic *ClusterInventoryClient) applyInventoryObj(info *resource.Info) error {
+	if cic.dryRun {
+		klog.V(4).Infof("dry-run apply inventory object: not applied")
+		return nil
+	}
+	if info == nil {
+		return fmt.Errorf("attempting apply a nil inventory object")
+	}
+	helper := resource.NewHelper(info.Client, info.Mapping)
+	klog.V(4).Infof("replacing inventory object: %s/%s", info.Namespace, info.Name)
+	var overwrite = true
+	replacedObj, err := helper.Replace(info.Namespace, info.Name, overwrite, info.Object)
+	if err != nil {
+		return err
+	}
+	var ignoreError = true
+	return info.Refresh(replacedObj, ignoreError)
+}
+
+// createInventoryObj creates the passed inventory object on the APIServer.
+func (cic *ClusterInventoryClient) createInventoryObj(info *resource.Info) error {
+	if cic.dryRun {
+		klog.V(4).Infof("dry-run create inventory object: not created")
+		return nil
+	}
+	if info == nil {
+		return fmt.Errorf("attempting create a nil inventory object")
+	}
+	obj, err := object.InfoToObjMeta(info)
+	if err != nil {
+		return err
+	}
+	mapping, err := cic.mapper.RESTMapping(obj.GroupKind)
+	if err != nil {
+		return err
+	}
+	client, err := cic.clientFunc(mapping)
+	if err != nil {
+		return err
+	}
+	helper := resource.NewHelper(client, mapping)
+	klog.V(4).Infof("creating inventory object: %s/%s", info.Namespace, info.Name)
+	var clearResourceVersion = true
+	createdObj, err := helper.Create(info.Namespace, clearResourceVersion, info.Object, nil)
+	if err != nil {
+		return err
+	}
+	var ignoreError = true
+	return info.Refresh(createdObj, ignoreError)
+}
+
+// DeleteInventoryObj deletes the passed inventory object from the APIServer, or
+// an error if one occurs.
+func (cic *ClusterInventoryClient) DeleteInventoryObj(info *resource.Info) error {
+	if cic.dryRun {
+		klog.V(4).Infof("dry-run delete inventory object: not deleted")
+		return nil
+	}
+	if info == nil {
+		return fmt.Errorf("attempting delete a nil inventory object")
+	}
+	obj, err := object.InfoToObjMeta(info)
+	if err != nil {
+		return err
+	}
+	mapping, err := cic.mapper.RESTMapping(obj.GroupKind)
+	if err != nil {
+		return err
+	}
+	client, err := cic.clientFunc(mapping)
+	if err != nil {
+		return err
+	}
+	helper := resource.NewHelper(client, mapping)
+	klog.V(4).Infof("deleting inventory object: %s/%s", info.Namespace, info.Name)
+	_, err = helper.Delete(info.Namespace, info.Name)
+	return err
+}
+
+// SetDryRun sets whether the inventory client will mutate the inventory
+// object in the cluster.
+func (cic *ClusterInventoryClient) SetDryRun(dryRun bool) {
+	cic.dryRun = dryRun
 }

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -1,0 +1,569 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestGetClusterInventoryInfo(t *testing.T) {
+	tests := map[string]struct {
+		inv       *resource.Info
+		localObjs []object.ObjMetadata
+		isError   bool
+	}{
+		"Nil local inventory object is an error": {
+			inv:       nil,
+			localObjs: []object.ObjMetadata{},
+			isError:   true,
+		},
+		"Empty local inventory object": {
+			inv:       invInfo,
+			localObjs: []object.ObjMetadata{},
+			isError:   false,
+		},
+		"Local inventory with a single object": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod2Info),
+			},
+			isError: false,
+		},
+		"Local inventory with multiple objects": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod2Info),
+				ignoreErrInfoToObjMeta(pod3Info)},
+			isError: false,
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			fakeBuilder := FakeBuilder{}
+			fakeBuilder.SetInventoryObjs(tc.localObjs)
+			invClient.builderFunc = fakeBuilder.GetBuilder()
+			var inv *resource.Info
+			if tc.inv != nil {
+				inv = storeObjsInInventory(tc.inv, tc.localObjs)
+			}
+			clusterInv, err := invClient.getClusterInventoryInfo(inv)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error but received none")
+				}
+				return
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error received: %s", err)
+			}
+			if clusterInv != nil {
+				wrapped := WrapInventoryObj(clusterInv)
+				clusterObjs, err := wrapped.Load()
+				if err != nil {
+					t.Fatalf("unexpected error received: %s", err)
+				}
+				if !object.SetEquals(tc.localObjs, clusterObjs) {
+					t.Fatalf("expected cluster objs (%v), got (%v)", tc.localObjs, clusterObjs)
+				}
+			}
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := map[string]struct {
+		localInv    *resource.Info
+		localObjs   []object.ObjMetadata
+		clusterObjs []object.ObjMetadata
+		pruneObjs   []object.ObjMetadata
+		isError     bool
+	}{
+		"Nil local inventory object is error": {
+			localInv:    nil,
+			localObjs:   []object.ObjMetadata{},
+			clusterObjs: []object.ObjMetadata{},
+			pruneObjs:   []object.ObjMetadata{},
+			isError:     true,
+		},
+		"Cluster and local inventories empty: no prune objects; no change": {
+			localInv:    copyInventoryInfo(),
+			localObjs:   []object.ObjMetadata{},
+			clusterObjs: []object.ObjMetadata{},
+			pruneObjs:   []object.ObjMetadata{},
+			isError:     false,
+		},
+		"Cluster and local inventories same: no prune objects; no change": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			pruneObjs: []object.ObjMetadata{},
+			isError:   false,
+		},
+		"Cluster two obj, local one: prune obj": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod3Info),
+			},
+			pruneObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod3Info),
+			},
+			isError: false,
+		},
+		"Cluster multiple objs, local multiple different objs: prune objs": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod2Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod2Info),
+				ignoreErrInfoToObjMeta(pod3Info)},
+			pruneObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod3Info),
+			},
+			isError: false,
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create the local inventory object storing "tc.localObjs"
+			invClient, _ := NewInventoryClient(tf)
+			invClient.SetDryRun(true)
+			// Create a fake builder to return "tc.clusterObjs" from
+			// the cluster inventory object.
+			fakeBuilder := FakeBuilder{}
+			fakeBuilder.SetInventoryObjs(tc.clusterObjs)
+			invClient.builderFunc = fakeBuilder.GetBuilder()
+			// Call "Merge" to create the union of clusterObjs and localObjs.
+			pruneObjs, err := invClient.Merge(tc.localInv, tc.localObjs)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error but received none")
+				}
+				return
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !object.SetEquals(tc.pruneObjs, pruneObjs) {
+				t.Errorf("expected (%v) prune objs; got (%v)", tc.pruneObjs, pruneObjs)
+			}
+		})
+	}
+}
+
+func TestCreateInventory(t *testing.T) {
+	tests := map[string]struct {
+		inv       *resource.Info
+		localObjs []object.ObjMetadata
+		isError   bool
+	}{
+		"Nil local inventory object is an error": {
+			inv:       nil,
+			localObjs: []object.ObjMetadata{},
+			isError:   true,
+		},
+		"Empty local inventory object": {
+			inv:       invInfo,
+			localObjs: []object.ObjMetadata{},
+			isError:   false,
+		},
+		"Local inventory with a single object": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod2Info),
+			},
+			isError: false,
+		},
+		"Local inventory with multiple objects": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod2Info),
+				ignoreErrInfoToObjMeta(pod3Info)},
+			isError: false,
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	// The fake client must see a POST to the confimap URL.
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.Method == "POST" && cmPathRegex.Match([]byte(req.URL.Path)) {
+				b, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				cm := corev1.ConfigMap{}
+				err = runtime.DecodeInto(codec, b, &cm)
+				if err != nil {
+					return nil, err
+				}
+				bodyRC := ioutil.NopCloser(bytes.NewReader(b))
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+			}
+			return nil, nil
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			inv := tc.inv
+			if inv != nil {
+				inv = storeObjsInInventory(tc.inv, tc.localObjs)
+			}
+			err := invClient.createInventoryObj(inv)
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error received: %s", err)
+			}
+			if tc.isError && err == nil {
+				t.Fatalf("expected error but received none")
+			}
+		})
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tests := map[string]struct {
+		localInv    *resource.Info
+		localObjs   []object.ObjMetadata
+		clusterObjs []object.ObjMetadata
+		isError     bool
+	}{
+		"Local inventory nil is error": {
+			localInv:    nil,
+			localObjs:   []object.ObjMetadata{},
+			clusterObjs: []object.ObjMetadata{},
+			isError:     true,
+		},
+		"Cluster and local inventories empty: no error": {
+			localInv:    copyInventoryInfo(),
+			localObjs:   []object.ObjMetadata{},
+			clusterObjs: []object.ObjMetadata{},
+			isError:     false,
+		},
+		"Cluster and local inventories same: no error": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			isError: false,
+		},
+		"Cluster two obj, local one: no error": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod3Info),
+			},
+			isError: false,
+		},
+		"Cluster multiple objs, local multiple different objs: no error": {
+			localInv: copyInventoryInfo(),
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod2Info),
+			},
+			clusterObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod2Info),
+				ignoreErrInfoToObjMeta(pod3Info)},
+			isError: false,
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			invClient.SetDryRun(true)
+			// Create fake builder returning the cluster inventory object
+			// storing the "tc.clusterObjs" objects.
+			fakeBuilder := FakeBuilder{}
+			fakeBuilder.SetInventoryObjs(tc.clusterObjs)
+			invClient.builderFunc = fakeBuilder.GetBuilder()
+			// Call "Replace", passing in the new local inventory objects
+			err := invClient.Replace(tc.localInv, tc.localObjs)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error but received none")
+				}
+				return
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error received: %s", err)
+			}
+		})
+	}
+}
+
+func TestGetClusterObjs(t *testing.T) {
+	tests := map[string]struct {
+		localInv    *resource.Info
+		clusterObjs []object.ObjMetadata
+		isError     bool
+	}{
+		"Nil cluster inventory is error": {
+			localInv:    nil,
+			clusterObjs: []object.ObjMetadata{},
+			isError:     true,
+		},
+		"No cluster objs": {
+			localInv:    copyInventoryInfo(),
+			clusterObjs: []object.ObjMetadata{},
+			isError:     false,
+		},
+		"Single cluster obj": {
+			localInv:    copyInventoryInfo(),
+			clusterObjs: []object.ObjMetadata{ignoreErrInfoToObjMeta(pod1Info)},
+			isError:     false,
+		},
+		"Multiple cluster objs": {
+			localInv:    copyInventoryInfo(),
+			clusterObjs: []object.ObjMetadata{ignoreErrInfoToObjMeta(pod1Info), ignoreErrInfoToObjMeta(pod3Info)},
+			isError:     false,
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			// Create fake builder returning "tc.clusterObjs" from cluster inventory.
+			fakeBuilder := FakeBuilder{}
+			fakeBuilder.SetInventoryObjs(tc.clusterObjs)
+			invClient.builderFunc = fakeBuilder.GetBuilder()
+			// Call "GetClusterObjs" and compare returned cluster inventory objs to expected.
+			clusterObjs, err := invClient.GetClusterObjs(tc.localInv)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error but received none")
+				}
+				return
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error received: %s", err)
+			}
+			if !object.SetEquals(tc.clusterObjs, clusterObjs) {
+				t.Errorf("expected (%v) cluster inventory objs; got (%v)", tc.clusterObjs, clusterObjs)
+			}
+		})
+	}
+}
+
+func TestDeleteInventoryObj(t *testing.T) {
+	tests := map[string]struct {
+		inv       *resource.Info
+		localObjs []object.ObjMetadata
+	}{
+		"Nil local inventory object is an error": {
+			inv:       nil,
+			localObjs: []object.ObjMetadata{},
+		},
+		"Empty local inventory object": {
+			inv:       invInfo,
+			localObjs: []object.ObjMetadata{},
+		},
+		"Local inventory with a single object": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod2Info),
+			},
+		},
+		"Local inventory with multiple objects": {
+			inv: invInfo,
+			localObjs: []object.ObjMetadata{
+				ignoreErrInfoToObjMeta(pod1Info),
+				ignoreErrInfoToObjMeta(pod2Info),
+				ignoreErrInfoToObjMeta(pod3Info)},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.Method == "DELETE" && cmPathRegex.Match([]byte(req.URL.Path)) {
+				b, err := ioutil.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				cm := corev1.ConfigMap{}
+				err = runtime.DecodeInto(codec, b, &cm)
+				if err != nil {
+					return nil, err
+				}
+				bodyRC := ioutil.NopCloser(bytes.NewReader(b))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
+			}
+			return nil, nil
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			invClient.SetDryRun(true)
+			inv := tc.inv
+			if inv != nil {
+				inv = storeObjsInInventory(tc.inv, tc.localObjs)
+			}
+			err := invClient.DeleteInventoryObj(inv)
+			if err != nil {
+				t.Fatalf("unexpected error received: %s", err)
+			}
+		})
+	}
+}
+
+type invAndObjs struct {
+	inv     *resource.Info
+	invObjs []object.ObjMetadata
+}
+
+func TestMergeInventoryObjs(t *testing.T) {
+	pod1Obj := ignoreErrInfoToObjMeta(pod1Info)
+	pod2Obj := ignoreErrInfoToObjMeta(pod2Info)
+	pod3Obj := ignoreErrInfoToObjMeta(pod3Info)
+	tests := map[string]struct {
+		invs     []invAndObjs
+		expected []object.ObjMetadata
+	}{
+		"Single inventory object with no inventory is valid": {
+			invs: []invAndObjs{
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{},
+				},
+			},
+			expected: []object.ObjMetadata{},
+		},
+		"Single inventory object returns same objects": {
+			invs: []invAndObjs{
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod1Obj},
+				},
+			},
+			expected: []object.ObjMetadata{pod1Obj},
+		},
+		"Two inventories with the same objects returns them": {
+			invs: []invAndObjs{
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod1Obj},
+				},
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod1Obj},
+				},
+			},
+			expected: []object.ObjMetadata{pod1Obj},
+		},
+		"Two inventories with different retain the union": {
+			invs: []invAndObjs{
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod1Obj},
+				},
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod2Obj},
+				},
+			},
+			expected: []object.ObjMetadata{pod1Obj, pod2Obj},
+		},
+		"More than two inventory objects retains all objects": {
+			invs: []invAndObjs{
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod1Obj, pod2Obj},
+				},
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod2Obj},
+				},
+				{
+					inv:     copyInventoryInfo(),
+					invObjs: []object.ObjMetadata{pod3Obj},
+				},
+			},
+			expected: []object.ObjMetadata{pod1Obj, pod2Obj, pod3Obj},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+	defer tf.Cleanup()
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invClient, _ := NewInventoryClient(tf)
+			invClient.SetDryRun(true)
+			inventories := []*resource.Info{}
+			for _, i := range tc.invs {
+				inv := storeObjsInInventory(i.inv, i.invObjs)
+				inventories = append(inventories, inv)
+			}
+			retained, err := invClient.mergeClusterInventory(inventories)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			wrapped := WrapInventoryObj(retained)
+			mergedObjs, _ := wrapped.Load()
+			if !object.SetEquals(tc.expected, mergedObjs) {
+				t.Errorf("expected merged inventory objects (%v), got (%v)", tc.expected, mergedObjs)
+			}
+		})
+	}
+}
+
+func ignoreErrInfoToObjMeta(info *resource.Info) object.ObjMetadata {
+	objMeta, _ := object.InfoToObjMeta(info)
+	return objMeta
+}

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -13,14 +13,9 @@ package inventory
 
 import (
 	"fmt"
-	"hash/fnv"
-	"sort"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -38,11 +33,38 @@ type Inventory interface {
 	GetObject() (*resource.Info, error)
 }
 
+// FindInventoryObj returns the "Inventory" object (ConfigMap with
+// inventory label) if it exists, or nil if it does not exist.
+func FindInventoryObj(infos []*resource.Info) *resource.Info {
+	for _, info := range infos {
+		if IsInventoryObject(info) {
+			return info
+		}
+	}
+	return nil
+}
+
+// IsInventoryObject returns true if the passed object has the
+// inventory label.
+func IsInventoryObject(info *resource.Info) bool {
+	if info == nil {
+		return false
+	}
+	inventoryLabel, err := retrieveInventoryLabel(info)
+	if err == nil && len(inventoryLabel) > 0 {
+		return true
+	}
+	return false
+}
+
 // retrieveInventoryLabel returns the string value of the InventoryLabel
-// for the passed object. Returns error if the passed object is nil or
+// for the passed inventory object. Returns error if the passed object is nil or
 // is not a inventory object.
-func retrieveInventoryLabel(obj runtime.Object) (string, error) {
-	var inventoryLabel string
+func retrieveInventoryLabel(info *resource.Info) (string, error) {
+	if info == nil {
+		return "", fmt.Errorf("inventory info is nil")
+	}
+	obj := info.Object
 	if obj == nil {
 		return "", fmt.Errorf("inventory object is nil")
 	}
@@ -58,264 +80,49 @@ func retrieveInventoryLabel(obj runtime.Object) (string, error) {
 	return strings.TrimSpace(inventoryLabel), nil
 }
 
-// IsInventoryObject returns true if the passed object has the
-// inventory label.
-func IsInventoryObject(obj runtime.Object) bool {
-	if obj == nil {
-		return false
-	}
-	inventoryLabel, err := retrieveInventoryLabel(obj)
-	if err == nil && len(inventoryLabel) > 0 {
-		return true
-	}
-	return false
-}
-
-// FindInventoryObj returns the "Inventory" object (ConfigMap with
-// inventory label) if it exists, and a boolean describing if it was found.
-func FindInventoryObj(infos []*resource.Info) (*resource.Info, bool) {
+// splitInfos takes a slice of resource.Info objects and splits it
+// into one slice that contains the inventory object templates and
+// another one that contains the remaining resources.
+func SplitInfos(infos []*resource.Info) (*resource.Info, []*resource.Info, error) {
+	invs := make([]*resource.Info, 0)
+	resources := make([]*resource.Info, 0)
 	for _, info := range infos {
-		if info != nil && IsInventoryObject(info.Object) {
-			return info, true
-		}
-	}
-	return nil, false
-}
-
-// Adds the metadata of all objects (passed as infos) to the
-// inventory object. Returns an error if a inventory object does not
-// exist, or we are unable to successfully add the metadata to
-// the inventory object; nil otherwise. Each object is in
-// unstructured.Unstructured format.
-func AddObjsToInventory(infos []*resource.Info) error {
-	var inventoryInfo *resource.Info
-	var inventoryObj *unstructured.Unstructured
-	objMap := map[string]string{}
-	for _, info := range infos {
-		obj := info.Object
-		if IsInventoryObject(obj) {
-			// If we have more than one inventory object--error.
-			if inventoryObj != nil {
-				return fmt.Errorf("error--applying more than one inventory object")
-			}
-			var ok bool
-			inventoryObj, ok = obj.(*unstructured.Unstructured)
-			if !ok {
-				return fmt.Errorf("inventory object is not an Unstructured: %#v", inventoryObj)
-			}
-			inventoryInfo = info
+		if IsInventoryObject(info) {
+			invs = append(invs, info)
 		} else {
-			if obj == nil {
-				return fmt.Errorf("creating inventory; object is nil")
-			}
-			gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
-			objMetadata, err := object.CreateObjMetadata(info.Namespace, info.Name, gk)
-			if err != nil {
-				return err
-			}
-			objMap[objMetadata.String()] = ""
+			resources = append(resources, info)
 		}
 	}
-
-	// If we've found the inventory object, store the object metadata inventory
-	// in the inventory config map.
-	if inventoryObj == nil {
-		return fmt.Errorf("inventory object not found")
-	}
-
-	if len(objMap) > 0 {
-		// Adds the inventory map to the ConfigMap "data" section.
-		err := unstructured.SetNestedStringMap(inventoryObj.UnstructuredContent(),
-			objMap, "data")
-		if err != nil {
-			return err
-		}
-		// Adds the hash of the obj metadata strings as an annotation to the
-		// inventory object. Object metadata strings must be sorted to make hash
-		// deterministic.
-		objList := mapKeysToSlice(objMap)
-		sort.Strings(objList)
-		objsHash, err := calcInventoryHash(objList)
-		if err != nil {
-			return err
-		}
-		// Add the hash as a suffix to the inventory object's name.
-		objsHashStr := strconv.FormatUint(uint64(objsHash), 16)
-		if err := addSuffixToName(inventoryInfo, objsHashStr); err != nil {
-			return err
-		}
-		annotations := inventoryObj.GetAnnotations()
-		if annotations == nil {
-			annotations = map[string]string{}
-		}
-		annotations[common.InventoryHash] = objsHashStr
-		inventoryObj.SetAnnotations(annotations)
-	}
-	return nil
-}
-
-// CreateInventoryObj creates an inventory object based on a inventory object
-// template. The passed "resources" parameter are applied at the same time
-// as the inventory object, and metadata for each is stored in the inventory
-// object.
-func CreateInventoryObj(inventory Inventory, resources []*resource.Info) (*resource.Info, error) {
-	objMetas, err := buildObjMetadata(resources)
-	if err != nil {
-		return nil, err
-	}
-	if err = inventory.Store(objMetas); err != nil {
-		return nil, err
-	}
-	return inventory.GetObject()
-}
-
-// buildObjectMetadata returns object metadata (ObjMetadata) for the
-// passed objects (infos). The object metadata is then stored in the
-// inventory object.
-func buildObjMetadata(infos []*resource.Info) ([]object.ObjMetadata, error) {
-	objMetas := []object.ObjMetadata{}
-	for _, info := range infos {
-		obj := info.Object
-		if obj == nil {
-			return nil, fmt.Errorf("")
-		}
-		gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
-		objMeta, err := object.CreateObjMetadata(info.Namespace, info.Name, gk)
-		if err != nil {
-			return nil, err
-		}
-		objMetas = append(objMetas, *objMeta)
-	}
-	return objMetas, nil
-}
-
-// RetrieveObjsFromInventoryObj returns a slice of pointers to the
-// object metadata. This function finds the inventory object, then
-// parses the stored resource metadata into ObjMetadata structs. Returns
-// an error if there is a problem parsing the data into ObjMetadata
-// structs, or if the inventory object is not in Unstructured format; nil
-// otherwise. If a inventory object does not exist, or it does not have a
-// "data" map, then returns an empty slice and no error.
-func RetrieveObjsFromInventory(infos []*resource.Info) ([]*object.ObjMetadata, error) {
-	objs := []*object.ObjMetadata{}
-	inventoryInfo, exists := FindInventoryObj(infos)
-	if exists {
-		inventoryObj, ok := inventoryInfo.Object.(*unstructured.Unstructured)
-		if !ok {
-			err := fmt.Errorf("inventory object is not an Unstructured: %#v", inventoryObj)
-			return objs, err
-		}
-		objMap, exists, err := unstructured.NestedStringMap(inventoryObj.Object, "data")
-		if err != nil {
-			err := fmt.Errorf("error retrieving object metadata from inventory object")
-			return objs, err
-		}
-		if exists {
-			for objStr := range objMap {
-				obj, err := object.ParseObjMetadata(objStr)
-				if err != nil {
-					return objs, err
-				}
-				objs = append(objs, obj)
-			}
+	if len(invs) == 0 {
+		return nil, resources, NoInventoryObjError{}
+	} else if len(invs) > 1 {
+		return nil, resources, MultipleInventoryObjError{
+			InventoryObjectTemplates: invs,
 		}
 	}
-	return objs, nil
-}
-
-// UnionPastObjs takes a set of inventory objects (infos), returning the
-// union of the objects referenced by these inventory objects.
-// Returns an error if any of the passed objects are not inventory
-// objects, or if unable to retrieve the referenced objects from any
-// inventory object.
-func UnionPastObjs(pastInvs []*resource.Info) ([]object.ObjMetadata, error) {
-	objSet := map[string]object.ObjMetadata{}
-	for _, inv := range pastInvs {
-		wrapped := WrapInventoryObj(inv)
-		objs, err := wrapped.Load()
-		if err != nil {
-			return nil, err
-		}
-		for _, obj := range objs {
-			objSet[obj.String()] = obj // De-duping
-		}
-	}
-	pastObjs := make([]object.ObjMetadata, 0, len(objSet))
-	for _, obj := range objSet {
-		pastObjs = append(pastObjs, obj)
-	}
-	return pastObjs, nil
+	return invs[0], resources, nil
 }
 
 // ClearInventoryObj finds the inventory object in the list of objects,
-// and sets an empty inventory. Returns error if the inventory object
-// is not Unstructured, the inventory object does not exist, or if
-// we can't set the empty inventory on the inventory object. If successful,
-// returns nil.
-func ClearInventoryObj(infos []*resource.Info) error {
-	// Initially, find the inventory object ConfigMap (in Unstructured format).
-	var inventoryObj *unstructured.Unstructured
-	for _, info := range infos {
-		obj := info.Object
-		if IsInventoryObject(obj) {
-			var ok bool
-			inventoryObj, ok = obj.(*unstructured.Unstructured)
-			if !ok {
-				return fmt.Errorf("inventory object is not an Unstructured: %#v", inventoryObj)
-			}
-			break
-		}
+// and sets an empty inventory. Returns an error if once occurred.
+func ClearInventoryObj(invInfo *resource.Info) (*resource.Info, error) {
+	if invInfo == nil {
+		return nil, fmt.Errorf("clearing nil inventory object")
 	}
-	if inventoryObj == nil {
-		return fmt.Errorf("inventory object not found")
+	if !IsInventoryObject(invInfo) {
+		return nil, fmt.Errorf("attempting to clear non-inventory object")
 	}
-	// Clears the inventory map of the ConfigMap "data" section.
-	emptyMap := map[string]string{}
-	err := unstructured.SetNestedStringMap(inventoryObj.UnstructuredContent(),
-		emptyMap, "data")
-	if err != nil {
-		return err
+	wrapped := WrapInventoryObj(invInfo)
+	if err := wrapped.Store([]object.ObjMetadata{}); err != nil {
+		return nil, err
 	}
-
-	return nil
-}
-
-// calcInventoryHash returns an unsigned int32 representing the hash
-// of the obj metadata strings. If there is an error writing bytes to
-// the hash, then the error is returned; nil is returned otherwise.
-// Used to quickly identify the set of resources in the inventory object.
-func calcInventoryHash(inv []string) (uint32, error) {
-	h := fnv.New32a()
-	for _, is := range inv {
-		_, err := h.Write([]byte(is))
-		if err != nil {
-			return uint32(0), err
-		}
-	}
-	return h.Sum32(), nil
-}
-
-// retrieveInventoryHash takes a inventory object (encapsulated by
-// a resource.Info), and returns the string representing the hash
-// of the set of obj metadata; returns empty string if the inventory
-// object is not in Unstructured format, or if the hash annotation
-// does not exist.
-func retrieveInventoryHash(inventoryInfo *resource.Info) string {
-	var invHash = ""
-	inventoryObj, ok := inventoryInfo.Object.(*unstructured.Unstructured)
-	if ok {
-		annotations := inventoryObj.GetAnnotations()
-		if annotations != nil {
-			invHash = annotations[common.InventoryHash]
-		}
-	}
-	return invHash
+	return wrapped.GetObject()
 }
 
 // addSuffixToName adds the passed suffix (usually a hash) as a suffix
 // to the name of the passed object stored in the Info struct. Returns
-// an error if the object is not "*unstructured.Unstructured" or if the
-// name stored in the object differs from the name in the Info struct.
+// an error if name stored in the object differs from the name in
+// the Info struct.
 func addSuffixToName(info *resource.Info, suffix string) error {
 	if info == nil {
 		return fmt.Errorf("nil resource.Info")
@@ -330,7 +137,7 @@ func addSuffixToName(info *resource.Info, suffix string) error {
 	if name != info.Name {
 		return fmt.Errorf("inventory object (%s) and resource.Info (%s) have different names", name, info.Name)
 	}
-	// Error if name alread has suffix.
+	// Error if name already has suffix.
 	suffix = "-" + suffix
 	if strings.HasSuffix(name, suffix) {
 		return fmt.Errorf("name already has suffix: %s", name)

--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -100,7 +100,6 @@ func TestCreateObjMetadata(t *testing.T) {
 			} else if test.expected != inv.String() {
 				t.Errorf("Expected inventory\n(%s) != created inventory\n(%s)\n", test.expected, inv.String())
 			}
-
 			// Parsing back the just created inventory string to ObjMetadata,
 			// so that tests will catch any change to CreateObjMetadata that
 			// would break ParseObjMetadata.
@@ -112,7 +111,7 @@ func TestCreateObjMetadata(t *testing.T) {
 			actual, err := ParseObjMetadata(inv.String())
 			if err != nil {
 				t.Errorf("Error parsing back ObjMetadata, when it should have worked.")
-			} else if !expectedObjMetadata.Equals(actual) {
+			} else if !expectedObjMetadata.Equals(&actual) {
 				t.Errorf("Expected inventory (%s) != parsed inventory (%s)\n", expectedObjMetadata, actual)
 			}
 		}
@@ -241,6 +240,12 @@ func TestParseObjMetadata(t *testing.T) {
 			inventory: &ObjMetadata{},
 			isError:   true,
 		},
+		// Too many fields
+		{
+			invStr:    "test-namespace_test-name_apps_foo_Deployment",
+			inventory: &ObjMetadata{},
+			isError:   true,
+		},
 	}
 
 	for _, test := range tests {
@@ -248,12 +253,228 @@ func TestParseObjMetadata(t *testing.T) {
 		if !test.isError {
 			if err != nil {
 				t.Errorf("Error parsing inventory when it should have worked.")
-			} else if !test.inventory.Equals(actual) {
+			} else if !test.inventory.Equals(&actual) {
 				t.Errorf("Expected inventory (%s) != parsed inventory (%s)\n", test.inventory, actual)
 			}
 		}
 		if test.isError && err == nil {
 			t.Errorf("Should have returned an error in ParseObjMetadata()")
 		}
+	}
+}
+
+var objMeta1 = ObjMetadata{
+	GroupKind: schema.GroupKind{
+		Group: "apps",
+		Kind:  "Deployment",
+	},
+	Name:      "dep",
+	Namespace: "default",
+}
+
+var objMeta2 = ObjMetadata{
+	GroupKind: schema.GroupKind{
+		Group: "apps",
+		Kind:  "StatefulSet",
+	},
+	Name:      "dep",
+	Namespace: "default",
+}
+
+var objMeta3 = ObjMetadata{
+	GroupKind: schema.GroupKind{
+		Group: "",
+		Kind:  "Pod",
+	},
+	Name:      "pod-a",
+	Namespace: "default",
+}
+
+var objMeta4 = ObjMetadata{
+	GroupKind: schema.GroupKind{
+		Group: "",
+		Kind:  "Pod",
+	},
+	Name:      "pod-b",
+	Namespace: "default",
+}
+
+func TestHash(t *testing.T) {
+	tests := map[string]struct {
+		objs     []ObjMetadata
+		expected string
+	}{
+		"No objects gives valid hash": {
+			objs:     []ObjMetadata{},
+			expected: "811c9dc5",
+		},
+		"Single object gives valid hash": {
+			objs:     []ObjMetadata{objMeta1},
+			expected: "3715cd95",
+		},
+		"Multiple objects gives valid hash": {
+			objs:     []ObjMetadata{objMeta1, objMeta2, objMeta3},
+			expected: "d69d726a",
+		},
+		"Different ordering gives same hash": {
+			objs:     []ObjMetadata{objMeta2, objMeta3, objMeta1},
+			expected: "d69d726a",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := Hash(tc.objs)
+			if err != nil {
+				t.Fatalf("Received unexpected error: %s", err)
+			}
+			if tc.expected != actual {
+				t.Errorf("expected hash string (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSetDiff(t *testing.T) {
+	testCases := map[string]struct {
+		setA     []ObjMetadata
+		setB     []ObjMetadata
+		expected []ObjMetadata
+	}{
+		"Empty sets results in empty diff": {
+			setA:     []ObjMetadata{},
+			setB:     []ObjMetadata{},
+			expected: []ObjMetadata{},
+		},
+		"Empty subtraction set results in same set": {
+			setA:     []ObjMetadata{objMeta1, objMeta3},
+			setB:     []ObjMetadata{},
+			expected: []ObjMetadata{objMeta1, objMeta3},
+		},
+		"Empty initial set results in empty diff": {
+			setA:     []ObjMetadata{},
+			setB:     []ObjMetadata{objMeta1, objMeta3},
+			expected: []ObjMetadata{},
+		},
+		"Sets equal results in empty diff": {
+			setA:     []ObjMetadata{objMeta2, objMeta1},
+			setB:     []ObjMetadata{objMeta1, objMeta2},
+			expected: []ObjMetadata{},
+		},
+		"Basic diff": {
+			setA:     []ObjMetadata{objMeta2, objMeta1},
+			setB:     []ObjMetadata{objMeta1},
+			expected: []ObjMetadata{objMeta2},
+		},
+		"Subtract non-elements results in no change": {
+			setA:     []ObjMetadata{objMeta1},
+			setB:     []ObjMetadata{objMeta3, objMeta4},
+			expected: []ObjMetadata{objMeta1},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := SetDiff(tc.setA, tc.setB)
+			if !SetEquals(tc.expected, actual) {
+				t.Errorf("SetDiff expected set (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUnion(t *testing.T) {
+	testCases := map[string]struct {
+		setA     []ObjMetadata
+		setB     []ObjMetadata
+		expected []ObjMetadata
+	}{
+		"Empty sets results in empty union": {
+			setA:     []ObjMetadata{},
+			setB:     []ObjMetadata{},
+			expected: []ObjMetadata{},
+		},
+		"Empty second set results in same set": {
+			setA:     []ObjMetadata{objMeta1, objMeta3},
+			setB:     []ObjMetadata{},
+			expected: []ObjMetadata{objMeta1, objMeta3},
+		},
+		"Empty initial set results in empty diff": {
+			setA:     []ObjMetadata{},
+			setB:     []ObjMetadata{objMeta1, objMeta3},
+			expected: []ObjMetadata{objMeta1, objMeta3},
+		},
+		"Same sets in different order results in same set": {
+			setA:     []ObjMetadata{objMeta2, objMeta1},
+			setB:     []ObjMetadata{objMeta1, objMeta2},
+			expected: []ObjMetadata{objMeta1, objMeta2},
+		},
+		"One item overlap": {
+			setA:     []ObjMetadata{objMeta2, objMeta1},
+			setB:     []ObjMetadata{objMeta1, objMeta3},
+			expected: []ObjMetadata{objMeta1, objMeta2, objMeta3},
+		},
+		"Disjoint sets results in larger set": {
+			setA:     []ObjMetadata{objMeta1, objMeta2},
+			setB:     []ObjMetadata{objMeta3, objMeta4},
+			expected: []ObjMetadata{objMeta1, objMeta2, objMeta3, objMeta4},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := Union(tc.setA, tc.setB)
+			if !SetEquals(tc.expected, actual) {
+				t.Errorf("SetDiff expected set (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSetEquals(t *testing.T) {
+	testCases := map[string]struct {
+		setA    []ObjMetadata
+		setB    []ObjMetadata
+		isEqual bool
+	}{
+		"Empty sets results in empty union": {
+			setA:    []ObjMetadata{},
+			setB:    []ObjMetadata{},
+			isEqual: true,
+		},
+		"Empty second set results in same set": {
+			setA:    []ObjMetadata{objMeta1, objMeta3},
+			setB:    []ObjMetadata{},
+			isEqual: false,
+		},
+		"Empty initial set results in empty diff": {
+			setA:    []ObjMetadata{},
+			setB:    []ObjMetadata{objMeta1, objMeta3},
+			isEqual: false,
+		},
+		"Different ordering are equal sets": {
+			setA:    []ObjMetadata{objMeta2, objMeta1},
+			setB:    []ObjMetadata{objMeta1, objMeta2},
+			isEqual: true,
+		},
+		"One item overlap": {
+			setA:    []ObjMetadata{objMeta2, objMeta1},
+			setB:    []ObjMetadata{objMeta1, objMeta3},
+			isEqual: false,
+		},
+		"Disjoint sets results in larger set": {
+			setA:    []ObjMetadata{objMeta1, objMeta2},
+			setB:    []ObjMetadata{objMeta3, objMeta4},
+			isEqual: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := SetEquals(tc.setA, tc.setB)
+			if tc.isEqual != actual {
+				t.Errorf("SetEqual expected (%t), got (%t)", tc.isEqual, actual)
+			}
+		})
 	}
 }

--- a/pkg/ordering/sort.go
+++ b/pkg/ordering/sort.go
@@ -18,7 +18,15 @@ var _ sort.Interface = SortableInfos{}
 func (a SortableInfos) Len() int      { return len(a) }
 func (a SortableInfos) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a SortableInfos) Less(i, j int) bool {
-	return less(object.InfoToObjMeta(a[i]), object.InfoToObjMeta(a[j]))
+	first, err := object.InfoToObjMeta(a[i])
+	if err != nil {
+		return false
+	}
+	second, err := object.InfoToObjMeta(a[j])
+	if err != nil {
+		return false
+	}
+	return less(first, second)
 }
 
 type SortableMetas []object.ObjMetadata


### PR DESCRIPTION
* Updates prune algorithm to use only one inventory object (instead of multiple). We now modify the current inventory object instead of creating a new one for each apply.
* Backwards compatible previous algorithm as follows: 1) Uses the existing inventory object as the one to modify, 2) Merges multiple inventory objects into one in the (rare) case that there are multiple inventory objects.
* Updates the inventory object in two locations: the very beginning of the apply algorithm, and the very end of the prune operation.
* The first inventory update modifies the inventory to store the union of the previous apply and the current apply. The last inventory update modifies the inventory to store only the object references for the current apply.
* Errors out of the apply algorithm if unable to perform the initial inventory union update.
* This algorithm is tolerant to failures in the middle of the algorithm as long as the first inventory union update succeeds.
* Adds `Merge`, `Replace`, `Init`, and `DeleteInventoryObj` methods within the `InventoryClient` interface to update the inventory object.
* Updates e2e tests to remove lines about inventory object updates.