### PR TITLE
Allow colon in the name of RBAC resources

### DIFF
--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -437,16 +437,6 @@ func TestLegacyInventoryName(t *testing.T) {
 			isModified: false,
 			isError:    true,
 		},
-		"Info name differs from object name should return error": {
-			info: &resource.Info{
-				Namespace: testNamespace,
-				Name:      inventoryObjName,
-				Object:    &legacyInvObj,
-			},
-			invName:    inventoryObjName,
-			isModified: false,
-			isError:    true,
-		},
 		"Legacy inventory name gets random suffix": {
 			info: &resource.Info{
 				Namespace: testNamespace,


### PR DESCRIPTION
* Allows colons in the names of RBAC resources.
* Fixes: https://github.com/GoogleContainerTools/kpt/issues/899
* Does NOT allow other valid RBAC name characters (only colon).