### PR TITLE
Added parsing to objmetadata_test.TestCreateObjMetadata

### DIFF
--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -4,6 +4,7 @@
 package object
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -97,7 +98,22 @@ func TestCreateObjMetadata(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error creating ObjMetadata when it should have worked.")
 			} else if test.expected != inv.String() {
-				t.Errorf("Expected inventory (%s) != created inventory(%s)\n", test.expected, inv.String())
+				t.Errorf("Expected inventory\n(%s) != created inventory\n(%s)\n", test.expected, inv.String())
+			}
+
+			// Parsing back the just created inventory string to ObjMetadata,
+			// so that tests will catch any change to CreateObjMetadata that
+			// would break ParseObjMetadata.
+			expectedObjMetadata := &ObjMetadata{
+				Namespace: strings.TrimSpace(test.namespace),
+				Name:      strings.TrimSpace(test.name),
+				GroupKind: test.gk,
+			}
+			actual, err := ParseObjMetadata(inv.String())
+			if err != nil {
+				t.Errorf("Error parsing back ObjMetadata, when it should have worked.")
+			} else if !expectedObjMetadata.Equals(actual) {
+				t.Errorf("Expected inventory (%s) != parsed inventory (%s)\n", expectedObjMetadata, actual)
 			}
 		}
 		if test.isError && err == nil {


### PR DESCRIPTION
This commit extends TestCreateObjMetadata. The test function does not
just verify CreateObjMetadata, but also uses ParseObjMetadata to verify
back and forth between both functions. I left specific testing of
ParseObjMetadata in place, because there might be edge cases, that
should be tested on its own.

I'm aware, that the TestCreateObjMetadata now tests two things, but I
think it makes life of maintainers and new contributors far easier.
E.g. the change I introduced in #193 would have been catched by tests,
rather than someone with a mental model of all of the code.