### PR TITLE
Fixes bug in destroy command

### DIFF
--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -63,11 +63,6 @@ func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
 	return nil
 }
 
-// ClearInventoryObj implements InventoryClient interface function. It does nothing for now.
-func (fic *FakeInventoryClient) ClearInventoryObj(inv *resource.Info) (*resource.Info, error) {
-	return inv, nil
-}
-
 func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
 func (fic *FakeInventoryClient) SetInventoryFactoryFunc(fn InventoryFactoryFunc) {}

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -34,9 +34,6 @@ type InventoryClient interface {
 	Replace(inv *resource.Info, objs []object.ObjMetadata) error
 	// DeleteInventoryObj deletes the passed inventory object from the APIServer.
 	DeleteInventoryObj(inv *resource.Info) error
-	// ClearInventoryObj clears all obj references from the passed inventory object,
-	// returning the cleared inventory object or an error.
-	ClearInventoryObj(inv *resource.Info) (*resource.Info, error)
 	// SetDryRunStrategy sets the dry run strategy on whether this we actually mutate.
 	SetDryRunStrategy(drs common.DryRunStrategy)
 	// Sets the function to create the Inventory object.
@@ -387,22 +384,6 @@ func (cic *ClusterInventoryClient) DeleteInventoryObj(info *resource.Info) error
 	klog.V(4).Infof("deleting inventory object: %s/%s", info.Namespace, info.Name)
 	_, err = helper.Delete(info.Namespace, info.Name)
 	return err
-}
-
-// ClearInventoryObj sets an empty inventory, which is used in destroy. Returns the
-// cleared inventory or an error if one occurred.
-func (cic *ClusterInventoryClient) ClearInventoryObj(invInfo *resource.Info) (*resource.Info, error) {
-	if invInfo == nil {
-		return nil, fmt.Errorf("clearing nil inventory object")
-	}
-	if !IsInventoryObject(invInfo) {
-		return nil, fmt.Errorf("attempting to clear non-inventory object")
-	}
-	wrapped := cic.InventoryFactoryFunc(invInfo)
-	if err := wrapped.Store([]object.ObjMetadata{}); err != nil {
-		return nil, err
-	}
-	return wrapped.GetObject()
 }
 
 // SetDryRun sets whether the inventory client will mutate the inventory

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -472,64 +472,6 @@ func TestDeleteInventoryObj(t *testing.T) {
 	}
 }
 
-func TestClearInventoryObject(t *testing.T) {
-	pod1 := ignoreErrInfoToObjMeta(pod1Info)
-	pod3 := ignoreErrInfoToObjMeta(pod3Info)
-	inv := storeObjsInInventory(invInfo, []object.ObjMetadata{pod1, pod3})
-	tests := map[string]struct {
-		invInfo *resource.Info
-		isError bool
-	}{
-		"Nil info should error": {
-			invInfo: nil,
-			isError: true,
-		},
-		"Info with nil Object should error": {
-			invInfo: nilInfo,
-			isError: true,
-		},
-		"Single non-inventory object should error": {
-			invInfo: pod1Info,
-			isError: true,
-		},
-		"Single inventory object without data should stay cleared": {
-			invInfo: invInfo,
-			isError: false,
-		},
-		"Single inventory object with data should be cleared": {
-			invInfo: inv,
-			isError: false,
-		},
-	}
-	tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
-	defer tf.Cleanup()
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			invClient, _ := NewInventoryClient(tf)
-			invInfo, err := invClient.ClearInventoryObj(tc.invInfo)
-			if tc.isError {
-				if err == nil {
-					t.Errorf("Should have produced an error, but returned none.")
-				}
-			}
-			if !tc.isError {
-				if err != nil {
-					t.Fatalf("Received unexpected error: %s", err)
-				}
-				wrapped := WrapInventoryObj(invInfo)
-				objs, err := wrapped.Load()
-				if err != nil {
-					t.Fatalf("Received unexpected error: %s", err)
-				}
-				if len(objs) > 0 {
-					t.Errorf("Inventory object inventory not cleared: %#v\n", objs)
-				}
-			}
-		})
-	}
-}
-
 type invAndObjs struct {
 	inv     *resource.Info
 	invObjs []object.ObjMetadata


### PR DESCRIPTION
* Fixes bug in `destroy` command. `destroy` command is currently working on accident.
* Since we've moved to a single inventory object, it does not make sense to clear the inventory object.
* Instead we should be passing an empty slice of local objects to `prune` to force the deletion of all objects.
* Moves set of `dry-run` strategy before prune to fix bug (`preview --destroy`) where dry run strategy was not set for prune.
* Manually tested. We need `--reconcile` flag for `destroy` before we can wait for objects to delete in our e2e tests.