### PR TITLE
Server side preview

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -141,7 +141,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		// emit the events.
 		EmitStatusEvents:       emitStatusEvents,
 		NoPrune:                r.noPrune,
-		DryRun:                 false,
+		DryRunStrategy:         common.DryRunNone,
 		PrunePropagationPolicy: prunePropPolicy,
 		PruneTimeout:           r.pruneTimeout,
 	})
@@ -149,7 +149,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
-	printer.Print(ch, false)
+	printer.Print(ch, common.DryRunNone)
 	return nil
 }
 

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -33,7 +33,7 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 
 			// The printer will print updates from the channel. It will block
 			// until the channel is closed.
-			printer.Print(ch, false)
+			printer.Print(ch, destroyer.DryRunStrategy)
 		},
 	}
 

--- a/cmd/printers/printer/printer.go
+++ b/cmd/printers/printer/printer.go
@@ -3,8 +3,11 @@
 
 package printer
 
-import "sigs.k8s.io/cli-utils/pkg/apply/event"
+import (
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+)
 
 type Printer interface {
-	Print(ch <-chan event.Event, preview bool)
+	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy)
 }

--- a/cmd/printers/table/printer.go
+++ b/cmd/printers/table/printer.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/print/table"
 )
 
@@ -17,7 +18,7 @@ type Printer struct {
 	IOStreams genericclioptions.IOStreams
 }
 
-func (t *Printer) Print(ch <-chan event.Event, _ bool) {
+func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy) {
 	// Wait for the init event that will give us the set of
 	// resources.
 	var initEvent event.InitEvent

--- a/examples/alphaTestExamples/crds.md
+++ b/examples/alphaTestExamples/crds.md
@@ -133,4 +133,6 @@ expectedOutputLine "foos.custom.io"
 
 kubectl get foos.custom.io --no-headers | awk '{print $1}' > $OUTPUT/status
 expectedOutputLine "example-foo"
+
+kind delete cluster
 ```

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -106,6 +106,7 @@ spec:
         name: the-container
         ports:
         - containerPort: 8080
+          protocol: TCP
 EOF
 ```
 
@@ -163,6 +164,10 @@ Run preview to check which commands will be executed
 kapply preview $BASE > $OUTPUT/status
 
 expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured (preview)"
+
+kapply preview $BASE --server-side > $OUTPUT/status
+
+expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured, 3 serverside applied (preview-server)"
 
 # Verify that preview didn't create any resources.
 kubectl get all -n hellospace > $OUTPUT/status 2>&1
@@ -228,6 +233,14 @@ expectedOutputLine "deployment.apps/the-deployment deleted (preview)"
 expectedOutputLine "configmap/the-map2 deleted (preview)"
 
 expectedOutputLine "service/the-service deleted (preview)"
+
+kapply preview $BASE --destroy --server-side > $OUTPUT/status;
+
+expectedOutputLine "deployment.apps/the-deployment deleted (preview-server)"
+
+expectedOutputLine "configmap/the-map2 deleted (preview-server)"
+
+expectedOutputLine "service/the-service deleted (preview-server)"
 
 # Verify that preview all resources are still there after running preview.
 kubectl get --no-headers all -n hellospace | wc -l | xargs > $OUTPUT/status

--- a/examples/alphaTestExamples/pruneAndDelete.md
+++ b/examples/alphaTestExamples/pruneAndDelete.md
@@ -155,4 +155,6 @@ expectedOutputLine "configmap/secondmap prune skipped"
 
 kubectl get cm --no-headers | awk '{print $1}' > $OUTPUT/status
 expectedOutputLine "secondmap"
+
+kind delete cluster;
 ```

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/solver"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -248,8 +249,7 @@ func (r *ResourceObjects) AllIds() []object.ObjMetadata {
 func (a *Applier) Run(ctx context.Context, objects []*resource.Info, options Options) <-chan event.Event {
 	eventChannel := make(chan event.Event)
 	setDefaults(&options)
-	a.invClient.SetDryRun(options.DryRun) // client shared with prune, so sets dry-run for prune too.
-
+	a.invClient.SetDryRunStrategy(options.DryRunStrategy) // client shared with prune, so sets dry-run for prune too.
 	go func() {
 		defer close(eventChannel)
 
@@ -277,7 +277,7 @@ func (a *Applier) Run(ctx context.Context, objects []*resource.Info, options Opt
 		}).BuildTaskQueue(resourceObjects, solver.Options{
 			ReconcileTimeout:       options.ReconcileTimeout,
 			Prune:                  !options.NoPrune,
-			DryRun:                 options.DryRun,
+			DryRunStrategy:         options.DryRunStrategy,
 			PrunePropagationPolicy: options.PrunePropagationPolicy,
 			PruneTimeout:           options.PruneTimeout,
 		})
@@ -332,9 +332,9 @@ type Options struct {
 	// objects should happen after apply.
 	NoPrune bool
 
-	// DryRun defines whether changes should actually be performed,
+	// DryRunStrategy defines whether changes should actually be performed,
 	// or if it is just talk and no action.
-	DryRun bool
+	DryRunStrategy common.DryRunStrategy
 
 	// PrunePropagationPolicy defines the deletion propagation policy
 	// that should be used for pruning. If this is not provided, the

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -78,9 +78,9 @@ func (po *PruneOptions) Initialize(factory util.Factory, invClient inventory.Inv
 // Options defines a set of parameters that can be used to tune
 // the behavior of the pruner.
 type Options struct {
-	// DryRun defines whether objects should actually be pruned or if
+	// DryRunStrategy defines whether objects should actually be pruned or if
 	// we should just print what would happen without actually doing it.
-	DryRun bool
+	DryRunStrategy common.DryRunStrategy
 
 	PropagationPolicy metav1.DeletionPropagation
 }
@@ -137,7 +137,7 @@ func (po *PruneOptions) Prune(localInfos []*resource.Info, eventChannel chan<- e
 			eventChannel <- createPruneEvent(obj, event.PruneSkipped)
 			continue
 		}
-		if !o.DryRun {
+		if !o.DryRunStrategy.ClientOrServerDryRun() {
 			klog.V(4).Infof("prune object delete: %s/%s", clusterObj.Namespace, clusterObj.Name)
 			err = namespacedClient.Delete(clusterObj.Name, &metav1.DeleteOptions{})
 			if err != nil {

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/task"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
@@ -117,7 +118,29 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 			options: Options{
 				ReconcileTimeout: time.Minute,
 				Prune:            true,
-				DryRun:           true,
+				DryRunStrategy:   common.DryRunClient,
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					Objects: []*resource.Info{
+						depInfo,
+						customInfo,
+					},
+				},
+				&task.SendEventTask{},
+				&task.PruneTask{},
+				&task.SendEventTask{},
+			},
+		},
+		"multiple resources with wait, prune and server-dryrun": {
+			infos: []*resource.Info{
+				depInfo,
+				customInfo,
+			},
+			options: Options{
+				ReconcileTimeout: time.Minute,
+				Prune:            true,
+				DryRunStrategy:   common.DryRunServer,
 			},
 			expectedTasks: []taskrunner.Task{
 				&task.ApplyTask{
@@ -173,7 +196,7 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 			},
 			options: Options{
 				ReconcileTimeout: time.Minute,
-				DryRun:           true,
+				DryRunStrategy:   common.DryRunClient,
 			},
 			expectedTasks: []taskrunner.Task{
 				&task.ApplyTask{

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 )
 
 // PruneTask prunes objects from the cluster
@@ -16,7 +17,7 @@ import (
 type PruneTask struct {
 	PruneOptions      *prune.PruneOptions
 	Objects           []*resource.Info
-	DryRun            bool
+	DryRunStrategy    common.DryRunStrategy
 	PropagationPolicy metav1.DeletionPropagation
 }
 
@@ -28,7 +29,7 @@ func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		err := p.PruneOptions.Prune(p.Objects, taskContext.EventChannel(),
 			prune.Options{
-				DryRun:            p.DryRun,
+				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,
 			})
 		taskContext.TaskChannel() <- taskrunner.TaskResult{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -38,3 +38,43 @@ func RandomStr(seed int64) string {
 	randomInt := rand.Intn(maxRandInt)
 	return fmt.Sprintf("%08d", randomInt)
 }
+
+var Strategies = []DryRunStrategy{DryRunClient, DryRunServer}
+
+type DryRunStrategy int
+
+const (
+	// DryRunNone indicates the client will make all mutating calls
+	DryRunNone DryRunStrategy = iota
+
+	// DryRunClient, or client-side dry-run, indicates the client will prevent
+	// making mutating calls such as CREATE, PATCH, and DELETE
+	DryRunClient
+
+	// DryRunServer, or server-side dry-run, indicates the client will send
+	// mutating calls to the APIServer with the dry-run parameter to prevent
+	// persisting changes.
+	//
+	// Note that clients sending server-side dry-run calls should verify that
+	// the APIServer and the resource supports server-side dry-run, and otherwise
+	// clients should fail early.
+	//
+	// If a client sends a server-side dry-run call to an APIServer that doesn't
+	// support server-side dry-run, then the APIServer will persist changes inadvertently.
+	DryRunServer
+)
+
+// ClientDryRun returns true if input drs is DryRunClient
+func (drs DryRunStrategy) ClientDryRun() bool {
+	return drs == DryRunClient
+}
+
+// ServerDryRun returns true if input drs is DryRunServer
+func (drs DryRunStrategy) ServerDryRun() bool {
+	return drs == DryRunServer
+}
+
+// ClientOrServerDryRun returns true if input drs is either client or server dry run
+func (drs DryRunStrategy) ClientOrServerDryRun() bool {
+	return drs == DryRunClient || drs == DryRunServer
+}

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -5,6 +5,7 @@ package inventory
 
 import (
 	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
@@ -62,7 +63,7 @@ func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
 	return nil
 }
 
-func (fic *FakeInventoryClient) SetDryRun(dryRun bool) {}
+func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
 // SetError forces an error on the subsequent client call if it returns an error.
 func (fic *FakeInventoryClient) SetError(err error) {


### PR DESCRIPTION
@seans3 @mortent 

This PR is to introduce new flag --server to preview command. If set, the preview is run on the server side. The default UX for client-side preview remains the same. If user explicitly specifies --server flag, then the preview output looks like this.

```
$ kapply preview /DIR --server

deployment.apps/nginx created (preview-server)
1 resource(s) applied. 1 created, 0 unchanged, 0 configured (preview-server)
0 resource(s) pruned, 0 skipped (preview-server)
```