### PR TITLE
Preview command refactored to use PreviewRunner

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,7 +59,7 @@ func main() {
 	updateHelp(names, initCmd)
 	applyCmd := apply.ApplyCommand(f, ioStreams)
 	updateHelp(names, applyCmd)
-	previewCmd := preview.NewCmdPreview(f, ioStreams)
+	previewCmd := preview.PreviewCommand(f, ioStreams)
 	updateHelp(names, previewCmd)
 	diffCmd := diff.NewCmdDiff(f, ioStreams)
 	updateHelp(names, diffCmd)


### PR DESCRIPTION
* Refactors preview command to include a `PreviewRunner` like the apply command.
* Helps expose the `Applier` and `Destroyer` to an upper layer for possible changes.
* Tested manually