### PR TITLE
New Provider wraps kubectl factory and inventory client

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -9,12 +9,15 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/provider"
 )
 
 // GetDestroyRunner creates and returns the DestroyRunner which stores the cobra command.
 func GetDestroyRunner(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *DestroyRunner {
+	provider := provider.NewProvider(f, inventory.WrapInventoryObj)
 	r := &DestroyRunner{
-		Destroyer: apply.NewDestroyer(f, ioStreams),
+		Destroyer: apply.NewDestroyer(provider, ioStreams),
 		ioStreams: ioStreams,
 	}
 	cmd := &cobra.Command{

--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -16,11 +16,11 @@ import (
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/poller"
-	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/provider"
 )
 
 var (
@@ -221,14 +221,9 @@ deployment.apps/foo is InProgress: inProgress
 			tf := cmdtesting.NewTestFactory().WithNamespace("namespace")
 			defer tf.Cleanup()
 
+			provider := provider.NewFakeProvider(tf, tc.inventory)
 			runner := &StatusRunner{
-				factory: tf,
-
-				invClientFactoryFunc: func(c cmdutil.Factory) (inventory.InventoryClient, error) {
-					return &inventory.FakeInventoryClient{
-						Objs: tc.inventory,
-					}, nil
-				},
+				provider: provider,
 				pollerFactoryFunc: func(c cmdutil.Factory) (poller.Poller, error) {
 					return &fakePoller{tc.events}, nil
 				},

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -37,6 +37,7 @@ import (
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/provider"
 )
 
 var (
@@ -216,7 +217,8 @@ func TestApplier(t *testing.T) {
 			tf.UnstructuredClient = newFakeRESTClient(t, tc.handlers)
 
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
-			applier := NewApplier(tf, ioStreams)
+			cf := provider.NewProvider(tf, nil)                        // nil InventoryFactoryFunc since not needed
+			applier := NewApplier(cf, ioStreams)
 
 			cmd := &cobra.Command{}
 			applier.SetFlags(cmd)

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -65,8 +65,6 @@ func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
 
 func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
-func (fic *FakeInventoryClient) SetInventoryFactoryFunc(fn InventoryFactoryFunc) {}
-
 // SetError forces an error on the subsequent client call if it returns an error.
 func (fic *FakeInventoryClient) SetError(err error) {
 	fic.Err = err

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -36,8 +36,6 @@ type InventoryClient interface {
 	DeleteInventoryObj(inv *resource.Info) error
 	// SetDryRunStrategy sets the dry run strategy on whether this we actually mutate.
 	SetDryRunStrategy(drs common.DryRunStrategy)
-	// Sets the function to create the Inventory object.
-	SetInventoryFactoryFunc(fn InventoryFactoryFunc)
 }
 
 // ClusterInventoryClient is a concrete implementation of the
@@ -55,7 +53,7 @@ var _ InventoryClient = &ClusterInventoryClient{}
 
 // NewInventoryClient returns a concrete implementation of the
 // InventoryClient interface or an error.
-func NewInventoryClient(factory cmdutil.Factory) (*ClusterInventoryClient, error) {
+func NewInventoryClient(factory cmdutil.Factory, invFunc InventoryFactoryFunc) (*ClusterInventoryClient, error) {
 	var err error
 	mapper, err := factory.ToRESTMapper()
 	if err != nil {
@@ -72,7 +70,7 @@ func NewInventoryClient(factory cmdutil.Factory) (*ClusterInventoryClient, error
 		validator:            validator,
 		clientFunc:           factory.UnstructuredClientForMapping,
 		dryRunStrategy:       common.DryRunNone,
-		InventoryFactoryFunc: WrapInventoryObj,
+		InventoryFactoryFunc: invFunc,
 	}
 	return &clusterInventoryClient, nil
 }
@@ -390,10 +388,4 @@ func (cic *ClusterInventoryClient) DeleteInventoryObj(info *resource.Info) error
 // object in the cluster.
 func (cic *ClusterInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {
 	cic.dryRunStrategy = drs
-}
-
-// SetDryRun sets whether the inventory client will mutate the inventory
-// object in the cluster.
-func (cic *ClusterInventoryClient) SetInventoryFactoryFunc(fn InventoryFactoryFunc) {
-	cic.InventoryFactoryFunc = fn
 }

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -56,7 +56,7 @@ func TestGetClusterInventoryInfo(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			invClient, _ := NewInventoryClient(tf)
+			invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 			fakeBuilder := FakeBuilder{}
 			fakeBuilder.SetInventoryObjs(tc.localObjs)
 			invClient.builderFunc = fakeBuilder.GetBuilder()
@@ -160,7 +160,7 @@ func TestMerge(t *testing.T) {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
 				// Create the local inventory object storing "tc.localObjs"
-				invClient, _ := NewInventoryClient(tf)
+				invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 				invClient.SetDryRunStrategy(drs)
 				// Create a fake builder to return "tc.clusterObjs" from
 				// the cluster inventory object.
@@ -246,7 +246,7 @@ func TestCreateInventory(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			invClient, _ := NewInventoryClient(tf)
+			invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 			inv := tc.inv
 			if inv != nil {
 				inv = storeObjsInInventory(tc.inv, tc.localObjs)
@@ -322,7 +322,7 @@ func TestReplace(t *testing.T) {
 		for i := range common.Strategies {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
-				invClient, _ := NewInventoryClient(tf)
+				invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 				invClient.SetDryRunStrategy(drs)
 				// Create fake builder returning the cluster inventory object
 				// storing the "tc.clusterObjs" objects.
@@ -378,7 +378,7 @@ func TestGetClusterObjs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			invClient, _ := NewInventoryClient(tf)
+			invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 			// Create fake builder returning "tc.clusterObjs" from cluster inventory.
 			fakeBuilder := FakeBuilder{}
 			fakeBuilder.SetInventoryObjs(tc.clusterObjs)
@@ -457,7 +457,7 @@ func TestDeleteInventoryObj(t *testing.T) {
 		for i := range common.Strategies {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
-				invClient, _ := NewInventoryClient(tf)
+				invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 				invClient.SetDryRunStrategy(drs)
 				inv := tc.inv
 				if inv != nil {
@@ -555,7 +555,7 @@ func TestMergeInventoryObjs(t *testing.T) {
 		for i := range common.Strategies {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
-				invClient, _ := NewInventoryClient(tf)
+				invClient, _ := NewInventoryClient(tf, WrapInventoryObj)
 				invClient.SetDryRunStrategy(drs)
 				inventories := []*resource.Info{}
 				for _, i := range tc.invs {

--- a/pkg/provider/fake-provider.go
+++ b/pkg/provider/fake-provider.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+type FakeProvider struct {
+	factory util.Factory
+	objs    []object.ObjMetadata
+}
+
+var _ Provider = &FakeProvider{}
+
+func NewFakeProvider(f util.Factory, objs []object.ObjMetadata) *FakeProvider {
+	return &FakeProvider{
+		factory: f,
+		objs:    objs,
+	}
+}
+
+func (f *FakeProvider) Factory() util.Factory {
+	return f.factory
+}
+
+func (f *FakeProvider) InventoryClient() (inventory.InventoryClient, error) {
+	return inventory.NewFakeInventoryClient(f.objs), nil
+}
+
+func (f *FakeProvider) ToRESTMapper() (meta.RESTMapper, error) {
+	return f.factory.ToRESTMapper()
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+// Provider is an interface which wraps the kubectl factory and
+// the inventory client.
+type Provider interface {
+	Factory() util.Factory
+	InventoryClient() (inventory.InventoryClient, error)
+	ToRESTMapper() (meta.RESTMapper, error)
+}
+
+// InventoryProvider implements the Provider interface.
+type InventoryProvider struct {
+	factory        util.Factory
+	invFactoryFunc inventory.InventoryFactoryFunc
+}
+
+// NewProvider encapsulates the passed values, and returns a pointer to an Provider.
+func NewProvider(f util.Factory, invFactoryFunc inventory.InventoryFactoryFunc) *InventoryProvider {
+	return &InventoryProvider{
+		factory:        f,
+		invFactoryFunc: invFactoryFunc,
+	}
+}
+
+// Factory returns the kubectl factory.
+func (f *InventoryProvider) Factory() util.Factory {
+	return f.factory
+}
+
+// InventoryClient returns an InventoryClient created with the stored
+// factory and InventoryFactoryFunc values, or an error if one occurred.
+func (f *InventoryProvider) InventoryClient() (inventory.InventoryClient, error) {
+	return inventory.NewInventoryClient(f.factory, f.invFactoryFunc)
+}
+
+// ToRESTMapper returns a RESTMapper created by the stored kubectl factory.
+func (f *InventoryProvider) ToRESTMapper() (meta.RESTMapper, error) {
+	return f.factory.ToRESTMapper()
+}


### PR DESCRIPTION
* Creates new `Provider` interface specifically for `cli-utils` which wraps the `kubectl Factory` and the `InventoryClient`.
* Creates two concrete implementations of this new `Provider` interface: `InventoryProvider` and `FakeProvider`.
* Moves closer to dependency injection, since this `cli-utils Provider` is created at the beginning of the `cli-utils` commands.