### PR TITLE
Move ApplyOptions into ApplyTask

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -35,21 +35,6 @@ func GetApplyRunner(provider provider.Provider, ioStreams genericclioptions.IOSt
 		RunE:                  r.RunE,
 	}
 
-	r.Applier.SetFlags(cmd)
-
-	// The following flags are added, but hidden because other code
-	// depend on them when parsing flags. These flags are hidden and unused.
-	var unusedBool bool
-	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
-	_ = cmd.Flags().MarkHidden("dry-run")
-	cmdutil.AddValidateFlags(cmd)
-	_ = cmd.Flags().MarkHidden("validate")
-	// Server-side flags are hidden for now.
-	cmdutil.AddServerSideApplyFlags(cmd)
-	_ = cmd.Flags().MarkHidden("server-side")
-	_ = cmd.Flags().MarkHidden("force-conflicts")
-	_ = cmd.Flags().MarkHidden("field-manager")
-
 	cmd.Flags().StringVar(&r.output, "output", printers.DefaultPrinter(),
 		fmt.Sprintf("Output format, must be one of %s", strings.Join(printers.SupportedPrinters(), ",")))
 
@@ -96,7 +81,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := r.Applier.Initialize(cmd); err != nil {
+	if err := r.Applier.Initialize(); err != nil {
 		return err
 	}
 

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -28,20 +28,6 @@ func GetDestroyRunner(provider provider.Provider, ioStreams genericclioptions.IO
 		RunE:                  r.RunE,
 	}
 
-	r.Destroyer.SetFlags(cmd)
-
-	// The following flags are added, but hidden because other code
-	// dependencies when parsing flags. These flags are hidden and unused.
-	var unusedBool bool
-	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
-	cmdutil.AddValidateFlags(cmd)
-	_ = cmd.Flags().MarkHidden("validate")
-	// Server-side flags are hidden for now.
-	cmdutil.AddServerSideApplyFlags(cmd)
-	_ = cmd.Flags().MarkHidden("server-side")
-	_ = cmd.Flags().MarkHidden("force-conflicts")
-	_ = cmd.Flags().MarkHidden("field-manager")
-
 	r.Command = cmd
 	return r
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -41,24 +41,9 @@ func GetPreviewRunner(provider provider.Provider, ioStreams genericclioptions.IO
 		RunE:                  r.RunE,
 	}
 
-	r.Applier.SetFlags(cmd)
-
 	cmd.Flags().BoolVar(&noPrune, "no-prune", noPrune, "If true, do not prune previously applied objects.")
 	cmd.Flags().BoolVar(&serverDryRun, "server-side", serverDryRun, "If true, preview runs in the server instead of the client.")
-
-	// The following flags are added, but hidden because other code
-	// dependend on them when parsing flags. These flags are hidden and unused.
-	var unusedBool bool
-	cmd.Flags().BoolVar(&unusedBool, "dry-run", unusedBool, "NOT USED")
 	cmd.Flags().BoolVar(&previewDestroy, "destroy", previewDestroy, "If true, preview of destroy operations will be displayed.")
-	_ = cmd.Flags().MarkHidden("dry-run")
-	cmdutil.AddValidateFlags(cmd)
-	_ = cmd.Flags().MarkHidden("validate")
-	cmd.Flags().Bool("force-conflicts", false, "If true, server-side apply will force the changes against conflicts.")
-	cmd.Flags().String("field-manager", "kubectl", "Name of the manager used to track field ownership.")
-	// hide unwanted server-side flags
-	_ = cmd.Flags().MarkHidden("force-conflicts")
-	_ = cmd.Flags().MarkHidden("field-manager")
 
 	r.Command = cmd
 	return r
@@ -112,7 +97,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 	// if destroy flag is set in preview, transmit it to destroyer DryRunStrategy flag
 	// and pivot execution to destroy with dry-run
 	if !r.Destroyer.DryRunStrategy.ClientOrServerDryRun() {
-		err = r.Applier.Initialize(cmd)
+		err = r.Applier.Initialize()
 		if err != nil {
 			return err
 		}

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
@@ -220,14 +218,7 @@ func TestApplier(t *testing.T) {
 			cf := provider.NewProvider(tf, nil)                        // nil InventoryFactoryFunc since not needed
 			applier := NewApplier(cf, ioStreams)
 
-			cmd := &cobra.Command{}
-			applier.SetFlags(cmd)
-			var notUsedFlag bool
-			// This flag needs to be set as there is a dependency on it.
-			cmd.Flags().BoolVar(&notUsedFlag, "dry-run", notUsedFlag, "")
-			cmdutil.AddValidateFlags(cmd)
-			cmdutil.AddServerSideApplyFlags(cmd)
-			err = applier.Initialize(cmd)
+			err = applier.Initialize()
 			if !assert.NoError(t, err) {
 				return
 			}

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -19,16 +19,14 @@ type InfoHelper interface {
 	UpdateInfos(infos []*resource.Info) error
 }
 
-func NewInfoHelper(factory util.Factory, namespace string) *infoHelper {
+func NewInfoHelper(factory util.Factory) *infoHelper {
 	return &infoHelper{
-		factory:          factory,
-		defaultNamespace: namespace,
+		factory: factory,
 	}
 }
 
 type infoHelper struct {
-	factory          util.Factory
-	defaultNamespace string
+	factory util.Factory
 }
 
 func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
@@ -35,9 +35,9 @@ import (
 )
 
 type TaskQueueSolver struct {
-	ApplyOptions *apply.ApplyOptions
 	PruneOptions *prune.PruneOptions
 	InfoHelper   info.InfoHelper
+	Factory      util.Factory
 	Mapper       meta.RESTMapper
 }
 
@@ -69,9 +69,9 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 		tasks = append(tasks, &task.ApplyTask{
 			Objects:        append(crdSplitRes.before, crdSplitRes.crds...),
 			CRDs:           crdSplitRes.crds,
-			ApplyOptions:   t.ApplyOptions,
 			DryRunStrategy: o.DryRunStrategy,
 			InfoHelper:     t.InfoHelper,
+			Factory:        t.Factory,
 			Mapper:         t.Mapper,
 		})
 		if !o.DryRunStrategy.ClientOrServerDryRun() {
@@ -91,9 +91,9 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 		&task.ApplyTask{
 			Objects:        remainingInfos,
 			CRDs:           crdSplitRes.crds,
-			ApplyOptions:   t.ApplyOptions,
 			DryRunStrategy: o.DryRunStrategy,
 			InfoHelper:     t.InfoHelper,
+			Factory:        t.Factory,
 			Mapper:         t.Mapper,
 		},
 		&task.SendEventTask{

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -11,7 +11,6 @@ import (
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/kubectl/pkg/cmd/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/task"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
@@ -21,7 +20,6 @@ import (
 )
 
 var (
-	applyOptions = &apply.ApplyOptions{}
 	pruneOptions = &prune.PruneOptions{}
 
 	depInfo    = createInfo("apps/v1", "Deployment", "foo", "bar")
@@ -217,7 +215,6 @@ func TestTaskQueueSolver_BuildTaskQueue(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			tqs := TaskQueueSolver{
-				ApplyOptions: applyOptions,
 				PruneOptions: pruneOptions,
 				Mapper:       testutil.NewFakeRESTMapper(),
 			}


### PR DESCRIPTION
This moves the use of the `ApplyOptions` from the `Applier` into the `ApplyTask`. This avoids calling the `NewApplyOptions` and `ao.Complete` functions, but instead builds the `ApplyOptions` instance directly by populating the fields. The advantage of this is that we no longer need to pass in cobra commands when creating the `ApplyOptions` object and we no longer get all the cobra flags from `ApplyOptions`.