### PR TITLE
Expose common functions used by ManifestReader

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -633,8 +633,6 @@ sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.8.0 h1:/MqPML99XAm2pbrD/eTpePh5rnU5bpnuTPqb29LpSz4=
-sigs.k8s.io/kustomize/kyaml v0.8.0/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/kustomize/kyaml v0.8.1 h1:5GRanVGU6+iq3ERTiQD9VIfyGByFVB4z4GthP8NkRYE=
 sigs.k8s.io/kustomize/kyaml v0.8.1/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -15,29 +15,14 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
 
-// ManifestReader defines the interface for reading a set
-// of manifests into info objects.
-type ManifestReader interface {
-	Read() ([]*resource.Info, error)
-}
-
-// ReaderOptions defines the shared inputs for the different
-// implementations of the ManifestReader interface.
-type ReaderOptions struct {
-	Factory          util.Factory
-	Validate         bool
-	Namespace        string
-	EnforceNamespace bool
-}
-
-// setNamespaces verifies that every namespaced resource has the namespace
+// SetNamespaces verifies that every namespaced resource has the namespace
 // set, and if one does not, it will set the namespace to the provided
 // defaultNamespace.
 // This implementation will check each resource (that doesn't already have
 // the namespace set) on whether it is namespace or cluster scoped. It does
 // this by first checking the RESTMapper, and it there is not match there,
 // it will look for CRDs in the provided Infos.
-func setNamespaces(factory util.Factory, infos []*resource.Info,
+func SetNamespaces(factory util.Factory, infos []*resource.Info,
 	defaultNamespace string, enforceNamespace bool) error {
 	mapper, err := factory.ToRESTMapper()
 	if err != nil {
@@ -124,9 +109,9 @@ func setNamespaces(factory util.Factory, infos []*resource.Info,
 	return nil
 }
 
-// filterLocalConfig returns a new slice of infos where all resources
+// FilterLocalConfig returns a new slice of infos where all resources
 // with the LocalConfig annotation is filtered out.
-func filterLocalConfig(infos []*resource.Info) []*resource.Info {
+func FilterLocalConfig(infos []*resource.Info) []*resource.Info {
 	var filterInfos []*resource.Info
 	for _, inf := range infos {
 		acc, _ := meta.Accessor(inf.Object)

--- a/pkg/manifestreader/common_test.go
+++ b/pkg/manifestreader/common_test.go
@@ -135,7 +135,7 @@ func TestSetNamespaces(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("namespace")
 			defer tf.Cleanup()
 
-			err := setNamespaces(tf, tc.infos, tc.defaultNamspace, tc.enforceNamespace)
+			err := SetNamespaces(tf, tc.infos, tc.defaultNamspace, tc.enforceNamespace)
 
 			if tc.expectedErrText != "" {
 				if err == nil {
@@ -212,7 +212,7 @@ func TestFilterLocalConfigs(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			res := filterLocalConfig(tc.input)
+			res := FilterLocalConfig(tc.input)
 
 			var names []string
 			for _, inf := range res {

--- a/pkg/manifestreader/manifestreader.go
+++ b/pkg/manifestreader/manifestreader.go
@@ -1,0 +1,24 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+// ManifestReader defines the interface for reading a set
+// of manifests into info objects.
+type ManifestReader interface {
+	Read() ([]*resource.Info, error)
+}
+
+// ReaderOptions defines the shared inputs for the different
+// implementations of the ManifestReader interface.
+type ReaderOptions struct {
+	Factory          util.Factory
+	Validate         bool
+	Namespace        string
+	EnforceNamespace bool
+}

--- a/pkg/manifestreader/path.go
+++ b/pkg/manifestreader/path.go
@@ -45,9 +45,9 @@ func (p *PathManifestReader) Read() ([]*resource.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	infos = filterLocalConfig(infos)
+	infos = FilterLocalConfig(infos)
 
-	err = setNamespaces(p.Factory, infos, p.Namespace, p.EnforceNamespace)
+	err = SetNamespaces(p.Factory, infos, p.Namespace, p.EnforceNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manifestreader/stream.go
+++ b/pkg/manifestreader/stream.go
@@ -42,9 +42,9 @@ func (r *StreamManifestReader) Read() ([]*resource.Info, error) {
 	if err != nil {
 		return nil, err
 	}
-	infos = filterLocalConfig(infos)
+	infos = FilterLocalConfig(infos)
 
-	err = setNamespaces(r.Factory, infos, r.Namespace, r.EnforceNamespace)
+	err = SetNamespaces(r.Factory, infos, r.Namespace, r.EnforceNamespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows other implementations of the ManifestReader interface to leverage the helper functions.