### PR TITLE
Add hidden server-dry-run flag

### DIFF
--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -101,7 +101,7 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	_ = cmd.Flags().MarkHidden("validate")
 	// Server-side flags are hidden for now.
 	cmdutil.AddServerSideApplyFlags(cmd)
-	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun, "NOT USED")
+	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun, "If true, submits a server-side request without persisting the resources")
 	_ = cmd.Flags().MarkHidden("server-dry-run")
 	_ = cmd.Flags().MarkHidden("server-side")
 	_ = cmd.Flags().MarkHidden("force-conflicts")

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -76,7 +76,7 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 				ch = applier.Run(ctx, infos, apply.Options{
 					EmitStatusEvents: false,
 					NoPrune:          noPrune,
-					DryRun:           true,
+					DryRun:           !applier.ApplyOptions.ServerDryRun,
 				})
 			} else {
 				ch = destroyer.Run()
@@ -92,7 +92,7 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	cmdutil.CheckErr(applier.SetFlags(cmd))
 
 	// The following flags are added, but hidden because other code
-	// dependend on them when parsing flags. These flags are hidden and unused.
+	// depend on them when parsing flags. These flags are hidden and unused.
 	var unusedBool bool
 	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
 	cmd.Flags().BoolVar(&destroyer.DryRun, "destroy", destroyer.DryRun, "If true, preview of destroy operations will be displayed.")
@@ -101,6 +101,8 @@ func NewCmdPreview(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 	_ = cmd.Flags().MarkHidden("validate")
 	// Server-side flags are hidden for now.
 	cmdutil.AddServerSideApplyFlags(cmd)
+	cmd.Flags().BoolVar(&applier.ApplyOptions.ServerDryRun, "server-dry-run", applier.ApplyOptions.ServerDryRun, "NOT USED")
+	_ = cmd.Flags().MarkHidden("server-dry-run")
 	_ = cmd.Flags().MarkHidden("server-side")
 	_ = cmd.Flags().MarkHidden("force-conflicts")
 	_ = cmd.Flags().MarkHidden("field-manager")


### PR DESCRIPTION
This flag would need to be updated when the kubectl library is updated to `--dry-run=server`, and as server-side apply is made into a first-class citizen in kapply.

I think the logic for the DryRun option is correct, since we're fine to send anything to the server as long as server-side dry-run is enabled.

Closes https://github.com/kubernetes-sigs/cli-utils/issues/197.