### PR TITLE
Move ManifestReader creation into Provider

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/cmd/status/printers"
@@ -22,7 +21,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/collector"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
-	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/cli-utils/pkg/util/factory"
 )
@@ -76,23 +74,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var reader manifestreader.ManifestReader
-	readerOptions := manifestreader.ReaderOptions{
-		Factory:   r.provider.Factory(),
-		Namespace: metav1.NamespaceDefault,
-	}
-	if len(args) == 0 {
-		reader = &manifestreader.StreamManifestReader{
-			ReaderName:    "stdin",
-			Reader:        cmd.InOrStdin(),
-			ReaderOptions: readerOptions,
-		}
-	} else {
-		reader = &manifestreader.PathManifestReader{
-			Path:          args[0],
-			ReaderOptions: readerOptions,
-		}
-	}
+	reader := r.provider.ManifestReader(cmd.InOrStdin(), args)
 	infos, err := reader.Read()
 	if err != nil {
 		return err

--- a/pkg/provider/fake-provider.go
+++ b/pkg/provider/fake-provider.go
@@ -4,9 +4,13 @@
 package provider
 
 import (
+	"io"
+
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
@@ -34,4 +38,16 @@ func (f *FakeProvider) InventoryClient() (inventory.InventoryClient, error) {
 
 func (f *FakeProvider) ToRESTMapper() (meta.RESTMapper, error) {
 	return f.factory.ToRESTMapper()
+}
+
+func (f *FakeProvider) ManifestReader(reader io.Reader, args []string) manifestreader.ManifestReader {
+	readerOptions := manifestreader.ReaderOptions{
+		Factory:   f.factory,
+		Namespace: metav1.NamespaceDefault,
+	}
+	return &manifestreader.StreamManifestReader{
+		ReaderName:    "stdin",
+		Reader:        reader,
+		ReaderOptions: readerOptions,
+	}
 }


### PR DESCRIPTION
* Moves `ManifrestReader` into Provider.
* Use `ManifestReader` to create `Infos` instead of `apply.GetObjects` within the `destroy` command like other commands.
* Several `Runner` commands now take `Provider` instead of `Factory`.
* Tested manually