### PR TITLE
Refactor inventory template intialization

### DIFF
--- a/cmd/initcmd/cmdinit.go
+++ b/cmd/initcmd/cmdinit.go
@@ -11,9 +11,15 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/config"
 )
 
-// NewCmdInit creates the `init` command, which generates the
-// inventory object template ConfigMap for a package.
-func NewCmdInit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+// InitRunner encapsulates the structures for the init command.
+type InitRunner struct {
+	Command     *cobra.Command
+	InitOptions *config.InitOptions
+}
+
+// GetInitRunner builds and returns the InitRunner. Connects the InitOptions.Run
+// to the cobra command.
+func GetInitRunner(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *InitRunner {
 	io := config.NewInitOptions(f, ioStreams)
 	cmd := &cobra.Command{
 		Use:                   "init DIRECTORY",
@@ -28,5 +34,14 @@ func NewCmdInit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		},
 	}
 	cmd.Flags().StringVarP(&io.InventoryID, "inventory-id", "i", "", "Identifier for group of applied resources. Must be composed of valid label characters.")
-	return cmd
+	i := &InitRunner{
+		Command:     cmd,
+		InitOptions: io,
+	}
+	return i
+}
+
+// NewCmdInit returns the cobra command for the init command.
+func NewCmdInit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	return GetInitRunner(f, ioStreams).Command
 }

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,7 @@ github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNue
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/inventory/configmap/cm-template.go
+++ b/pkg/inventory/configmap/cm-template.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package configmap
+
+// Template for ConfigMap inventory object. The following fields
+// must be filled in for this to be valid:
+//
+//  <DATETIME>: The time this is auto-generated
+//  <NAMESPACE>: The namespace to place this inventory object
+//  <RANDOMSUFFIX>: The random suffix added to the end of the name
+//  <INVENTORYID>: The label value to retrieve this inventory object
+//
+const ConfigMapTemplate = `# NOTE: auto-generated. Some fields should NOT be modified.
+# Date: <DATETIME>
+#
+# Contains the "inventory object" template ConfigMap.
+# When this object is applied, it is handled specially,
+# storing the metadata of all the other objects applied.
+# This object and its stored inventory is subsequently
+# used to calculate the set of objects to automatically
+# delete (prune), when an object is omitted from further
+# applies. When applied, this "inventory object" is also
+# used to identify the entire set of objects to delete.
+#
+# NOTE: The name of this inventory template file
+# does NOT have any impact on group-related functionality
+# such as deletion or pruning.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # DANGER: Do not change the inventory object namespace.
+  # Changing the namespace will cause a loss of continuity
+  # with previously applied grouped objects. Set deletion
+  # and pruning functionality will be impaired.
+  namespace: <NAMESPACE>
+  # NOTE: The name of the inventory object does NOT have
+  # any impact on group-related functionality such as
+  # deletion or pruning.
+  name: inventory-<RANDOMSUFFIX>
+  labels:
+    # DANGER: Do not change the value of this label.
+    # Changing this value will cause a loss of continuity
+    # with previously applied grouped objects. Set deletion
+    # and pruning functionality will be impaired.
+    cli-utils.sigs.k8s.io/inventory-id: <INVENTORYID>
+`


### PR DESCRIPTION
* Adds `InitRunner` similar to the other commands for `init` command.
* Makes the inventory template dynamic, moving configmap-specific code into configmap location.
