### PR TITLE
Function to set inventory factory function on inventory client

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -50,7 +50,6 @@ func NewApplier(factory util.Factory, ioStreams genericclioptions.IOStreams) *Ap
 	}
 	a.infoHelperFactoryFunc = a.infoHelperFactory
 	a.InventoryFactoryFunc = inventory.WrapInventoryObj
-	a.PruneOptions.InventoryFactoryFunc = inventory.WrapInventoryObj
 	return a
 }
 
@@ -98,6 +97,8 @@ func (a *Applier) Initialize(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	// Propagate inventory factory function to inventory client
+	a.invClient.SetInventoryFactoryFunc(a.InventoryFactoryFunc)
 	err = a.PruneOptions.Initialize(a.factory, a.invClient)
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -41,14 +41,6 @@ type PruneOptions struct {
 	// structure is shared. IMPORTANT: the apply task must
 	// always complete before this prune is run.
 	currentUids sets.String
-	// The set of retrieved inventory objects (as Infos) selected
-	// by the inventory label. This set should also include the
-	// current inventory object. Stored here to make testing
-	// easier by manually setting the retrieved inventory infos.
-
-	// InventoryFactoryFunc wraps and returns an interface for the
-	// object which will load and store the inventory.
-	InventoryFactoryFunc func(*resource.Info) inventory.Inventory
 }
 
 // NewPruneOptions returns a struct (PruneOptions) encapsulating the necessary
@@ -56,7 +48,6 @@ type PruneOptions struct {
 // gathering this information.
 func NewPruneOptions(currentUids sets.String) *PruneOptions {
 	po := &PruneOptions{currentUids: currentUids}
-	po.InventoryFactoryFunc = inventory.WrapInventoryObj
 	return po
 }
 

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -193,7 +193,6 @@ func TestPrune(t *testing.T) {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
 				po := NewPruneOptions(populateObjectIds(tc.currentInfos, t))
-				po.InventoryFactoryFunc = inventory.WrapInventoryObj
 				// Set up the previously applied objects.
 				clusterObjs, _ := object.InfosToObjMetas(tc.pastInfos)
 				po.InvClient = inventory.NewFakeInventoryClient(clusterObjs)

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -70,6 +70,8 @@ func (fic *FakeInventoryClient) ClearInventoryObj(inv *resource.Info) (*resource
 
 func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
+func (fic *FakeInventoryClient) SetInventoryFactoryFunc(fn InventoryFactoryFunc) {}
+
 // SetError forces an error on the subsequent client call if it returns an error.
 func (fic *FakeInventoryClient) SetError(err error) {
 	fic.err = err

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -39,6 +39,8 @@ type InventoryClient interface {
 	ClearInventoryObj(inv *resource.Info) (*resource.Info, error)
 	// SetDryRunStrategy sets the dry run strategy on whether this we actually mutate.
 	SetDryRunStrategy(drs common.DryRunStrategy)
+	// Sets the function to create the Inventory object.
+	SetInventoryFactoryFunc(fn InventoryFactoryFunc)
 }
 
 // ClusterInventoryClient is a concrete implementation of the
@@ -407,4 +409,10 @@ func (cic *ClusterInventoryClient) ClearInventoryObj(invInfo *resource.Info) (*r
 // object in the cluster.
 func (cic *ClusterInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {
 	cic.dryRunStrategy = drs
+}
+
+// SetDryRun sets whether the inventory client will mutate the inventory
+// object in the cluster.
+func (cic *ClusterInventoryClient) SetInventoryFactoryFunc(fn InventoryFactoryFunc) {
+	cic.InventoryFactoryFunc = fn
 }


### PR DESCRIPTION
* Small PR to add function which allows setting the `InventoryFactoryFunc` on the `InventoryClient`. This must be a function, since the `InventoryClient` is an interface (we can not set a field on an interface).
* Removes unneeded `InventoryFactoryFunc` from `PruneOptions`