### PR TITLE
Remove IOStreams from the Applier

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -24,7 +24,7 @@ import (
 
 func GetApplyRunner(provider provider.Provider, ioStreams genericclioptions.IOStreams) *ApplyRunner {
 	r := &ApplyRunner{
-		Applier:   apply.NewApplier(provider, ioStreams),
+		Applier:   apply.NewApplier(provider),
 		ioStreams: ioStreams,
 		provider:  provider,
 	}

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -17,7 +17,7 @@ import (
 // GetDestroyRunner creates and returns the DestroyRunner which stores the cobra command.
 func GetDestroyRunner(provider provider.Provider, ioStreams genericclioptions.IOStreams) *DestroyRunner {
 	r := &DestroyRunner{
-		Destroyer: apply.NewDestroyer(provider, ioStreams),
+		Destroyer: apply.NewDestroyer(provider),
 		ioStreams: ioStreams,
 		provider:  provider,
 	}
@@ -47,7 +47,7 @@ type DestroyRunner struct {
 }
 
 func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
-	err := r.Destroyer.Initialize(cmd, args)
+	err := r.Destroyer.Initialize()
 	if err != nil {
 		return err
 	}

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -28,8 +28,8 @@ var (
 // GetPreviewRunner creates and returns the PreviewRunner which stores the cobra command.
 func GetPreviewRunner(provider provider.Provider, ioStreams genericclioptions.IOStreams) *PreviewRunner {
 	r := &PreviewRunner{
-		Applier:   apply.NewApplier(provider, ioStreams),
-		Destroyer: apply.NewDestroyer(provider, ioStreams),
+		Applier:   apply.NewApplier(provider),
+		Destroyer: apply.NewDestroyer(provider),
 		ioStreams: ioStreams,
 		provider:  provider,
 	}
@@ -71,7 +71,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	var ch <-chan event.Event
-	err = r.Destroyer.Initialize(cmd, args)
+	err = r.Destroyer.Initialize()
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-errors/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
@@ -33,11 +32,10 @@ import (
 // the ApplyOptions were responsible for printing progress. This is now
 // handled by a separate printer with the KubectlPrinterAdapter bridging
 // between the two.
-func NewApplier(provider provider.Provider, ioStreams genericclioptions.IOStreams) *Applier {
+func NewApplier(provider provider.Provider) *Applier {
 	a := &Applier{
 		PruneOptions: prune.NewPruneOptions(),
 		provider:     provider,
-		ioStreams:    ioStreams,
 	}
 	a.infoHelperFactoryFunc = a.infoHelperFactory
 	return a
@@ -54,8 +52,7 @@ func NewApplier(provider provider.Provider, ioStreams genericclioptions.IOStream
 // parameters and/or the set of resources that needs to be applied to the
 // cluster, different sets of tasks might be needed.
 type Applier struct {
-	provider  provider.Provider
-	ioStreams genericclioptions.IOStreams
+	provider provider.Provider
 
 	PruneOptions *prune.PruneOptions
 	StatusPoller poller.Poller

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -214,9 +213,8 @@ func TestApplier(t *testing.T) {
 
 			tf.UnstructuredClient = newFakeRESTClient(t, tc.handlers)
 
-			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
-			cf := provider.NewProvider(tf, nil)                        // nil InventoryFactoryFunc since not needed
-			applier := NewApplier(cf, ioStreams)
+			cf := provider.NewProvider(tf, nil) // nil InventoryFactoryFunc since not needed
+			applier := NewApplier(cf)
 
 			err = applier.Initialize()
 			if !assert.NoError(t, err) {

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -7,10 +7,8 @@ import (
 	"fmt"
 
 	"github.com/go-errors/errors"
-	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
@@ -25,11 +23,10 @@ import (
 // the ApplyOptions were responsible for printing progress. This is now
 // handled by a separate printer with the KubectlPrinterAdapter bridging
 // between the two.
-func NewDestroyer(provider provider.Provider, ioStreams genericclioptions.IOStreams) *Destroyer {
+func NewDestroyer(provider provider.Provider) *Destroyer {
 	return &Destroyer{
 		PruneOptions: prune.NewPruneOptions(),
 		provider:     provider,
-		ioStreams:    ioStreams,
 	}
 }
 
@@ -37,7 +34,6 @@ func NewDestroyer(provider provider.Provider, ioStreams genericclioptions.IOStre
 // prune them. This also deletes all the previous inventory objects
 type Destroyer struct {
 	provider       provider.Provider
-	ioStreams      genericclioptions.IOStreams
 	PruneOptions   *prune.PruneOptions
 	invClient      inventory.InventoryClient
 	DryRunStrategy common.DryRunStrategy
@@ -46,7 +42,7 @@ type Destroyer struct {
 // Initialize sets up the Destroyer for actually doing an destroy against
 // a cluster. This involves validating command line inputs and configuring
 // clients for communicating with the cluster.
-func (d *Destroyer) Initialize(cmd *cobra.Command, paths []string) error {
+func (d *Destroyer) Initialize() error {
 	invClient, err := d.provider.InventoryClient()
 	if err != nil {
 		return errors.WrapPrefix(err, "error creating inventory client", 1)


### PR DESCRIPTION
The IOStreams are no longer in use in the Applier, so we can remove them. They are still used in the cobra commands.