### PR TITLE
Handle the --namespace flag

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -117,10 +117,21 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Fetch the namespace from the configloader. The source of this
+	// either the namespace flag or the context. If the namespace is provided
+	// with the flag, enforceNamespace will be true. In this case, it is
+	// an error if any of the resources in the package has a different
+	// namespace set.
+	namespace, enforceNamespace, err := r.provider.Factory().ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
 	var reader manifestreader.ManifestReader
 	readerOptions := manifestreader.ReaderOptions{
-		Factory:   r.provider.Factory(),
-		Namespace: metav1.NamespaceDefault,
+		Factory:          r.provider.Factory(),
+		Namespace:        namespace,
+		EnforceNamespace: enforceNamespace,
 	}
 	if len(args) == 0 {
 		reader = &manifestreader.StreamManifestReader{

--- a/cmd/initcmd/cmdinit.go
+++ b/cmd/initcmd/cmdinit.go
@@ -6,14 +6,15 @@ package initcmd
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"sigs.k8s.io/cli-utils/pkg/config"
 )
 
 // NewCmdInit creates the `init` command, which generates the
 // inventory object template ConfigMap for a package.
-func NewCmdInit(ioStreams genericclioptions.IOStreams) *cobra.Command {
-	io := config.NewInitOptions(ioStreams)
+func NewCmdInit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	io := config.NewInitOptions(f, ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "init DIRECTORY",
 		DisableFlagsInUseLine: true,
@@ -27,6 +28,5 @@ func NewCmdInit(ioStreams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&io.InventoryID, "inventory-id", "i", "", "Identifier for group of applied resources. Must be composed of valid label characters.")
-	cmd.Flags().StringVarP(&io.Namespace, "inventory-namespace", "", "", "namespace for the resources to be initialized")
 	return cmd
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	names := []string{"init", "apply", "preview", "diff", "destroy", "status"}
-	initCmd := initcmd.NewCmdInit(ioStreams)
+	initCmd := initcmd.NewCmdInit(f, ioStreams)
 	updateHelp(names, initCmd)
 	applyCmd := apply.ApplyCommand(f, ioStreams)
 	updateHelp(names, applyCmd)

--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/solver"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
 
 // ManifestReader defines the interface for reading a set
@@ -53,6 +54,13 @@ func setNamespaces(factory util.Factory, infos []*resource.Info,
 
 	for _, inf := range infos {
 		accessor, _ := meta.Accessor(inf.Object)
+
+		// Exclude any inventory objects here since we don't want to change
+		// their namespace.
+		if inventory.IsInventoryObject(inf) {
+			continue
+		}
+
 		// if the resource already has the namespace set, we don't
 		// need to do anything
 		if ns := accessor.GetNamespace(); ns != "" {


### PR DESCRIPTION
The `--namespace` flag is currently not used by any of the commands, but it is available as a flag. This PR updates the commands to actually use both the namespace provided in the context as well as the namespace provided with the flag. It behaves as follows:

For `kapply init`:
 * If the user has not provided a namespace for the inventory with the `--inventory-namespace` flag and none of the resources in the package has the namespace set, it will fall back to use the namespace provided with the `--namespace` flag and then to the namespace provided in the context.

For `kapply apply/preview`:
 * If a resource does not have the namespace set and the resource has namespace scope, it will fall back to use the namespace provided with the `--namespace` flag and then to the namespace provided in the context. The inventory template is ignored in this process, so this will never affect the namespace for the inventory
 * If the namespace is provided with the `--namespace` flag, it is considered an error if any of the resources (except the inventory) is in a different namespace. This is aligned with the behavior in kubectl. 

Fixes: https://github.com/GoogleContainerTools/kpt/issues/975, https://github.com/GoogleContainerTools/kpt/issues/826