### PR TITLE
Improve error handling

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -23,9 +23,12 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Use:                   "destroy (DIRECTORY | STDIN)",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Destroy all the resources related to configuration"),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := args
-			cmdutil.CheckErr(destroyer.Initialize(cmd, paths))
+			err := destroyer.Initialize(cmd, paths)
+			if err != nil {
+				return err
+			}
 
 			// Run the destroyer. It will return a channel where we can receive updates
 			// to keep track of progress and any issues.
@@ -33,11 +36,12 @@ func NewCmdDestroy(f util.Factory, ioStreams genericclioptions.IOStreams) *cobra
 
 			// The printer will print updates from the channel. It will block
 			// until the channel is closed.
-			printer.Print(ch, destroyer.DryRunStrategy)
+			err = printer.Print(ch, destroyer.DryRunStrategy)
+			return err
 		},
 	}
 
-	cmdutil.CheckErr(destroyer.SetFlags(cmd))
+	destroyer.SetFlags(cmd)
 
 	// The following flags are added, but hidden because other code
 	// dependencies when parsing flags. These flags are hidden and unused.

--- a/cmd/initcmd/cmdinit.go
+++ b/cmd/initcmd/cmdinit.go
@@ -6,7 +6,6 @@ package initcmd
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"sigs.k8s.io/cli-utils/pkg/config"
 )
@@ -19,9 +18,12 @@ func NewCmdInit(ioStreams genericclioptions.IOStreams) *cobra.Command {
 		Use:                   "init DIRECTORY",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a prune manifest ConfigMap as a inventory object"),
-		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(io.Complete(args))
-			cmdutil.CheckErr(io.Run())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := io.Complete(args)
+			if err != nil {
+				return err
+			}
+			return io.Run()
 		},
 	}
 	cmd.Flags().StringVarP(&io.InventoryID, "inventory-id", "i", "", "Identifier for group of applied resources. Must be composed of valid label characters.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/initcmd"
 	"sigs.k8s.io/cli-utils/cmd/preview"
 	"sigs.k8s.io/cli-utils/cmd/status"
+	"sigs.k8s.io/cli-utils/pkg/errors"
 	"sigs.k8s.io/cli-utils/pkg/util/factory"
 
 	// This is here rather than in the libraries because of
@@ -29,6 +30,10 @@ var cmd = &cobra.Command{
 	Use:   "kapply",
 	Short: "Perform cluster operations using declarative configuration",
 	Long:  "Perform cluster operations using declarative configuration",
+	// We silence error reporting from Cobra here since we want to improve
+	// the error messages coming from the commands.
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func main() {
@@ -69,7 +74,7 @@ func main() {
 	defer logs.FlushLogs()
 
 	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
+		errors.CheckErr(cmd.ErrOrStderr(), err, "kapply")
 	}
 }
 

--- a/cmd/printers/printer/printer.go
+++ b/cmd/printers/printer/printer.go
@@ -9,5 +9,5 @@ import (
 )
 
 type Printer interface {
-	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy)
+	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy) error
 }

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -113,12 +113,12 @@ func (a *Applier) Initialize(cmd *cobra.Command) error {
 // SetFlags configures the command line flags needed for apply and
 // status. This is a temporary solution as we should separate the configuration
 // of cobra flags from the Applier.
-func (a *Applier) SetFlags(cmd *cobra.Command) error {
+func (a *Applier) SetFlags(cmd *cobra.Command) {
 	a.ApplyOptions.DeleteFlags.AddFlags(cmd)
 	for _, flag := range []string{"kustomize", "filename", "recursive"} {
 		err := cmd.Flags().MarkHidden(flag)
 		if err != nil {
-			return err
+			panic(err)
 		}
 	}
 	a.ApplyOptions.RecordFlags.AddFlags(cmd)
@@ -129,7 +129,6 @@ func (a *Applier) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("timeout")
 	_ = cmd.Flags().MarkHidden("wait")
 	a.ApplyOptions.Overwrite = true
-	return nil
 }
 
 // infoHelperFactory returns a new instance of the InfoHelper.

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -219,7 +219,7 @@ func TestApplier(t *testing.T) {
 			applier := NewApplier(tf, ioStreams)
 
 			cmd := &cobra.Command{}
-			_ = applier.SetFlags(cmd)
+			applier.SetFlags(cmd)
 			var notUsedFlag bool
 			// This flag needs to be set as there is a dependency on it.
 			cmd.Flags().BoolVar(&notUsedFlag, "dry-run", notUsedFlag, "")

--- a/pkg/apply/basic_printer.go
+++ b/pkg/apply/basic_printer.go
@@ -5,7 +5,6 @@ package apply
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -13,15 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
-	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
-)
-
-const (
-	defaultExitErrorCode int = 1
-	timeoutExitErrorCode int = 3
 )
 
 // BasicPrinter is a simple implementation that just prints the events
@@ -96,7 +89,7 @@ func (sc *statusCollector) updateStatus(id object.ObjMetadata, se pollevent.Even
 // format on StdOut. As we support other printer implementations
 // this should probably be an interface.
 // This function will block until the channel is closed.
-func (b *BasicPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy) {
+func (b *BasicPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy) error {
 	printFunc := b.getPrintFunc(previewStrategy)
 	applyStats := &applyStats{}
 	statusCollector := &statusCollector{
@@ -108,7 +101,7 @@ func (b *BasicPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRu
 	for e := range ch {
 		switch e.Type {
 		case event.ErrorType:
-			b.processErrorEvent(e.ErrorEvent, statusCollector, printFunc)
+			return e.ErrorEvent.Err
 		case event.ApplyType:
 			b.processApplyEvent(e.ApplyEvent, applyStats, statusCollector, printFunc)
 		case event.StatusType:
@@ -119,27 +112,7 @@ func (b *BasicPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRu
 			b.processDeleteEvent(e.DeleteEvent, deleteStats, printFunc)
 		}
 	}
-}
-
-func (b *BasicPrinter) processErrorEvent(ee event.ErrorEvent, c *statusCollector,
-	p printFunc) {
-	p("\nFatal error: %s", ee.Err.Error())
-
-	if timeoutErr, ok := taskrunner.IsTimeoutError(ee.Err); ok {
-		for _, id := range timeoutErr.Identifiers {
-			ls, found := c.latestStatus[id]
-			if !found {
-				continue
-			}
-			if timeoutErr.Condition.Meets(ls.Resource.Status) {
-				continue
-			}
-			p("%s/%s %s %s", id.GroupKind.Kind,
-				id.Name, ls.Resource.Status, ls.Resource.Message)
-		}
-		os.Exit(timeoutExitErrorCode)
-	}
-	os.Exit(defaultExitErrorCode)
+	return nil
 }
 
 func (b *BasicPrinter) processApplyEvent(ae event.ApplyEvent, as *applyStats,

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -155,12 +155,12 @@ func (d *Destroyer) Run() <-chan event.Event {
 // SetFlags configures the command line flags needed for destroy
 // This is a temporary solution as we should separate the configuration
 // of cobra flags from the Destroyer.
-func (d *Destroyer) SetFlags(cmd *cobra.Command) error {
+func (d *Destroyer) SetFlags(cmd *cobra.Command) {
 	d.ApplyOptions.DeleteFlags.AddFlags(cmd)
 	for _, flag := range []string{"kustomize", "filename", "recursive"} {
 		err := cmd.Flags().MarkHidden(flag)
 		if err != nil {
-			return err
+			panic(err)
 		}
 	}
 	d.ApplyOptions.RecordFlags.AddFlags(cmd)
@@ -171,7 +171,6 @@ func (d *Destroyer) SetFlags(cmd *cobra.Command) error {
 	_ = cmd.Flags().MarkHidden("timeout")
 	_ = cmd.Flags().MarkHidden("wait")
 	d.ApplyOptions.Overwrite = true
-	return nil
 }
 
 // runPruneEventTransformer creates a channel for events and

--- a/pkg/apply/taskrunner/collector.go
+++ b/pkg/apply/taskrunner/collector.go
@@ -36,6 +36,7 @@ type resourceStatusCollector struct {
 type resourceStatus struct {
 	Identifier    object.ObjMetadata
 	CurrentStatus status.Status
+	Message       string
 	Generation    int64
 }
 
@@ -44,6 +45,7 @@ type resourceStatus struct {
 func (a *resourceStatusCollector) resourceStatus(r *event.ResourceStatus) {
 	if ri, found := a.resourceMap[r.Identifier]; found {
 		ri.CurrentStatus = r.Status
+		ri.Message = r.Message
 		ri.Generation = getGeneration(r)
 		a.resourceMap[r.Identifier] = ri
 	}

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -83,7 +83,7 @@ func (w *WaitTask) setTimer(taskContext *TaskContext) {
 		// to the token first.
 		case <-w.token:
 			taskContext.TaskChannel() <- TaskResult{
-				Err: TimeoutError{
+				Err: &TimeoutError{
 					Identifiers: w.Identifiers,
 					Timeout:     w.Timeout,
 					Condition:   w.Condition,

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"text/template"
+
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+const (
+	DefaultErrorExitCode = 1
+	TimeoutErrorExitCode = 3
+)
+
+var errorMsgForType map[reflect.Type]string
+var statusCodeForType map[reflect.Type]int
+
+//nolint:gochecknoinits
+func init() {
+	errorMsgForType = make(map[reflect.Type]string)
+	errorMsgForType[reflect.TypeOf(inventory.NoInventoryObjError{})] = `
+Package uninitialized. Please run "{{.cmdNameBase}} init" command.
+
+The package needs to be initialized to generate the template
+which will store state for resource sets. This state is
+necessary to perform functionality such as deleting an entire
+package or automatically deleting omitted resources (pruning).
+`
+
+	errorMsgForType[reflect.TypeOf(inventory.MultipleInventoryObjError{})] = `
+Package has multiple inventory object templates.
+
+The package should have one and only one inventory object template.
+`
+	//nolint:lll
+	errorMsgForType[reflect.TypeOf(taskrunner.TimeoutError{})] = `
+Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{printf "%d" (len .err.TimedOutResources)}} out of {{printf "%d" (len .err.Identifiers)}} resources to reach condition {{ .err.Condition}}:
+
+{{- range .err.TimedOutResources}}
+{{printf "%s/%s %s %s" .Identifier.GroupKind.Kind .Identifier.Name .Status .Message }}
+{{- end}}
+`
+
+	statusCodeForType = make(map[reflect.Type]int)
+	statusCodeForType[reflect.TypeOf(taskrunner.TimeoutError{})] = TimeoutErrorExitCode
+}
+
+// CheckErr looks up the appropriate error message and exit status for known
+// errors. It will print the information to the provided io.Writer. If we
+// don't know the error, it delegates to the error handling in cmdutil.
+func CheckErr(w io.Writer, err error, cmdNameBase string) {
+	errText, found := textForError(err, cmdNameBase)
+	if found {
+		exitStatus := findErrExitCode(err)
+		if len(errText) > 0 {
+			if !strings.HasSuffix(errText, "\n") {
+				errText += "\n"
+			}
+			fmt.Fprint(w, errText)
+		}
+		os.Exit(exitStatus)
+	}
+
+	cmdutil.CheckErr(err)
+}
+
+// textForError looks up the error message based on the type of the error.
+func textForError(baseErr error, cmdNameBase string) (string, bool) {
+	errType := findErrType(baseErr)
+	tmplText, found := errorMsgForType[errType]
+	if !found {
+		return "", false
+	}
+
+	tmpl, err := template.New("errMsg").Parse(tmplText)
+	if err != nil {
+		// Just return false here instead of the error. It will just
+		// mean a less informative error message and we rather show the
+		// original error.
+		return "", false
+	}
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, map[string]interface{}{
+		"cmdNameBase": cmdNameBase,
+		"err":         baseErr,
+	})
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(b.String()), true
+}
+
+// findErrType finds the type of the error. It returns the real type in the
+// event the error is actually a pointer to a type.
+func findErrType(err error) reflect.Type {
+	switch reflect.ValueOf(err).Kind() {
+	case reflect.Ptr:
+		// If the value of the interface is a pointer, we use the type
+		// of the real value.
+		return reflect.ValueOf(err).Elem().Type()
+	case reflect.Struct:
+		return reflect.TypeOf(err)
+	default:
+		panic("unexpected error type")
+	}
+}
+
+// findErrExitCode looks up if there is a defined error code for the provided
+// error type.
+func findErrExitCode(err error) int {
+	errType := findErrType(err)
+	if exitStatus, found := statusCodeForType[errType]; found {
+		return exitStatus
+	}
+	return DefaultErrorExitCode
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,100 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestTextForError(t *testing.T) {
+	testCases := map[string]struct {
+		err             error
+		cmdNameBase     string
+		expectFound     bool
+		expectedErrText string
+	}{
+		"kapply command base name": {
+			err:             inventory.NoInventoryObjError{},
+			cmdNameBase:     "kapply",
+			expectFound:     true,
+			expectedErrText: "Please run \"kapply init\" command.",
+		},
+		"different command base name": {
+			err:             inventory.NoInventoryObjError{},
+			cmdNameBase:     "mycommand",
+			expectFound:     true,
+			expectedErrText: "Please run \"mycommand init\" command.",
+		},
+		"known error without directives in the template": {
+			err:             inventory.MultipleInventoryObjError{},
+			cmdNameBase:     "kapply",
+			expectFound:     true,
+			expectedErrText: "Package has multiple inventory object templates.",
+		},
+		"unknown error": {
+			err:         fmt.Errorf("this is a test"),
+			cmdNameBase: "kapply",
+			expectFound: false,
+		},
+		"timeout error": {
+			err: &taskrunner.TimeoutError{
+				Timeout: 2 * time.Second,
+				Identifiers: []object.ObjMetadata{
+					{
+						GroupKind: schema.GroupKind{
+							Kind:  "Deployment",
+							Group: "apps",
+						},
+						Name: "foo",
+					},
+				},
+				Condition: taskrunner.AllCurrent,
+				TimedOutResources: []taskrunner.TimedOutResource{
+					{
+						Identifier: object.ObjMetadata{
+							GroupKind: schema.GroupKind{
+								Kind:  "Deployment",
+								Group: "apps",
+							},
+							Name: "foo",
+						},
+						Status: status.InProgressStatus,
+					},
+				},
+			},
+			cmdNameBase: "kapply",
+			expectFound: true,
+			expectedErrText: `
+Timeout after 2 seconds waiting for 1 out of 1 resources to reach condition AllCurrent:
+Deployment/foo InProgress
+`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			errText, found := textForError(tc.err, tc.cmdNameBase)
+
+			if !tc.expectFound {
+				assert.False(t, found)
+				return
+			}
+
+			assert.True(t, found)
+
+			fmt.Printf("%s\n", errText)
+			assert.Contains(t, errText, strings.TrimSpace(tc.expectedErrText))
+		})
+	}
+}

--- a/pkg/print/table/base.go
+++ b/pkg/print/table/base.go
@@ -91,12 +91,6 @@ func (t *BaseTablePrinter) PrintTable(rs ResourceStates,
 		linePrintCount += t.printSubTable(resource.SubResources(), "")
 	}
 
-	// If we have encountered an error, print that below the table.
-	if rs.Error() != nil {
-		lineCount := t.printError(rs.Error())
-		linePrintCount += lineCount
-	}
-
 	return linePrintCount
 }
 
@@ -141,14 +135,6 @@ func (t *BaseTablePrinter) printSubTable(resources []Resource,
 		linePrintCount += t.printSubTable(resource.SubResources(), prefix)
 	}
 	return linePrintCount
-}
-
-//TODO: This should be able to return the correct number of printed lines,
-// even if the error message has line breaks or is so long that it needs to
-// be wrapped over multiple lines.
-func (t *BaseTablePrinter) printError(err error) int {
-	t.printOrDie("\nFatal error: %v\n", err)
-	return 2 // This is the number of lines printed.
 }
 
 func (t *BaseTablePrinter) printOrDie(format string, a ...interface{}) {


### PR DESCRIPTION
The cobra commands defined in cli-utils is also used in kpt. So whenever we print information about other commands in the error messages, we want to let kpt override the base name of the command. An example is that we want to print `kpt live init` instead of `kapply init`. In order to do this, we should let all errors from the cobra commands bubble all the way up to the main function, such that kpt will have a chance to adjust the actual error messages. The way we currently use `cmdutil.CheckErr` in several places calls `os.Exit` inside the cobra command, which means kpt never has a chance to handle the error. 