### PR TITLE
Provider can now return error for ManifestReader creation

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -115,7 +115,10 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	reader := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	if err != nil {
+		return err
+	}
 	infos, err := reader.Read()
 	if err != nil {
 		return err

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -67,7 +67,10 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Retrieve the inventory object.
-	reader := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	if err != nil {
+		return err
+	}
 	infos, err := reader.Read()
 	if err != nil {
 		return err

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -100,7 +100,10 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		r.Destroyer.DryRunStrategy = drs
 	}
 
-	reader := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	if err != nil {
+		return err
+	}
 	infos, err := reader.Read()
 	if err != nil {
 		return err

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -74,7 +74,10 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	reader := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.provider.ManifestReader(cmd.InOrStdin(), args)
+	if err != nil {
+		return err
+	}
 	infos, err := reader.Read()
 	if err != nil {
 		return err

--- a/pkg/provider/fake-provider.go
+++ b/pkg/provider/fake-provider.go
@@ -40,7 +40,7 @@ func (f *FakeProvider) ToRESTMapper() (meta.RESTMapper, error) {
 	return f.factory.ToRESTMapper()
 }
 
-func (f *FakeProvider) ManifestReader(reader io.Reader, args []string) manifestreader.ManifestReader {
+func (f *FakeProvider) ManifestReader(reader io.Reader, args []string) (manifestreader.ManifestReader, error) {
 	readerOptions := manifestreader.ReaderOptions{
 		Factory:   f.factory,
 		Namespace: metav1.NamespaceDefault,
@@ -49,5 +49,5 @@ func (f *FakeProvider) ManifestReader(reader io.Reader, args []string) manifestr
 		ReaderName:    "stdin",
 		Reader:        reader,
 		ReaderOptions: readerOptions,
-	}
+	}, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
@@ -19,7 +18,7 @@ type Provider interface {
 	Factory() util.Factory
 	InventoryClient() (inventory.InventoryClient, error)
 	ToRESTMapper() (meta.RESTMapper, error)
-	ManifestReader(reader io.Reader, args []string) manifestreader.ManifestReader
+	ManifestReader(reader io.Reader, args []string) (manifestreader.ManifestReader, error)
 }
 
 // InventoryProvider implements the Provider interface.
@@ -52,7 +51,7 @@ func (f *InventoryProvider) ToRESTMapper() (meta.RESTMapper, error) {
 	return f.factory.ToRESTMapper()
 }
 
-func (f *InventoryProvider) ManifestReader(reader io.Reader, args []string) manifestreader.ManifestReader {
+func (f *InventoryProvider) ManifestReader(reader io.Reader, args []string) (manifestreader.ManifestReader, error) {
 	// Fetch the namespace from the configloader. The source of this
 	// either the namespace flag or the context. If the namespace is provided
 	// with the flag, enforceNamespace will be true. In this case, it is
@@ -60,8 +59,7 @@ func (f *InventoryProvider) ManifestReader(reader io.Reader, args []string) mani
 	// namespace set.
 	namespace, enforceNamespace, err := f.factory.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		namespace = metav1.NamespaceDefault
-		enforceNamespace = false
+		return nil, err
 	}
 
 	readerOptions := manifestreader.ReaderOptions{
@@ -83,5 +81,5 @@ func (f *InventoryProvider) ManifestReader(reader io.Reader, args []string) mani
 			ReaderOptions: readerOptions,
 		}
 	}
-	return mReader
+	return mReader, nil
 }


### PR DESCRIPTION
* Function signature for `provider.ManifestReader()` can now return an error.
* Error can be returned from kubeconfig `Namespace()` method, and this error can be propagated.