### PR TITLE
Use Unstructured instead of Info

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/kustomize/kyaml/setters2"
 )
@@ -109,7 +110,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err := r.Applier.Initialize(); err != nil {
 		return err
 	}
-	ch := r.Applier.Run(context.Background(), infos, apply.Options{
+	ch := r.Applier.Run(context.Background(), object.InfosToUnstructureds(infos), apply.Options{
 		PollInterval:     r.period,
 		ReconcileTimeout: r.reconcileTimeout,
 		// If we are not waiting for status, tell the applier to not

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/kustomize/kyaml/setters2"
 )
@@ -112,7 +113,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 		// Run the applier. It will return a channel where we can receive updates
 		// to keep track of progress and any issues.
-		ch = r.Applier.Run(ctx, infos, apply.Options{
+		ch = r.Applier.Run(ctx, object.InfosToUnstructureds(infos), apply.Options{
 			EmitStatusEvents: false,
 			NoPrune:          noPrune,
 			DryRunStrategy:   drs,

--- a/examples/alphaTestExamples/inventoryNamespace.md
+++ b/examples/alphaTestExamples/inventoryNamespace.md
@@ -86,9 +86,9 @@ test-namespace is created first, so the following resources within the namespace
 <!-- @runApply @testE2EAgainstLatestRelease -->
 ```
 kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
-expectedOutputLine "namespace/test-namespace configured"
+expectedOutputLine "namespace/test-namespace unchanged"
 expectedOutputLine "configmap/cm-a created"
-expectedOutputLine "2 resource(s) applied. 1 created, 0 unchanged, 1 configured"
+expectedOutputLine "2 resource(s) applied. 1 created, 1 unchanged, 0 configured"
 expectedOutputLine "0 resource(s) pruned, 0 skipped"
 
 # There should be only one inventory object

--- a/hack/testExamplesE2EAgainstKapply.sh
+++ b/hack/testExamplesE2EAgainstKapply.sh
@@ -7,7 +7,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-mdrip --blockTimeOut 6m0s --mode test \
+mdrip -alsologtostderr -v 10 --blockTimeOut 6m0s --mode test \
     --label testE2EAgainstLatestRelease examples/alphaTestExamples
 
 echo "Example e2e tests passed against ."

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -5,10 +5,12 @@ package info
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // InfoHelper provides functions for interacting with Info objects.
@@ -17,6 +19,8 @@ type InfoHelper interface {
 	// objects. This must be called at a time when all needed resource
 	// types are available in the RESTMapper.
 	UpdateInfos(infos []*resource.Info) error
+
+	BuildInfos(objs []*unstructured.Unstructured) ([]*resource.Info, error)
 }
 
 func NewInfoHelper(factory util.Factory) *infoHelper {
@@ -49,6 +53,15 @@ func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {
 		info.Client = c
 	}
 	return nil
+}
+
+func (ih *infoHelper) BuildInfos(objs []*unstructured.Unstructured) ([]*resource.Info, error) {
+	infos := object.UnstructuredsToInfos(objs)
+	err := ih.UpdateInfos(infos)
+	if err != nil {
+		return nil, err
+	}
+	return infos, nil
 }
 
 func (ih *infoHelper) ToRESTMapper() (meta.RESTMapper, error) {

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -5,10 +5,11 @@ package task
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // PruneTask prunes objects from the cluster
@@ -16,7 +17,7 @@ import (
 // set of resources that have just been applied.
 type PruneTask struct {
 	PruneOptions      *prune.PruneOptions
-	Objects           []*resource.Info
+	Objects           []*unstructured.Unstructured
 	DryRunStrategy    common.DryRunStrategy
 	PropagationPolicy metav1.DeletionPropagation
 }
@@ -28,8 +29,8 @@ type PruneTask struct {
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		currentUIDs := taskContext.AllResourceUIDs()
-		err := p.PruneOptions.Prune(p.Objects, currentUIDs, taskContext.EventChannel(),
-			prune.Options{
+		err := p.PruneOptions.Prune(object.UnstructuredsToInfos(p.Objects),
+			currentUIDs, taskContext.EventChannel(), prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,
 			})

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -211,7 +211,7 @@ func (cic *ClusterInventoryClient) getClusterInventoryInfo(localInv *resource.In
 	}
 	groupResource := mapping.Resource.GroupResource().String()
 	namespace := localObj.Namespace
-	label, err := retrieveInventoryLabel(localInv)
+	label, err := retrieveInventoryLabel(object.InfoToUnstructured(localInv))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inventory/inventory_error.go
+++ b/pkg/inventory/inventory_error.go
@@ -5,7 +5,9 @@
 
 package inventory
 
-import "k8s.io/cli-runtime/pkg/resource"
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
 const noInventoryErrorStr = `Package uninitialized. Please run "init" command.
 
@@ -32,7 +34,7 @@ func (g NoInventoryObjError) Error() string {
 }
 
 type MultipleInventoryObjError struct {
-	InventoryObjectTemplates []*resource.Info
+	InventoryObjectTemplates []*unstructured.Unstructured
 }
 
 func (g MultipleInventoryObjError) Error() string {

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -216,10 +216,6 @@ func TestIsInventoryObject(t *testing.T) {
 		isInventory bool
 	}{
 		{
-			invInfo:     nil,
-			isInventory: false,
-		},
-		{
 			invInfo:     invInfo,
 			isInventory: true,
 		},
@@ -230,7 +226,7 @@ func TestIsInventoryObject(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		inventory := IsInventoryObject(test.invInfo)
+		inventory := IsInventoryObject(test.invInfo.Object.(*unstructured.Unstructured))
 		if test.isInventory && !inventory {
 			t.Errorf("Inventory object not identified: %#v", test.invInfo)
 		}
@@ -246,12 +242,6 @@ func TestRetrieveInventoryLabel(t *testing.T) {
 		inventoryLabel string
 		isError        bool
 	}{
-		// Nil inventory object throws error.
-		{
-			inventoryInfo:  nil,
-			inventoryLabel: "",
-			isError:        true,
-		},
 		// Pod is not a inventory object.
 		{
 			inventoryInfo:  pod2Info,
@@ -272,7 +262,7 @@ func TestRetrieveInventoryLabel(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, err := retrieveInventoryLabel(test.inventoryInfo)
+		actual, err := retrieveInventoryLabel(object.InfoToUnstructured(test.inventoryInfo))
 		if test.isError && err == nil {
 			t.Errorf("Did not receive expected error.\n")
 		}

--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/solver"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
 
@@ -33,7 +34,7 @@ func SetNamespaces(factory util.Factory, infos []*resource.Info,
 
 	// find any crds in the set of resources.
 	for _, inf := range infos {
-		if solver.IsCRD(inf) {
+		if solver.IsCRD(object.InfoToUnstructured(inf)) {
 			crdInfos = append(crdInfos, inf)
 		}
 	}
@@ -43,7 +44,7 @@ func SetNamespaces(factory util.Factory, infos []*resource.Info,
 
 		// Exclude any inventory objects here since we don't want to change
 		// their namespace.
-		if inventory.IsInventoryObject(inf) {
+		if inventory.IsInventoryObject(object.InfoToUnstructured(inf)) {
 			continue
 		}
 

--- a/pkg/object/infos.go
+++ b/pkg/object/infos.go
@@ -1,0 +1,38 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+)
+
+func InfoToUnstructured(info *resource.Info) *unstructured.Unstructured {
+	return info.Object.(*unstructured.Unstructured)
+}
+
+func UnstructuredToInfo(obj *unstructured.Unstructured) *resource.Info {
+	return &resource.Info{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Source:    "unstructured",
+		Object:    obj,
+	}
+}
+
+func InfosToUnstructureds(infos []*resource.Info) []*unstructured.Unstructured {
+	var objs []*unstructured.Unstructured
+	for _, info := range infos {
+		objs = append(objs, InfoToUnstructured(info))
+	}
+	return objs
+}
+
+func UnstructuredsToInfos(objs []*unstructured.Unstructured) []*resource.Info {
+	var infos []*resource.Info
+	for _, obj := range objs {
+		infos = append(infos, UnstructuredToInfo(obj))
+	}
+	return infos
+}

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -24,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -195,6 +196,26 @@ func InfoToObjMeta(info *resource.Info) (ObjMetadata, error) {
 	obj := info.Object
 	gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
 	return CreateObjMetadata(info.Namespace, info.Name, gk)
+}
+
+func UnstructuredsToObjMetas(objs []*unstructured.Unstructured) []ObjMetadata {
+	var objMetas []ObjMetadata
+	for _, obj := range objs {
+		objMetas = append(objMetas, ObjMetadata{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+			GroupKind: obj.GroupVersionKind().GroupKind(),
+		})
+	}
+	return objMetas
+}
+
+func UnstructuredToObjMeta(obj *unstructured.Unstructured) ObjMetadata {
+	return ObjMetadata{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		GroupKind: obj.GroupVersionKind().GroupKind(),
+	}
 }
 
 // CalcHash returns a hash of the sorted strings from

--- a/pkg/ordering/sort.go
+++ b/pkg/ordering/sort.go
@@ -6,6 +6,7 @@ package ordering
 import (
 	"sort"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -26,6 +27,18 @@ func (a SortableInfos) Less(i, j int) bool {
 	if err != nil {
 		return false
 	}
+	return less(first, second)
+}
+
+type SortableUnstructureds []*unstructured.Unstructured
+
+var _ sort.Interface = SortableUnstructureds{}
+
+func (a SortableUnstructureds) Len() int      { return len(a) }
+func (a SortableUnstructureds) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortableUnstructureds) Less(i, j int) bool {
+	first := object.UnstructuredToObjMeta(a[i])
+	second := object.UnstructuredToObjMeta(a[j])
 	return less(first, second)
 }
 


### PR DESCRIPTION
First step to replace the use of `resource.Info` with `unstructured.Unstructured`. It will require several PRs to complete this, but this makes the changes for the main `Applier` logic. 

With `resource.Info`, the passed in resources are updated with the state from the cluster after apply. This is no longer the case now. We currently only rely on this for fetching the generation of the resources after apply, but we still handle this in the `ApplyTask`.