### PR TITLE
CachingClusterReader should continue on all list errors

### DIFF
--- a/pkg/kstatus/polling/clusterreader/caching_reader.go
+++ b/pkg/kstatus/polling/clusterreader/caching_reader.go
@@ -239,17 +239,13 @@ func (c *CachingClusterReader) Sync(ctx context.Context) error {
 		list.SetGroupVersionKind(mapping.GroupVersionKind)
 		err = c.reader.List(ctx, &list, listOptions...)
 		if err != nil {
-			// If we get an IsNotFound error here, it means the type
-			// we are listing doesn't exist on the server. This is ok,
-			// because it might be that a CRD is part of the set of
-			// resources that are being applied.
-			if errors.IsNotFound(err) {
-				cache[gn] = cacheEntry{
-					err: err,
-				}
-				continue
+			// We continue even if there is an error. Whenever any pollers
+			// request a resource covered by this gns, we just return the
+			// error.
+			cache[gn] = cacheEntry{
+				err: err,
 			}
-			return err
+			continue
 		}
 		cache[gn] = cacheEntry{
 			resources: list,

--- a/pkg/kstatus/polling/clusterreader/caching_reader_test.go
+++ b/pkg/kstatus/polling/clusterreader/caching_reader_test.go
@@ -138,9 +138,9 @@ func TestSync_Errors(t *testing.T) {
 				apiextv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"),
 			),
 			readerError:     errors.NewInternalError(fmt.Errorf("testing")),
-			expectSyncError: true,
+			expectSyncError: false,
 			cacheError:      true,
-			cacheErrorText:  "not found",
+			cacheErrorText:  "Internal error occurred: testing",
 		},
 		"mapping not found": {
 			mapper:          testutil.NewFakeRESTMapper(),


### PR DESCRIPTION
Currently the CachingClusterReader bails out if it gets any other errors than `NotFound` when listing a specific GVK in a namespace. This is not correct, it should just store the error and return it whenever anyone requests a resource that should have been included in the result from the list call.