### PR TITLE
Handle local config annotation

### DIFF
--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -16,6 +16,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
 
 const (
@@ -177,6 +178,13 @@ func allInSameNamespace(packageDir string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
+
+	// Filter out any resources with the LocalConfig annotation
+	nodes, err = (&filters.IsLocalConfig{}).Filter(nodes)
+	if err != nil {
+		return "", false, err
+	}
+
 	var ns string
 	for _, node := range nodes {
 		rm, err := node.GetMeta()

--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -48,6 +48,16 @@ metadata:
   name: objC
 `)
 
+var readFileD = []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: objD
+  namespace: namespaceD
+  annotations:
+    config.kubernetes.io/local-config: "true"
+`)
+
 func TestComplete(t *testing.T) {
 	tests := map[string]struct {
 		args               []string
@@ -93,6 +103,23 @@ func TestComplete(t *testing.T) {
 			args: []string{},
 			files: map[string][]byte{
 				"c_test.yaml": readFileC,
+			},
+			isError:           false,
+			expectedNamespace: "foo",
+		},
+		"Resources with the LocalConfig annotation should be ignored": {
+			args: []string{},
+			files: map[string][]byte{
+				"b_test.yaml": readFileB,
+				"d_test.yaml": readFileD,
+			},
+			isError:           false,
+			expectedNamespace: "namespaceB",
+		},
+		"If all resources have the LocalConfig annotation use the default namespace": {
+			args: []string{},
+			files: map[string][]byte{
+				"d_test.yaml": readFileD,
 			},
 			isError:           false,
 			expectedNamespace: "foo",

--- a/pkg/manifestreader/path.go
+++ b/pkg/manifestreader/path.go
@@ -45,6 +45,7 @@ func (p *PathManifestReader) Read() ([]*resource.Info, error) {
 	if err != nil {
 		return nil, err
 	}
+	infos = filterLocalConfig(infos)
 
 	err = setNamespaces(p.Factory, infos, p.Namespace, p.EnforceNamespace)
 	if err != nil {

--- a/pkg/manifestreader/stream.go
+++ b/pkg/manifestreader/stream.go
@@ -42,6 +42,7 @@ func (r *StreamManifestReader) Read() ([]*resource.Info, error) {
 	if err != nil {
 		return nil, err
 	}
+	infos = filterLocalConfig(infos)
 
 	err = setNamespaces(r.Factory, infos, r.Namespace, r.EnforceNamespace)
 	if err != nil {


### PR DESCRIPTION
This provides a way for users to tag resources that should not be applied to the cluster. Examples of this is function declarations, client-side CRs and kustomization files. 

Fixes: https://github.com/GoogleContainerTools/kpt/issues/932, https://github.com/GoogleContainerTools/kpt/issues/755