### PR TITLE
JSON printer for apply

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
+	"sigs.k8s.io/cli-utils/cmd/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/provider"
@@ -69,8 +70,6 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := &apply.BasicPrinter{
-		IOStreams: r.ioStreams,
-	}
+	printer := printers.GetPrinter(printers.EventsPrinter, r.ioStreams)
 	return printer.Print(ch, r.Destroyer.DryRunStrategy)
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
+	"sigs.k8s.io/cli-utils/cmd/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -152,8 +153,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := &apply.BasicPrinter{
-		IOStreams: r.ioStreams,
-	}
+	printer := printers.GetPrinter(printers.EventsPrinter, r.ioStreams)
 	return printer.Print(ch, drs)
 }

--- a/cmd/printers/events/formatter.go
+++ b/cmd/printers/events/formatter.go
@@ -1,0 +1,143 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func NewFormatter(ioStreams genericclioptions.IOStreams,
+	previewStrategy common.DryRunStrategy) list.Formatter {
+	return &formatter{
+		print: getPrintFunc(ioStreams.Out, previewStrategy),
+	}
+}
+
+type formatter struct {
+	print printFunc
+}
+
+func (ef *formatter) FormatApplyEvent(ae event.ApplyEvent, as *list.ApplyStats, c list.Collector) error {
+	switch ae.Type {
+	case event.ApplyEventCompleted:
+		output := fmt.Sprintf("%d resource(s) applied. %d created, %d unchanged, %d configured",
+			as.Sum(), as.Created, as.Unchanged, as.Configured)
+		// Only print information about serverside apply if some of the
+		// resources actually were applied serverside.
+		if as.ServersideApplied > 0 {
+			output += fmt.Sprintf(", %d serverside applied", as.ServersideApplied)
+		}
+		ef.print(output)
+		for id, se := range c.LatestStatus() {
+			ef.printResourceStatus(id, se)
+		}
+	case event.ApplyEventResourceUpdate:
+		obj := ae.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		name := getName(obj)
+		ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name),
+			strings.ToLower(ae.Operation.String()))
+	}
+	return nil
+}
+
+func (ef *formatter) FormatStatusEvent(se pollevent.Event, _ list.Collector) error {
+	switch se.EventType {
+	case pollevent.ResourceUpdateEvent:
+		id := se.Resource.Identifier
+		ef.printResourceStatus(id, se)
+	case pollevent.ErrorEvent:
+		id := se.Resource.Identifier
+		gk := id.GroupKind
+		ef.print("%s error: %s\n", resourceIDToString(gk, id.Name),
+			se.Error.Error())
+	case pollevent.CompletedEvent:
+		ef.print("all resources has reached the Current status")
+	}
+	return nil
+}
+
+func (ef *formatter) FormatPruneEvent(pe event.PruneEvent, ps *list.PruneStats) error {
+	switch pe.Type {
+	case event.PruneEventCompleted:
+		ef.print("%d resource(s) pruned, %d skipped", ps.Pruned, ps.Skipped)
+	case event.PruneEventResourceUpdate:
+		obj := pe.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		name := getName(obj)
+		switch pe.Operation {
+		case event.Pruned:
+			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "pruned")
+		case event.PruneSkipped:
+			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "prune skipped")
+		}
+	}
+	return nil
+}
+
+func (ef *formatter) FormatDeleteEvent(de event.DeleteEvent, ds *list.DeleteStats) error {
+	switch de.Type {
+	case event.DeleteEventCompleted:
+		ef.print("%d resource(s) deleted, %d skipped", ds.Deleted, ds.Skipped)
+	case event.DeleteEventResourceUpdate:
+		obj := de.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		name := getName(obj)
+		switch de.Operation {
+		case event.Deleted:
+			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "deleted")
+		case event.DeleteSkipped:
+			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "delete skipped")
+		}
+	}
+	return nil
+}
+
+func (ef *formatter) FormatErrorEvent(_ event.ErrorEvent) error {
+	return nil
+}
+
+func (ef *formatter) printResourceStatus(id object.ObjMetadata, se pollevent.Event) {
+	ef.print("%s is %s: %s", resourceIDToString(id.GroupKind, id.Name),
+		se.Resource.Status.String(), se.Resource.Message)
+}
+
+func getName(obj runtime.Object) string {
+	if acc, err := meta.Accessor(obj); err == nil {
+		if n := acc.GetName(); len(n) > 0 {
+			return n
+		}
+	}
+	return "<unknown>"
+}
+
+// resourceIDToString returns the string representation of a GroupKind and a resource name.
+func resourceIDToString(gk schema.GroupKind, name string) string {
+	return fmt.Sprintf("%s/%s", strings.ToLower(gk.String()), name)
+}
+
+type printFunc func(format string, a ...interface{})
+
+func getPrintFunc(w io.Writer, previewStrategy common.DryRunStrategy) printFunc {
+	return func(format string, a ...interface{}) {
+		if previewStrategy.ClientDryRun() {
+			format += " (preview)"
+		} else if previewStrategy.ServerDryRun() {
+			format += " (preview-server)"
+		}
+		fmt.Fprintf(w, format+"\n", a...)
+	}
+}

--- a/cmd/printers/events/formatter_test.go
+++ b/cmd/printers/events/formatter_test.go
@@ -1,0 +1,288 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func TestFormatter_FormatApplyEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.ApplyEvent
+		applyStats      *list.ApplyStats
+		statusCollector list.Collector
+		expected        string
+	}{
+		"resource created without no dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.ApplyEvent{
+				Operation: event.Created,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep created",
+		},
+		"resource updated with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.ApplyEvent{
+				Operation: event.Configured,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep configured (preview)",
+		},
+		"resource updated with server dryrun": {
+			previewStrategy: common.DryRunServer,
+			event: event.ApplyEvent{
+				Operation: event.Configured,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("batch", "CronJob", "foo", "my-cron"),
+			},
+			expected: "cronjob.batch/my-cron configured (preview-server)",
+		},
+		"completed event": {
+			previewStrategy: common.DryRunNone,
+			event: event.ApplyEvent{
+				Type: event.ApplyEventCompleted,
+			},
+			applyStats: &list.ApplyStats{
+				ServersideApplied: 1,
+			},
+			statusCollector: &fakeCollector{
+				m: map[object.ObjMetadata]pollevent.Event{
+					object.ObjMetadata{ //nolint:gofmt
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "my-dep",
+					}: {
+						Resource: &pollevent.ResourceStatus{
+							Status:  status.CurrentStatus,
+							Message: "Resource is Current",
+						},
+					},
+				},
+			},
+			expected: `
+1 resource(s) applied. 0 created, 0 unchanged, 0 configured, 1 serverside applied
+deployment.apps/my-dep is Current: Resource is Current
+`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatApplyEvent(tc.event, tc.applyStats, tc.statusCollector)
+			assert.NoError(t, err)
+
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+		})
+	}
+}
+
+func TestFormatter_FormatStatusEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           pollevent.Event
+		statusCollector list.Collector
+		expected        string
+	}{
+		"resource update with Current status": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.ResourceUpdateEvent,
+				Resource: &pollevent.ResourceStatus{
+					Identifier: object.ObjMetadata{
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "bar",
+					},
+					Status:  status.CurrentStatus,
+					Message: "Resource is Current",
+				},
+			},
+			expected: "deployment.apps/bar is Current: Resource is Current",
+		},
+		"status event with error": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.ErrorEvent,
+				Resource: &pollevent.ResourceStatus{
+					Identifier: object.ObjMetadata{
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "bar",
+					},
+				},
+				Error: fmt.Errorf("this is a test error"),
+			},
+			expected: "deployment.apps/bar error: this is a test error",
+		},
+		"status event with completed type": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.CompletedEvent,
+			},
+			expected: "all resources has reached the Current status",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatStatusEvent(tc.event, tc.statusCollector)
+			assert.NoError(t, err)
+
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+		})
+	}
+}
+
+func TestFormatter_FormatPruneEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.PruneEvent
+		pruneStats      *list.PruneStats
+		expected        string
+	}{
+		"resource pruned without no dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.PruneEvent{
+				Operation: event.Pruned,
+				Type:      event.PruneEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep pruned",
+		},
+		"resource skipped with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.PruneEvent{
+				Operation: event.PruneSkipped,
+				Type:      event.PruneEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep prune skipped (preview)",
+		},
+		"prune event with completed status": {
+			previewStrategy: common.DryRunNone,
+			event: event.PruneEvent{
+				Type: event.PruneEventCompleted,
+			},
+			pruneStats: &list.PruneStats{
+				Pruned:  1,
+				Skipped: 2,
+			},
+			expected: "1 resource(s) pruned, 2 skipped",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatPruneEvent(tc.event, tc.pruneStats)
+			assert.NoError(t, err)
+
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+		})
+	}
+}
+
+func TestFormatter_FormatDeleteEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.DeleteEvent
+		deleteStats     *list.DeleteStats
+		statusCollector list.Collector
+		expected        string
+	}{
+		"resource deleted without no dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.DeleteEvent{
+				Operation: event.Deleted,
+				Type:      event.DeleteEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep deleted",
+		},
+		"resource skipped with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.DeleteEvent{
+				Operation: event.DeleteSkipped,
+				Type:      event.DeleteEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep delete skipped (preview)",
+		},
+		"delete event with completed status": {
+			previewStrategy: common.DryRunNone,
+			event: event.DeleteEvent{
+				Type: event.DeleteEventCompleted,
+			},
+			deleteStats: &list.DeleteStats{
+				Deleted: 1,
+				Skipped: 2,
+			},
+			expected: "1 resource(s) deleted, 2 skipped",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatDeleteEvent(tc.event, tc.deleteStats)
+			assert.NoError(t, err)
+
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(out.String()))
+		})
+	}
+}
+
+func createObject(group, kind, namespace, name string) runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/v1", group),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+type fakeCollector struct {
+	m map[object.ObjMetadata]pollevent.Event
+}
+
+func (f *fakeCollector) LatestStatus() map[object.ObjMetadata]pollevent.Event {
+	return f.m
+}

--- a/cmd/printers/events/printer.go
+++ b/cmd/printers/events/printer.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/cmd/printers/printer"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
+	return &list.BaseListPrinter{
+		IOStreams:        ioStreams,
+		FormatterFactory: NewFormatter,
+	}
+}

--- a/cmd/printers/json/doc.go
+++ b/cmd/printers/json/doc.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package json provides a printer that outputs the eventstream in json
+// format. Each event is printed as a json object, so the output will
+// appear as a stream of json objects, each representing a single event.
+//
+// Every event will contain the following properties:
+//  * timestamp: RFC3339-formatted timestamp describing when the event happened.
+//  * type: Describes the type of the operation which the event is related to. Values
+//    can be apply, status, prune, delete, or error.
+//  * eventType: Describes the type of the event. The set of possible values depends on the
+//    the value of the type field.
+//
+// All the different types have a similar structure, with the exception of the
+// error type. There is one event type pertaining to a specific resource, it being that
+// it is applied, pruned or its status was updated, and there is a separate event type
+// when all resources have been applied, deleted and so on. For any event that
+// pertains to a particular resource, the fields group, kind, name and namespace
+// will always be present.
+//
+// Events of type apply can have two different values for eventType, each which comes
+// with a specific set of fields:
+//  * resourceApplied: A resource has been applied to the cluster.
+//    * fields identifying the resource.
+//    * operation: The operation that was performed on the resource. Must be one of
+//      created, configured, unchanged and serversideApplied.
+//  * completed: All resources have been applied.
+//    * count: Total number of resources applied
+//    * createdCount: Number of resources created.
+//    * configuredCount: Number of resources configured.
+//    * unchangedCount: Number of resources unchanged.
+//    * serversideAppliedCount: Number of resources applied serverside.
+//
+// Events of type status is a notification when either the status of resource
+// has changed, or when a set of resources has reached their desired status. Events
+// of type status can have three different values for eventType:
+//  * resourceStatus: The status has changed for a resource.
+//    * fields identifying the resource.
+//    * status: The new status for the resource.
+//    * message: Text that provides more information about the resource status.
+//  * completed: All resources have reached the desired status.
+//  * error: An error occurred when trying to get the status for a resource.
+//    * fields identifying the resource.
+//    * error: The error message.
+//
+// Events of type prune can have two different values for eventType, each which comes
+// with a specific set of fields:
+//  * resourcePruned: A resource has been pruned or was intended to be pruned but has been
+//    skipped due to the presence of a lifecycle directive.
+//    * fields identifying the resource.
+//    * operation: The operation that was performed on the resource. Must be one
+//      of pruned or skipped.
+//  * completed: All resources have been pruned or skipped.
+//    * count: Total number of resources pruned or skipped.
+//    * prunedCount: Number of resources pruned.
+//    * skippedCount: Number of resources skipped.
+//
+// Events of type delete can have two different values for eventType, each which comes
+// with a specific set of fields:
+//  * resourceDeleted: A resource has been deleted or was intended to be deleted but has been
+//    skipped due to the presence of a lifecycle directive.
+//    * fields identifying the resource.
+//    * operation: The operation that was performed on the resource. Must be one
+//      of deleted or skipped.
+//  * completed: All resources have been deleted or skipped.
+//    * count: Total number of resources deleted or skipped.
+//    * deletedCount: Number of resources deleted.
+//    * skippedCount: Number of resources skipped.
+//
+// Events of type error means there is an unrecoverable error and further
+// processing will stop. Only a single value for eventType is possible:
+//  * error: A fatal error has happened.
+//    * error: The error message.
+package json

--- a/cmd/printers/json/formatter.go
+++ b/cmd/printers/json/formatter.go
@@ -1,0 +1,170 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func NewFormatter(ioStreams genericclioptions.IOStreams,
+	previewStrategy common.DryRunStrategy) list.Formatter {
+	return &formatter{
+		ioStreams:       ioStreams,
+		previewStrategy: previewStrategy,
+	}
+}
+
+type formatter struct {
+	previewStrategy common.DryRunStrategy
+	ioStreams       genericclioptions.IOStreams
+}
+
+func (jf *formatter) FormatApplyEvent(ae event.ApplyEvent, as *list.ApplyStats, c list.Collector) error {
+	switch ae.Type {
+	case event.ApplyEventCompleted:
+		if err := jf.printEvent("apply", "completed", map[string]interface{}{
+			"count":           as.Sum(),
+			"createdCount":    as.Created,
+			"unchangedCount":  as.Unchanged,
+			"configuredCount": as.Configured,
+			"serverSideCount": as.ServersideApplied,
+		}); err != nil {
+			return err
+		}
+
+		for id, se := range c.LatestStatus() {
+			if err := jf.printResourceStatus(id, se); err != nil {
+				return err
+			}
+		}
+	case event.ApplyEventResourceUpdate:
+		obj := ae.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return jf.printEvent("apply", "resourceApplied", map[string]interface{}{
+			"group":     gvk.Group,
+			"kind":      gvk.Kind,
+			"namespace": getNamespace(obj),
+			"name":      getName(obj),
+			"operation": ae.Operation.String(),
+		})
+	}
+	return nil
+}
+
+func (jf *formatter) FormatStatusEvent(se pollevent.Event, _ list.Collector) error {
+	switch se.EventType {
+	case pollevent.ResourceUpdateEvent:
+		id := se.Resource.Identifier
+		return jf.printResourceStatus(id, se)
+	case pollevent.ErrorEvent:
+		id := se.Resource.Identifier
+		return jf.printEvent("status", "error", map[string]interface{}{
+			"group":     id.GroupKind.Group,
+			"kind":      id.GroupKind.Kind,
+			"namespace": id.Namespace,
+			"name":      id.Name,
+			"error":     se.Error.Error(),
+		})
+	case pollevent.CompletedEvent:
+		return jf.printEvent("status", "completed", map[string]interface{}{})
+	}
+	return nil
+}
+
+func (jf *formatter) printResourceStatus(id object.ObjMetadata, se pollevent.Event) error {
+	return jf.printEvent("status", "resourceStatus",
+		map[string]interface{}{
+			"group":     id.GroupKind.Group,
+			"kind":      id.GroupKind.Kind,
+			"namespace": id.Namespace,
+			"name":      id.Name,
+			"status":    se.Resource.Status.String(),
+			"message":   se.Resource.Message,
+		})
+}
+
+func (jf *formatter) FormatPruneEvent(pe event.PruneEvent, ps *list.PruneStats) error {
+	switch pe.Type {
+	case event.PruneEventCompleted:
+		return jf.printEvent("prune", "completed", map[string]interface{}{
+			"pruned":  ps.Pruned,
+			"skipped": ps.Skipped,
+		})
+	case event.PruneEventResourceUpdate:
+		obj := pe.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return jf.printEvent("prune", "resourcePruned", map[string]interface{}{
+			"group":     gvk.Group,
+			"kind":      gvk.Kind,
+			"namespace": getNamespace(obj),
+			"name":      getName(obj),
+			"operation": pe.Operation.String(),
+		})
+	}
+	return nil
+}
+
+func (jf *formatter) FormatDeleteEvent(de event.DeleteEvent, ds *list.DeleteStats) error {
+	switch de.Type {
+	case event.DeleteEventCompleted:
+		return jf.printEvent("delete", "completed", map[string]interface{}{
+			"deleted": ds.Deleted,
+			"skipped": ds.Skipped,
+		})
+	case event.DeleteEventResourceUpdate:
+		obj := de.Object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return jf.printEvent("delete", "resourceDeleted", map[string]interface{}{
+			"group":     gvk.Group,
+			"kind":      gvk.Kind,
+			"namespace": getNamespace(obj),
+			"name":      getName(obj),
+			"operation": de.Operation.String(),
+		})
+	}
+	return nil
+}
+
+func (jf *formatter) FormatErrorEvent(ee event.ErrorEvent) error {
+	return jf.printEvent("error", "error", map[string]interface{}{
+		"error": ee.Err.Error(),
+	})
+}
+
+func (jf *formatter) printEvent(t, eventType string, content map[string]interface{}) error {
+	m := make(map[string]interface{})
+	m["timestamp"] = time.Now().UTC().Format(time.RFC3339)
+	m["type"] = t
+	m["eventType"] = eventType
+	for key, val := range content {
+		m[key] = val
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(jf.ioStreams.Out, string(b)+"\n")
+	return err
+}
+
+func getName(obj runtime.Object) string {
+	acc, _ := meta.Accessor(obj)
+	return acc.GetName()
+}
+
+func getNamespace(obj runtime.Object) string {
+	acc, _ := meta.Accessor(obj)
+	return acc.GetNamespace()
+}

--- a/cmd/printers/json/formatter_test.go
+++ b/cmd/printers/json/formatter_test.go
@@ -1,0 +1,445 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func TestFormatter_FormatApplyEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.ApplyEvent
+		applyStats      *list.ApplyStats
+		statusCollector list.Collector
+		expected        []map[string]interface{}
+	}{
+		"resource created without dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.ApplyEvent{
+				Operation: event.Created,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: []map[string]interface{}{
+				{
+					"eventType": "resourceApplied",
+					"group":     "apps",
+					"kind":      "Deployment",
+					"name":      "my-dep",
+					"namespace": "default",
+					"operation": "Created",
+					"timestamp": "",
+					"type":      "apply",
+				},
+			},
+		},
+		"resource updated with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.ApplyEvent{
+				Operation: event.Configured,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: []map[string]interface{}{
+				{
+					"eventType": "resourceApplied",
+					"group":     "apps",
+					"kind":      "Deployment",
+					"name":      "my-dep",
+					"namespace": "",
+					"operation": "Configured",
+					"timestamp": "",
+					"type":      "apply",
+				},
+			},
+		},
+		"resource updated with server dryrun": {
+			previewStrategy: common.DryRunServer,
+			event: event.ApplyEvent{
+				Operation: event.Configured,
+				Type:      event.ApplyEventResourceUpdate,
+				Object:    createObject("batch", "CronJob", "foo", "my-cron"),
+			},
+			expected: []map[string]interface{}{
+				{
+					"eventType": "resourceApplied",
+					"group":     "batch",
+					"kind":      "CronJob",
+					"name":      "my-cron",
+					"namespace": "foo",
+					"operation": "Configured",
+					"timestamp": "",
+					"type":      "apply",
+				},
+			},
+		},
+		"completed event": {
+			previewStrategy: common.DryRunNone,
+			event: event.ApplyEvent{
+				Type: event.ApplyEventCompleted,
+			},
+			applyStats: &list.ApplyStats{
+				ServersideApplied: 1,
+			},
+			statusCollector: &fakeCollector{
+				m: map[object.ObjMetadata]pollevent.Event{
+					object.ObjMetadata{ //nolint:gofmt
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "my-dep",
+					}: {
+						Resource: &pollevent.ResourceStatus{
+							Status:  status.CurrentStatus,
+							Message: "Resource is Current",
+						},
+					},
+				},
+			},
+			expected: []map[string]interface{}{
+				{
+					"configuredCount": 0,
+					"count":           1,
+					"createdCount":    0,
+					"eventType":       "completed",
+					"serverSideCount": 1,
+					"type":            "apply",
+					"unchangedCount":  0,
+					"timestamp":       "",
+				},
+				{
+					"eventType": "resourceStatus",
+					"group":     "apps",
+					"kind":      "Deployment",
+					"message":   "Resource is Current",
+					"name":      "my-dep",
+					"namespace": "foo",
+					"status":    "Current",
+					"timestamp": "",
+					"type":      "status",
+				},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatApplyEvent(tc.event, tc.applyStats, tc.statusCollector)
+			assert.NoError(t, err)
+
+			objects := strings.Split(strings.TrimSpace(out.String()), "\n")
+
+			if !assert.Equal(t, len(tc.expected), len(objects)) {
+				t.FailNow()
+			}
+			for i := range tc.expected {
+				assertOutput(t, tc.expected[i], objects[i])
+			}
+		})
+	}
+}
+
+func TestFormatter_FormatStatusEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           pollevent.Event
+		statusCollector list.Collector
+		expected        map[string]interface{}
+	}{
+		"resource update with Current status": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.ResourceUpdateEvent,
+				Resource: &pollevent.ResourceStatus{
+					Identifier: object.ObjMetadata{
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "bar",
+					},
+					Status:  status.CurrentStatus,
+					Message: "Resource is Current",
+				},
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourceStatus",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"message":   "Resource is Current",
+				"name":      "bar",
+				"namespace": "foo",
+				"status":    "Current",
+				"timestamp": "",
+				"type":      "status",
+			},
+		},
+		"status event with error": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.ErrorEvent,
+				Resource: &pollevent.ResourceStatus{
+					Identifier: object.ObjMetadata{
+						GroupKind: schema.GroupKind{
+							Group: "apps",
+							Kind:  "Deployment",
+						},
+						Namespace: "foo",
+						Name:      "bar",
+					},
+				},
+				Error: fmt.Errorf("this is a test error"),
+			},
+			expected: map[string]interface{}{
+				"error":     "this is a test error",
+				"eventType": "error",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "bar",
+				"namespace": "foo",
+				"timestamp": "",
+				"type":      "status",
+			},
+		},
+		"status event with completed type": {
+			previewStrategy: common.DryRunNone,
+			event: pollevent.Event{
+				EventType: pollevent.CompletedEvent,
+			},
+			expected: map[string]interface{}{
+				"eventType": "completed",
+				"timestamp": "",
+				"type":      "status",
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatStatusEvent(tc.event, tc.statusCollector)
+			assert.NoError(t, err)
+
+			assertOutput(t, tc.expected, out.String())
+		})
+	}
+}
+
+func TestFormatter_FormatPruneEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.PruneEvent
+		pruneStats      *list.PruneStats
+		expected        map[string]interface{}
+	}{
+		"resource pruned without dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.PruneEvent{
+				Operation: event.Pruned,
+				Type:      event.PruneEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourcePruned",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "my-dep",
+				"namespace": "default",
+				"operation": "Pruned",
+				"timestamp": "",
+				"type":      "prune",
+			},
+		},
+		"resource skipped with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.PruneEvent{
+				Operation: event.PruneSkipped,
+				Type:      event.PruneEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourcePruned",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "my-dep",
+				"namespace": "",
+				"operation": "PruneSkipped",
+				"timestamp": "",
+				"type":      "prune",
+			},
+		},
+		"prune event with completed status": {
+			previewStrategy: common.DryRunNone,
+			event: event.PruneEvent{
+				Type: event.PruneEventCompleted,
+			},
+			pruneStats: &list.PruneStats{
+				Pruned:  1,
+				Skipped: 2,
+			},
+			expected: map[string]interface{}{
+				"eventType": "completed",
+				"skipped":   2,
+				"pruned":    1,
+				"timestamp": "",
+				"type":      "prune",
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatPruneEvent(tc.event, tc.pruneStats)
+			assert.NoError(t, err)
+
+			assertOutput(t, tc.expected, out.String())
+		})
+	}
+}
+
+func TestFormatter_FormatDeleteEvent(t *testing.T) {
+	testCases := map[string]struct {
+		previewStrategy common.DryRunStrategy
+		event           event.DeleteEvent
+		deleteStats     *list.DeleteStats
+		statusCollector list.Collector
+		expected        map[string]interface{}
+	}{
+		"resource deleted without no dryrun": {
+			previewStrategy: common.DryRunNone,
+			event: event.DeleteEvent{
+				Operation: event.Deleted,
+				Type:      event.DeleteEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourceDeleted",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "my-dep",
+				"namespace": "default",
+				"operation": "Deleted",
+				"timestamp": "",
+				"type":      "delete",
+			},
+		},
+		"resource skipped with client dryrun": {
+			previewStrategy: common.DryRunClient,
+			event: event.DeleteEvent{
+				Operation: event.DeleteSkipped,
+				Type:      event.DeleteEventResourceUpdate,
+				Object:    createObject("apps", "Deployment", "", "my-dep"),
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourceDeleted",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "my-dep",
+				"namespace": "",
+				"operation": "DeleteSkipped",
+				"timestamp": "",
+				"type":      "delete",
+			},
+		},
+		"delete event with completed status": {
+			previewStrategy: common.DryRunNone,
+			event: event.DeleteEvent{
+				Type: event.DeleteEventCompleted,
+			},
+			deleteStats: &list.DeleteStats{
+				Deleted: 1,
+				Skipped: 2,
+			},
+			expected: map[string]interface{}{
+				"deleted":   1,
+				"eventType": "completed",
+				"skipped":   2,
+				"timestamp": "",
+				"type":      "delete",
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			ioStreams, _, out, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+			formatter := NewFormatter(ioStreams, tc.previewStrategy)
+			err := formatter.FormatDeleteEvent(tc.event, tc.deleteStats)
+			assert.NoError(t, err)
+
+			assertOutput(t, tc.expected, out.String())
+		})
+	}
+}
+
+func assertOutput(t *testing.T, expectedMap map[string]interface{}, actual string) bool {
+	var m map[string]interface{}
+	err := json.Unmarshal([]byte(actual), &m)
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	if _, found := expectedMap["timestamp"]; found {
+		if _, ok := m["timestamp"]; ok {
+			delete(expectedMap, "timestamp")
+			delete(m, "timestamp")
+		} else {
+			t.Error("expected to find key 'timestamp', but didn't")
+			return false
+		}
+	}
+
+	for key, val := range m {
+		if floatVal, ok := val.(float64); ok {
+			m[key] = int(floatVal)
+		}
+	}
+
+	return assert.Equal(t, expectedMap, m)
+}
+
+func createObject(group, kind, namespace, name string) runtime.Object {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": fmt.Sprintf("%s/v1", group),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+type fakeCollector struct {
+	m map[object.ObjMetadata]pollevent.Event
+}
+
+func (f *fakeCollector) LatestStatus() map[object.ObjMetadata]pollevent.Event {
+	return f.m
+}

--- a/cmd/printers/json/printer.go
+++ b/cmd/printers/json/printer.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/cmd/printers/printer"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
+)
+
+func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
+	return &list.BaseListPrinter{
+		IOStreams:        ioStreams,
+		FormatterFactory: NewFormatter,
+	}
+}

--- a/cmd/printers/printers.go
+++ b/cmd/printers/printers.go
@@ -5,14 +5,17 @@ package printers
 
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/cmd/printers/events"
+	"sigs.k8s.io/cli-utils/cmd/printers/json"
 	"sigs.k8s.io/cli-utils/cmd/printers/printer"
 	"sigs.k8s.io/cli-utils/cmd/printers/table"
-	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/print/list"
 )
 
 const (
 	EventsPrinter = "events"
 	TablePrinter  = "table"
+	JSONPrinter   = "json"
 )
 
 func GetPrinter(printerType string, ioStreams genericclioptions.IOStreams) printer.Printer {
@@ -21,15 +24,18 @@ func GetPrinter(printerType string, ioStreams genericclioptions.IOStreams) print
 		return &table.Printer{
 			IOStreams: ioStreams,
 		}
-	default:
-		return &apply.BasicPrinter{
-			IOStreams: ioStreams,
+	case JSONPrinter:
+		return &list.BaseListPrinter{
+			IOStreams:        ioStreams,
+			FormatterFactory: json.NewFormatter,
 		}
+	default:
+		return events.NewPrinter(ioStreams)
 	}
 }
 
 func SupportedPrinters() []string {
-	return []string{EventsPrinter, TablePrinter}
+	return []string{EventsPrinter, TablePrinter, JSONPrinter}
 }
 
 func DefaultPrinter() string {

--- a/pkg/print/list/base.go
+++ b/pkg/print/list/base.go
@@ -1,0 +1,174 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package list
+
+import (
+	"fmt"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+type Formatter interface {
+	FormatApplyEvent(ae event.ApplyEvent, as *ApplyStats, c Collector) error
+	FormatStatusEvent(se pollevent.Event, sc Collector) error
+	FormatPruneEvent(pe event.PruneEvent, ps *PruneStats) error
+	FormatDeleteEvent(de event.DeleteEvent, ds *DeleteStats) error
+	FormatErrorEvent(ee event.ErrorEvent) error
+}
+
+type FormatterFactory func(ioStreams genericclioptions.IOStreams,
+	previewStrategy common.DryRunStrategy) Formatter
+
+type BaseListPrinter struct {
+	FormatterFactory FormatterFactory
+	IOStreams        genericclioptions.IOStreams
+}
+
+type ApplyStats struct {
+	ServersideApplied int
+	Created           int
+	Unchanged         int
+	Configured        int
+}
+
+func (a *ApplyStats) inc(op event.ApplyEventOperation) {
+	switch op {
+	case event.ServersideApplied:
+		a.ServersideApplied++
+	case event.Created:
+		a.Created++
+	case event.Unchanged:
+		a.Unchanged++
+	case event.Configured:
+		a.Configured++
+	default:
+		panic(fmt.Errorf("unknown apply operation %s", op.String()))
+	}
+}
+
+func (a *ApplyStats) Sum() int {
+	return a.ServersideApplied + a.Configured + a.Unchanged + a.Created
+}
+
+type PruneStats struct {
+	Pruned  int
+	Skipped int
+}
+
+func (p *PruneStats) incPruned() {
+	p.Pruned++
+}
+
+func (p *PruneStats) incSkipped() {
+	p.Skipped++
+}
+
+type DeleteStats struct {
+	Deleted int
+	Skipped int
+}
+
+func (d *DeleteStats) incDeleted() {
+	d.Deleted++
+}
+
+func (d *DeleteStats) incSkipped() {
+	d.Skipped++
+}
+
+type Collector interface {
+	LatestStatus() map[object.ObjMetadata]pollevent.Event
+}
+
+type StatusCollector struct {
+	latestStatus map[object.ObjMetadata]pollevent.Event
+}
+
+func (sc *StatusCollector) updateStatus(id object.ObjMetadata, se pollevent.Event) {
+	sc.latestStatus[id] = se
+}
+
+func (sc *StatusCollector) LatestStatus() map[object.ObjMetadata]pollevent.Event {
+	return sc.latestStatus
+}
+
+// Print outputs the events from the provided channel in a simple
+// format on StdOut. As we support other printer implementations
+// this should probably be an interface.
+// This function will block until the channel is closed.
+func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy) error {
+	applyStats := &ApplyStats{}
+	statusCollector := &StatusCollector{
+		latestStatus: make(map[object.ObjMetadata]pollevent.Event),
+	}
+	printStatus := false
+	pruneStats := &PruneStats{}
+	deleteStats := &DeleteStats{}
+	formatter := b.FormatterFactory(b.IOStreams, previewStrategy)
+	for e := range ch {
+		switch e.Type {
+		case event.ErrorType:
+			_ = formatter.FormatErrorEvent(e.ErrorEvent)
+			return e.ErrorEvent.Err
+		case event.ApplyType:
+			if e.ApplyEvent.Type == event.ApplyEventResourceUpdate {
+				applyStats.inc(e.ApplyEvent.Operation)
+			}
+			if e.ApplyEvent.Type == event.ApplyEventCompleted {
+				printStatus = true
+			}
+			if err := formatter.FormatApplyEvent(e.ApplyEvent, applyStats, statusCollector); err != nil {
+				return err
+			}
+		case event.StatusType:
+			switch se := e.StatusEvent; se.EventType {
+			case pollevent.ResourceUpdateEvent:
+				statusCollector.updateStatus(e.StatusEvent.Resource.Identifier, e.StatusEvent)
+				if printStatus {
+					if err := formatter.FormatStatusEvent(e.StatusEvent, statusCollector); err != nil {
+						return err
+					}
+				}
+			case pollevent.ErrorEvent:
+				if err := formatter.FormatStatusEvent(e.StatusEvent, statusCollector); err != nil {
+					return err
+				}
+			case pollevent.CompletedEvent:
+				printStatus = false
+				if err := formatter.FormatStatusEvent(e.StatusEvent, statusCollector); err != nil {
+					return err
+				}
+			}
+		case event.PruneType:
+			if e.PruneEvent.Type == event.PruneEventResourceUpdate {
+				switch e.PruneEvent.Operation {
+				case event.Pruned:
+					pruneStats.incPruned()
+				case event.PruneSkipped:
+					pruneStats.incSkipped()
+				}
+			}
+			if err := formatter.FormatPruneEvent(e.PruneEvent, pruneStats); err != nil {
+				return err
+			}
+		case event.DeleteType:
+			if e.DeleteEvent.Type == event.DeleteEventResourceUpdate {
+				switch e.DeleteEvent.Operation {
+				case event.Deleted:
+					deleteStats.incDeleted()
+				case event.DeleteSkipped:
+					deleteStats.incSkipped()
+				}
+			}
+			if err := formatter.FormatDeleteEvent(e.DeleteEvent, deleteStats); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This provides a third option for the `--output` flag that determines the output format. By setting the value to `json`, the output will be similar to the events output, but the information about each event will be provided as a json object. A small number of fields will be set on all events, with the remaining information depending on the type of the event. If an error occurs, it will be first printed in the json format and then output with additional information in normal format, similar to when errors occurs with the other output formats.

Example output:
```json
{"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"nginx-deployment","namespace":"default","operation":"Created","timestamp":"2020-09-06T19:06:03Z","type":"apply"}
{"eventType":"resourceApplied","group":"batch","kind":"CronJob","name":"hello","namespace":"default","operation":"Created","timestamp":"2020-09-06T19:06:03Z","type":"apply"}
{"eventType":"resourceApplied","group":"policy","kind":"PodDisruptionBudget","name":"mypdb","namespace":"default","operation":"Created","timestamp":"2020-09-06T19:06:03Z","type":"apply"}
{"configuredCount":0,"count":3,"createdCount":3,"eventType":"completed","serverSideCount":0,"timestamp":"2020-09-06T19:06:03Z","type":"apply","unchangedCount":0}
{"eventType":"resourceStatus","group":"apps","kind":"Deployment","message":"Resource not found","name":"nginx-deployment","namespace":"default","status":"NotFound","timestamp":"2020-09-06T19:06:03Z","type":"status"}
{"eventType":"resourceStatus","group":"batch","kind":"CronJob","message":"Resource is always ready","name":"hello","namespace":"default","status":"Current","timestamp":"2020-09-06T19:06:03Z","type":"status"}
{"eventType":"resourceStatus","group":"policy","kind":"PodDisruptionBudget","message":"Resource not found","name":"mypdb","namespace":"default","status":"NotFound","timestamp":"2020-09-06T19:06:03Z","type":"status"}
{"eventType":"resourceStatus","group":"apps","kind":"Deployment","message":"Available: 0/1","name":"nginx-deployment","namespace":"default","status":"InProgress","timestamp":"2020-09-06T19:06:05Z","type":"status"}
{"eventType":"resourceStatus","group":"policy","kind":"PodDisruptionBudget","message":"AllowedDisruptions has been computed.","name":"mypdb","namespace":"default","status":"Current","timestamp":"2020-09-06T19:06:05Z","type":"status"}
{"eventType":"resourceStatus","group":"apps","kind":"Deployment","message":"Deployment is available. Replicas: 1","name":"nginx-deployment","namespace":"default","status":"Current","timestamp":"2020-09-06T19:06:15Z","type":"status"}
{"eventType":"completed","timestamp":"2020-09-06T19:06:15Z","type":"status"}
{"eventType":"completed","pruned":0,"skipped":0,"timestamp":"2020-09-06T19:06:15Z","type":"prune"}
```