### PR TITLE
Install stringer in generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ fmt:
 	go fmt ./...
 
 generate:
+	(which $(GOPATH)/bin/stringer || go get golang.org/x/tools/cmd/stringer)
 	go generate ./...
 
 license:


### PR DESCRIPTION
go generate requires stringer - to generate code for the Event types.