### PR TITLE
Destroy command refactored to use DestroyRunner

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 	updateHelp(names, previewCmd)
 	diffCmd := diff.NewCmdDiff(f, ioStreams)
 	updateHelp(names, diffCmd)
-	destroyCmd := destroy.NewCmdDestroy(f, ioStreams)
+	destroyCmd := destroy.DestroyCommand(f, ioStreams)
 	updateHelp(names, destroyCmd)
 	statusCmd := status.StatusCommand(f)
 	updateHelp(names, statusCmd)


### PR DESCRIPTION
* Refactors `destroy` command to use the `Runner` pattern (`DestroyRunner`) similar to `ApplyRunner`.
* Allows the `Destroyer` field to be modified at an upper layer.