### PR TITLE
Moves destroyer Initialize() to immediately before Run()

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -55,11 +55,6 @@ type DestroyRunner struct {
 }
 
 func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
-	err := r.Destroyer.Initialize()
-	if err != nil {
-		return err
-	}
-
 	// Retrieve the inventory object.
 	reader, err := r.provider.ManifestReader(cmd.InOrStdin(), args)
 	if err != nil {
@@ -76,6 +71,10 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
+	err = r.Destroyer.Initialize()
+	if err != nil {
+		return err
+	}
 	ch := r.Destroyer.Run(inv)
 
 	// The printer will print updates from the channel. It will block

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -77,10 +77,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	var ch <-chan event.Event
-	err = r.Destroyer.Initialize()
-	if err != nil {
-		return err
-	}
 
 	drs := common.DryRunClient
 	if serverDryRun {
@@ -131,6 +127,10 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		})
 	} else {
 		inv, _, err := inventory.SplitUnstructureds(objs)
+		if err != nil {
+			return err
+		}
+		err = r.Destroyer.Initialize()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Very small change which moves `destroyer.Initialize()` to immediately before `destroyer.Run()` in two places.
* Does NOT change any functionality.
* Groups operations more logically.
