### PR TITLE
split inventory and resources in the apply interface

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/kustomize/kyaml/setters2"
 )
@@ -110,13 +111,17 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	inv, objs, err := inventory.SplitUnstructureds(objs)
+	if err != nil {
+		return err
+	}
 
 	// Run the applier. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
 	if err := r.Applier.Initialize(); err != nil {
 		return err
 	}
-	ch := r.Applier.Run(context.Background(), objs, apply.Options{
+	ch := r.Applier.Run(context.Background(), inv, objs, apply.Options{
 		ServerSideOptions: r.serverSideOptions,
 		PollInterval:      r.period,
 		ReconcileTimeout:  r.reconcileTimeout,

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -100,6 +100,10 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	inv, objs, err := inventory.SplitUnstructureds(objs)
+	if err != nil {
+		return err
+	}
 
 	// if destroy flag is set in preview, transmit it to destroyer DryRunStrategy flag
 	// and pivot execution to destroy with dry-run
@@ -119,17 +123,13 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 		// Run the applier. It will return a channel where we can receive updates
 		// to keep track of progress and any issues.
-		ch = r.Applier.Run(ctx, objs, apply.Options{
+		ch = r.Applier.Run(ctx, inv, objs, apply.Options{
 			EmitStatusEvents:  false,
 			NoPrune:           noPrune,
 			DryRunStrategy:    drs,
 			ServerSideOptions: r.serverSideOptions,
 		})
 	} else {
-		inv, _, err := inventory.SplitUnstructureds(objs)
-		if err != nil {
-			return err
-		}
 		err = r.Destroyer.Initialize()
 		if err != nil {
 			return err

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -66,17 +66,12 @@ func (d *Destroyer) Run(inv *unstructured.Unstructured) <-chan event.Event {
 		defer close(ch)
 		d.invClient.SetDryRunStrategy(d.DryRunStrategy)
 
-		// Force a pruning of all cluster resources by clearing out the
-		// local resources, and sending only the inventory object to the
-		// prune.
-		invs := []*unstructured.Unstructured{inv}
-
 		// Start the event transformer goroutine so we can transform
 		// the Prune events emitted from the Prune function to Delete
 		// Events. That we use Prune to implement destroy is an
 		// implementation detail and the events should not be Prune events.
 		tempChannel, completedChannel := runPruneEventTransformer(ch)
-		err := d.PruneOptions.Prune(invs, sets.NewString(), tempChannel, prune.Options{
+		err := d.PruneOptions.Prune(inv, nil, sets.NewString(), tempChannel, prune.Options{
 			DryRunStrategy:    d.DryRunStrategy,
 			PropagationPolicy: metav1.DeletePropagationBackground,
 		})

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -80,12 +80,8 @@ type Options struct {
 // (retrieved from previous inventory objects) but omitted in
 // the current apply. Prune also delete all previous inventory
 // objects. Returns an error if there was a problem.
-func (po *PruneOptions) Prune(localObjs []*unstructured.Unstructured, currentUIDs sets.String,
+func (po *PruneOptions) Prune(localInv *unstructured.Unstructured, localObjs []*unstructured.Unstructured, currentUIDs sets.String,
 	eventChannel chan<- event.Event, o Options) error {
-	localInv, localObjs, err := inventory.SplitUnstructureds(localObjs)
-	if err != nil {
-		return err
-	}
 	invNamespace := localInv.GetNamespace()
 	klog.V(4).Infof("prune local inventory object: %s/%s", invNamespace, localInv.GetName())
 	clusterObjs, err := po.InvClient.GetClusterObjs(localInv)

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -161,7 +161,6 @@ func TestPrune(t *testing.T) {
 				po.InvClient = inventory.NewFakeInventoryClient(clusterObjs)
 				// Set up the currently applied objects.
 				currentInventory := createInventoryInfo(tc.currentObjs...)
-				currentObjs := append(tc.currentObjs, currentInventory)
 				// Set up the fake dynamic client to recognize all objects, and the RESTMapper.
 				po.client = fake.NewSimpleDynamicClient(scheme.Scheme,
 					namespace, pdb, role)
@@ -173,7 +172,7 @@ func TestPrune(t *testing.T) {
 				err := func() error {
 					defer close(eventChannel)
 					// Run the prune and validate.
-					return po.Prune(currentObjs, populateObjectIds(tc.currentObjs, t), eventChannel, Options{
+					return po.Prune(currentInventory, tc.currentObjs, populateObjectIds(tc.currentObjs, t), eventChannel, Options{
 						DryRunStrategy: drs,
 					})
 				}()

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -51,7 +51,7 @@ type Options struct {
 
 type resourceObjects interface {
 	ObjsForApply() []*unstructured.Unstructured
-	ObjsForPrune() []*unstructured.Unstructured
+	Inventory() *unstructured.Unstructured
 	IdsForApply() []object.ObjMetadata
 	IdsForPrune() []object.ObjMetadata
 }
@@ -128,7 +128,8 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 	if o.Prune {
 		tasks = append(tasks,
 			&task.PruneTask{
-				Objects:           ro.ObjsForPrune(),
+				Objects:           ro.ObjsForApply(),
+				InventoryObject:   ro.Inventory(),
 				PruneOptions:      t.PruneOptions,
 				PropagationPolicy: o.PrunePropagationPolicy,
 				DryRunStrategy:    o.DryRunStrategy,

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -309,6 +309,7 @@ func getType(task taskrunner.Task) reflect.Type {
 
 type fakeResourceObjects struct {
 	objsForApply []*unstructured.Unstructured
+	inventory    *unstructured.Unstructured
 	idsForApply  []object.ObjMetadata
 	idsForPrune  []object.ObjMetadata
 }
@@ -317,8 +318,8 @@ func (f *fakeResourceObjects) ObjsForApply() []*unstructured.Unstructured {
 	return f.objsForApply
 }
 
-func (f *fakeResourceObjects) ObjsForPrune() []*unstructured.Unstructured {
-	return f.objsForApply
+func (f *fakeResourceObjects) Inventory() *unstructured.Unstructured {
+	return f.inventory
 }
 
 func (f *fakeResourceObjects) IdsForApply() []object.ObjMetadata {

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -16,6 +16,7 @@ import (
 // set of resources that have just been applied.
 type PruneTask struct {
 	PruneOptions      *prune.PruneOptions
+	InventoryObject   *unstructured.Unstructured
 	Objects           []*unstructured.Unstructured
 	DryRunStrategy    common.DryRunStrategy
 	PropagationPolicy metav1.DeletionPropagation
@@ -28,7 +29,7 @@ type PruneTask struct {
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		currentUIDs := taskContext.AllResourceUIDs()
-		err := p.PruneOptions.Prune(p.Objects,
+		err := p.PruneOptions.Prune(p.InventoryObject, p.Objects,
 			currentUIDs, taskContext.EventChannel(), prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -86,6 +86,23 @@ func retrieveInventoryLabel(obj *unstructured.Unstructured) (string, error) {
 	return strings.TrimSpace(inventoryLabel), nil
 }
 
+// ValidateNoInventory takes a slice of unstructured.Unstructured objects and
+// validates that no inventory object is in the input slice.
+func ValidateNoInventory(objs []*unstructured.Unstructured) error {
+	invs := make([]*unstructured.Unstructured, 0)
+	for _, obj := range objs {
+		if IsInventoryObject(obj) {
+			invs = append(invs, obj)
+		}
+	}
+	if len(invs) == 0 {
+		return nil
+	}
+	return MultipleInventoryObjError{
+		InventoryObjectTemplates: invs,
+	}
+}
+
 // splitUnstructureds takes a slice of unstructured.Unstructured objects and
 // splits it into one slice that contains the inventory object templates and
 // another one that contains the remaining resources.


### PR DESCRIPTION
Change the `Applier.Run` from
```
func (a *Applier) Run(ctx context.Context, objects []*unstructured.Unstructured,
options Options) <-chan event.Event {}
```
to 
```
func (a *Applier) Run(ctx context.Context, inventory *unstructured.Unstructured, objects []*unstructured.Unstructured,
options Options) <-chan event.Event {
```
