### PR TITLE
Use the TaskContext for passing UIDs of applied resources to the pruner

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -41,7 +41,7 @@ func NewApplier(provider provider.Provider, ioStreams genericclioptions.IOStream
 		ApplyOptions: applyOptions,
 		// VisitedUids keeps track of the unique identifiers for all
 		// currently applied objects. Used to calculate prune set.
-		PruneOptions: prune.NewPruneOptions(applyOptions.VisitedUids),
+		PruneOptions: prune.NewPruneOptions(),
 		provider:     provider,
 		ioStreams:    ioStreams,
 	}

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -29,9 +29,7 @@ import (
 func NewDestroyer(provider provider.Provider, ioStreams genericclioptions.IOStreams) *Destroyer {
 	return &Destroyer{
 		ApplyOptions: apply.NewApplyOptions(ioStreams),
-		// Create and maintain an empty set of UID's. This empty UID set
-		// is used during prune calculation to prune every object.
-		PruneOptions: prune.NewPruneOptions(sets.NewString()),
+		PruneOptions: prune.NewPruneOptions(),
 		provider:     provider,
 		ioStreams:    ioStreams,
 	}
@@ -98,7 +96,7 @@ func (d *Destroyer) Run(inv *resource.Info) <-chan event.Event {
 		// Events. That we use Prune to implement destroy is an
 		// implementation detail and the events should not be Prune events.
 		tempChannel, completedChannel := runPruneEventTransformer(ch)
-		err := d.PruneOptions.Prune(infos, tempChannel, prune.Options{
+		err := d.PruneOptions.Prune(infos, sets.NewString(), tempChannel, prune.Options{
 			DryRunStrategy:    d.DryRunStrategy,
 			PropagationPolicy: metav1.DeletePropagationBackground,
 		})

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -192,7 +192,7 @@ func TestPrune(t *testing.T) {
 		for i := range common.Strategies {
 			drs := common.Strategies[i]
 			t.Run(name, func(t *testing.T) {
-				po := NewPruneOptions(populateObjectIds(tc.currentInfos, t))
+				po := NewPruneOptions()
 				// Set up the previously applied objects.
 				clusterObjs, _ := object.InfosToObjMetas(tc.pastInfos)
 				po.InvClient = inventory.NewFakeInventoryClient(clusterObjs)
@@ -210,7 +210,7 @@ func TestPrune(t *testing.T) {
 				err := func() error {
 					defer close(eventChannel)
 					// Run the prune and validate.
-					return po.Prune(currentInfos, eventChannel, Options{
+					return po.Prune(currentInfos, populateObjectIds(tc.currentInfos, t), eventChannel, Options{
 						DryRunStrategy: drs,
 					})
 				}()

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -119,8 +119,9 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 				if err != nil {
 					continue
 				}
+				uid := acc.GetUID()
 				gen := acc.GetGeneration()
-				taskContext.ResourceApplied(id, gen)
+				taskContext.ResourceApplied(id, uid, gen)
 			}
 		}
 		a.sendTaskResult(taskContext, nil)

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -27,7 +27,8 @@ type PruneTask struct {
 // to signal to the taskrunner that the task has completed (or failed).
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		err := p.PruneOptions.Prune(p.Objects, taskContext.EventChannel(),
+		currentUIDs := taskContext.AllResourceUIDs()
+		err := p.PruneOptions.Prune(p.Objects, currentUIDs, taskContext.EventChannel(),
 			prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -112,9 +112,10 @@ func (w *WaitTask) checkCondition(taskContext *TaskContext, coll *resourceStatus
 func (w *WaitTask) computeResourceWaitData(taskContext *TaskContext) []resourceWaitData {
 	var rwd []resourceWaitData
 	for _, id := range w.Identifiers {
+		gen, _ := taskContext.ResourceGeneration(id)
 		rwd = append(rwd, resourceWaitData{
 			identifier: id,
-			generation: taskContext.ResourceGeneration(id),
+			generation: gen,
 		})
 	}
 	return rwd


### PR DESCRIPTION
Decouple the applier and the prune logic.