### PR TITLE
Applies inventory namespace first if necessary

### DIFF
--- a/examples/alphaTestExamples/inventoryNamespace.md
+++ b/examples/alphaTestExamples/inventoryNamespace.md
@@ -1,0 +1,126 @@
+[kind]: https://github.com/kubernetes-sigs/kind
+
+# Demo: Inventory with Namespace
+
+This demo shows that the namespace the inventory object
+is applied into will get applied first, so the inventory
+object will always have a namespace to be applied into.
+
+First define a place to work:
+
+<!-- @makeWorkplace @testE2EAgainstLatestRelease -->
+```
+DEMO_HOME=$(mktemp -d)
+```
+
+Alternatively, use
+
+> ```
+> DEMO_HOME=~/hello
+> ```
+
+## Establish the base
+
+<!-- @createBase @testE2EAgainstLatestRelease -->
+```
+BASE=$DEMO_HOME/base
+mkdir -p $BASE
+OUTPUT=$DEMO_HOME/output
+mkdir -p $OUTPUT
+
+function expectedOutputLine() {
+  test 1 == \
+  $(grep "$@" $OUTPUT/status | wc -l); \
+  echo $?
+}
+```
+
+## Create the "app"
+
+Create the config yaml for a config map and a namespace: (cm-a, test-namespace).
+
+<!-- @createFirstConfigMaps @testE2EAgainstLatestRelease-->
+```
+cat <<EOF >$BASE/config-map-a.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-a
+  namespace: test-namespace
+  labels:
+    name: test-config-map-label
+EOF
+
+cat <<EOF >$BASE/test-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace
+EOF
+```
+
+## Run end-to-end tests
+
+The following requires installation of [kind].
+
+Delete any existing kind cluster and create a new one. By default the name of the cluster is "kind".
+
+<!-- @deleteAndCreateKindCluster @testE2EAgainstLatestRelease -->
+```
+kind delete cluster
+kind create cluster
+```
+
+Use the kapply init command to generate the inventory template. This contains
+the namespace and inventory id used by apply to create inventory objects. 
+<!-- @createInventoryTemplate @testE2EAgainstLatestRelease-->
+```
+kapply init --namespace=test-namespace $BASE > $OUTPUT/status
+expectedOutputLine "namespace: test-namespace is used for inventory object"
+```
+
+Apply the "app" to the cluster. The test-namespace should be configured, and
+the config map should be created, and no resources should be pruned. The
+test-namespace is created first, so the following resources within the namespace
+(including the inventory object) will not fail.
+<!-- @runApply @testE2EAgainstLatestRelease -->
+```
+kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
+expectedOutputLine "namespace/test-namespace configured"
+expectedOutputLine "configmap/cm-a created"
+expectedOutputLine "2 resource(s) applied. 1 created, 0 unchanged, 1 configured"
+expectedOutputLine "0 resource(s) pruned, 0 skipped"
+
+# There should be only one inventory object
+kubectl get cm -n test-namespace --selector='cli-utils.sigs.k8s.io/inventory-id' --no-headers | wc -l > $OUTPUT/status
+expectedOutputLine "1"
+
+# Capture the inventory object name for later testing
+invName=$(kubectl get cm -n test-namespace --selector='cli-utils.sigs.k8s.io/inventory-id' --no-headers | awk '{print $1}')
+
+# There should be one config map that is not the inventory object
+kubectl get cm -n test-namespace --selector='!cli-utils.sigs.k8s.io/inventory-id' --no-headers | wc -l > $OUTPUT/status
+expectedOutputLine "1"
+
+# ConfigMap cm-a had been created in the cluster
+kubectl get configmap/cm-a -n test-namespace --no-headers | wc -l > $OUTPUT/status
+expectedOutputLine "1"
+```
+
+Now delete the inventory namespace from the local config. Ensure
+that the subsequent apply does not prune this omitted namespace.
+<!-- @noPruneInventoryNamespace @testE2EAgainstLatestRelease -->
+```
+rm -f $BASE/test-namespace.yaml
+kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
+expectedOutputLine "0 resource(s) pruned, 1 skipped"
+
+# Inventory namespace should still exist
+kubectl get ns test-namespace --no-headers | wc -l > $OUTPUT/status
+
+# Inventory object should still exist
+kubectl get cm/${invName} -n test-namespace --no-headers | wc -l > $OUTPUT/status
+
+# ConfigMap cm-a should still exist
+kubectl get configmap/cm-a -n test-namespace --no-headers | wc -l > $OUTPUT/status
+expectedOutputLine "1"

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -70,6 +70,7 @@ func (d *Destroyer) Initialize(cmd *cobra.Command, paths []string) error {
 	if err != nil {
 		return errors.WrapPrefix(err, "error setting up PruneOptions", 1)
 	}
+	d.PruneOptions.Destroy = true
 
 	// Propagate dry-run flags.
 	d.ApplyOptions.DryRun = d.DryRunStrategy.ClientDryRun()

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -65,6 +65,13 @@ func (fic *FakeInventoryClient) DeleteInventoryObj(inv *resource.Info) error {
 
 func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
 
+func (fic *FakeInventoryClient) ApplyInventoryNamespace(info *resource.Info) error {
+	if fic.Err != nil {
+		return fic.Err
+	}
+	return nil
+}
+
 // SetError forces an error on the subsequent client call if it returns an error.
 func (fic *FakeInventoryClient) SetError(err error) {
 	fic.Err = err

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -46,6 +47,9 @@ var RBACGroupKind = map[schema.GroupKind]bool{
 	{Group: rbacv1.GroupName, Kind: "RoleBinding"}:        true,
 	{Group: rbacv1.GroupName, Kind: "ClusterRoleBinding"}: true,
 }
+
+// CoreV1Namespace is Namespace GVK.
+var CoreV1Namespace = corev1.SchemeGroupVersion.WithKind("Namespace")
 
 // ObjMetadata organizes and stores the indentifying information
 // for an object. This struct (as a string) is stored in a


### PR DESCRIPTION
* If the inventory namespace is one of the applied resources, apply this namespace before the inventory object.
* Fixes problem where inventory fails to apply because the namespace it lives in does not yet exist.
* Adds end-to-end test to validate the namespace is created before the inventory object is applied.
* Refactors common code to create the `resource.Helper` in `helperFromInfo()`