### PR TITLE
Avoid panic if error is of unknown type

### DIFF
--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -47,6 +47,11 @@ func TestTextForError(t *testing.T) {
 			cmdNameBase: "kapply",
 			expectFound: false,
 		},
+		"unknown error type": {
+			err:         sliceError{},
+			cmdNameBase: "kapply",
+			expectFound: false,
+		},
 		"timeout error": {
 			err: &taskrunner.TimeoutError{
 				Timeout: 2 * time.Second,
@@ -92,9 +97,13 @@ Deployment/foo InProgress
 			}
 
 			assert.True(t, found)
-
-			fmt.Printf("%s\n", errText)
 			assert.Contains(t, errText, strings.TrimSpace(tc.expectedErrText))
 		})
 	}
+}
+
+type sliceError []string
+
+func (s sliceError) Error() string {
+	return "this is a test"
 }


### PR DESCRIPTION
Currently we only expect errors to be either a struct or a pointer. But errors can be of any type, so this removes the panic on unknown type.