### PR TITLE
Inventory client uses factory function

### DIFF
--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -63,6 +63,11 @@ func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
 	return nil
 }
 
+// ClearInventoryObj implements InventoryClient interface function. It does nothing for now.
+func (fic *FakeInventoryClient) ClearInventoryObj(inv *resource.Info) (*resource.Info, error) {
+	return inv, nil
+}
+
 func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
 // SetError forces an error on the subsequent client call if it returns an error.

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -38,6 +38,10 @@ type Inventory interface {
 	GetObject() (*resource.Info, error)
 }
 
+// InventoryFactoryFunc creates the object which implements the Inventory
+// interface from the passed info object.
+type InventoryFactoryFunc func(*resource.Info) Inventory
+
 // FindInventoryObj returns the "Inventory" object (ConfigMap with
 // inventory label) if it exists, or nil if it does not exist.
 func FindInventoryObj(infos []*resource.Info) *resource.Info {
@@ -106,22 +110,6 @@ func SplitInfos(infos []*resource.Info) (*resource.Info, []*resource.Info, error
 		}
 	}
 	return invs[0], resources, nil
-}
-
-// ClearInventoryObj finds the inventory object in the list of objects,
-// and sets an empty inventory. Returns an error if once occurred.
-func ClearInventoryObj(invInfo *resource.Info) (*resource.Info, error) {
-	if invInfo == nil {
-		return nil, fmt.Errorf("clearing nil inventory object")
-	}
-	if !IsInventoryObject(invInfo) {
-		return nil, fmt.Errorf("attempting to clear non-inventory object")
-	}
-	wrapped := WrapInventoryObj(invInfo)
-	if err := wrapped.Store([]object.ObjMetadata{}); err != nil {
-		return nil, err
-	}
-	return wrapped.GetObject()
 }
 
 // addSuffixToName adds the passed suffix (usually a hash) as a suffix

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -354,61 +354,6 @@ func TestSplitInfos(t *testing.T) {
 	}
 }
 
-func TestClearInventoryObject(t *testing.T) {
-	pod1 := ignoreErrInfoToObjMeta(pod1Info)
-	pod3 := ignoreErrInfoToObjMeta(pod3Info)
-	inv := storeObjsInInventory(invInfo, []object.ObjMetadata{pod1, pod3})
-	tests := map[string]struct {
-		invInfo *resource.Info
-		isError bool
-	}{
-		"Nil info should error": {
-			invInfo: nil,
-			isError: true,
-		},
-		"Info with nil Object should error": {
-			invInfo: nilInfo,
-			isError: true,
-		},
-		"Single non-inventory object should error": {
-			invInfo: pod1Info,
-			isError: true,
-		},
-		"Single inventory object without data should stay cleared": {
-			invInfo: invInfo,
-			isError: false,
-		},
-		"Single inventory object with data should be cleared": {
-			invInfo: inv,
-			isError: false,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			invInfo, err := ClearInventoryObj(tc.invInfo)
-			if tc.isError {
-				if err == nil {
-					t.Errorf("Should have produced an error, but returned none.")
-				}
-			}
-			if !tc.isError {
-				if err != nil {
-					t.Fatalf("Received unexpected error: %s", err)
-				}
-				wrapped := WrapInventoryObj(invInfo)
-				objs, err := wrapped.Load()
-				if err != nil {
-					t.Fatalf("Received unexpected error: %s", err)
-				}
-				if len(objs) > 0 {
-					t.Errorf("Inventory object inventory not cleared: %#v\n", objs)
-				}
-			}
-		})
-	}
-}
-
 func TestAddSuffixToName(t *testing.T) {
 	tests := []struct {
 		info     *resource.Info


### PR DESCRIPTION
* Updates `InventoryClient` to use the inventory factory function.
* Adds `ClearInventoryObj` to `InventoryClient`, since this function needs the inventory factory function. Moves the unit tests for this function from `inventory_test.go` to `inventory-client_test.go`.
* Updates `Destroyer` to store the `InventoryClient`, since it needs it to call `ClearInventoryObj`.