### PR TITLE
Adds random suffix to legacy default inventory name

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -3,6 +3,11 @@
 
 package common
 
+import (
+	"fmt"
+	"math/rand"
+)
+
 const (
 	// InventoryLabel is the label stored on the ConfigMap
 	// inventory object. The value of the label is a unique
@@ -22,4 +27,14 @@ const (
 	OnRemoveAnnotation = "cli-utils.sigs.k8s.io/on-remove"
 	// Resource lifecycle annotation value to prevent deletion.
 	OnRemoveKeep = "keep"
+	// Maximum random number, non-inclusive, eight digits.
+	maxRandInt = 100000000
 )
+
+// RandomStr returns an eight-digit (with leading zeros) string of a
+// random number seeded with the parameter.
+func RandomStr(seed int64) string {
+	rand.Seed(seed)
+	randomInt := rand.Intn(maxRandInt)
+	return fmt.Sprintf("%08d", randomInt)
+}

--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -16,12 +15,12 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 const (
 	manifestFilename = "inventory-template.yaml"
-	maxRandInt       = 100000000
 )
 const configMapTemplate = `# NOTE: auto-generated. Some fields should NOT be modified.
 # Date: <DATETIME>
@@ -211,9 +210,7 @@ func fileExists(path string) bool {
 func (i *InitOptions) fillInValues() string {
 	now := time.Now()
 	nowStr := now.Format("2006-01-02 15:04:05 MST")
-	rand.Seed(time.Now().UTC().UnixNano())
-	randomInt := rand.Intn(maxRandInt)
-	randomSuffix := fmt.Sprintf("%08d", randomInt)
+	randomSuffix := common.RandomStr(now.UTC().UnixNano())
 	manifestStr := configMapTemplate
 	manifestStr = strings.ReplaceAll(manifestStr, "<DATETIME>", nowStr)
 	manifestStr = strings.ReplaceAll(manifestStr, "<NAMESPACE>", i.Namespace)

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -325,6 +325,12 @@ func (cic *ClusterInventoryClient) createInventoryObj(info *resource.Info) error
 	if info == nil {
 		return fmt.Errorf("attempting create a nil inventory object")
 	}
+	// Default inventory name gets random suffix. Fixes problem where legacy
+	// inventory templates within same namespace will collide on name.
+	err := fixLegacyInventoryName(info)
+	if err != nil {
+		return err
+	}
 	obj, err := object.InfoToObjMeta(info)
 	if err != nil {
 		return err


### PR DESCRIPTION
* Adds random suffix to default legacy inventory name (e.g. simply `inventory`) during initial inventory object creation.
* Fixes a possible problem where names of inventory objects can collide in the same namespace.
* Collision can happen in the following scenario:
    1. Two packages in the same namespace (e.g. frontend, backend)
    2. User brings down both packages (e.g. `kapply destroy <frontend>`, `kapply destroy <backend>`)
    3. User brings back up both packages (e.g. `kapply apply <frontend>`, `kapply apply <backend>`). An error occurs here if the inventory templates have not been updated with another `kapply init <frontend>` or `kapply init <backend>`. Both of the legacy inventory templates have a `ConfigMap` with name `inventory`. If in the same namespace, these objects collide.