### PR TITLE
Add output flag to destroy and preview commands

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -4,6 +4,9 @@
 package destroy
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -28,6 +31,9 @@ func GetDestroyRunner(provider provider.Provider, ioStreams genericclioptions.IO
 		RunE:                  r.RunE,
 	}
 
+	cmd.Flags().StringVar(&r.output, "output", printers.DefaultPrinter(),
+		fmt.Sprintf("Output format, must be one of %s", strings.Join(printers.SupportedPrinters(), ",")))
+
 	r.Command = cmd
 	return r
 }
@@ -44,6 +50,8 @@ type DestroyRunner struct {
 	ioStreams genericclioptions.IOStreams
 	Destroyer *apply.Destroyer
 	provider  provider.Provider
+
+	output string
 }
 
 func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
@@ -72,6 +80,6 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := printers.GetPrinter(printers.EventsPrinter, r.ioStreams)
+	printer := printers.GetPrinter(r.output, r.ioStreams)
 	return printer.Print(ch, r.Destroyer.DryRunStrategy)
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -5,6 +5,8 @@ package preview
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -44,6 +46,8 @@ func GetPreviewRunner(provider provider.Provider, ioStreams genericclioptions.IO
 	cmd.Flags().BoolVar(&noPrune, "no-prune", noPrune, "If true, do not prune previously applied objects.")
 	cmd.Flags().BoolVar(&serverDryRun, "server-side", serverDryRun, "If true, preview runs in the server instead of the client.")
 	cmd.Flags().BoolVar(&previewDestroy, "destroy", previewDestroy, "If true, preview of destroy operations will be displayed.")
+	cmd.Flags().StringVar(&r.output, "output", printers.DefaultPrinter(),
+		fmt.Sprintf("Output format, must be one of %s", strings.Join(printers.SupportedPrinters(), ",")))
 
 	r.Command = cmd
 	return r
@@ -62,6 +66,8 @@ type PreviewRunner struct {
 	Applier   *apply.Applier
 	Destroyer *apply.Destroyer
 	provider  provider.Provider
+
+	output string
 }
 
 // RunE is the function run from the cobra command.
@@ -133,6 +139,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := printers.GetPrinter(printers.EventsPrinter, r.ioStreams)
+	printer := printers.GetPrinter(r.output, r.ioStreams)
 	return printer.Print(ch, drs)
 }


### PR DESCRIPTION
Hi 👋 

This PR adds output flag support to the `destroy` and `preview` commands, following suite with the output functionality already present in the `apply` command.

The flag is duplicated across the three commands right now. What do you think, is it fine as is or should I refactor it with code sharing in mind?