### PR TITLE
update events to include indentifier and error

### DIFF
--- a/cmd/printers/events/formatter_test.go
+++ b/cmd/printers/events/formatter_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -241,7 +240,7 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 	}
 }
 
-func createObject(group, kind, namespace, name string) runtime.Object {
+func createObject(group, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/v1", group),

--- a/cmd/printers/json/formatter_test.go
+++ b/cmd/printers/json/formatter_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -386,7 +385,7 @@ func assertOutput(t *testing.T, expectedMap map[string]interface{}, actual strin
 	return assert.Equal(t, expectedMap, m)
 }
 
-func createObject(group, kind, namespace, name string) runtime.Object {
+func createObject(group, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": fmt.Sprintf("%s/v1", group),

--- a/pkg/apply/event/applyeventtype_string.go
+++ b/pkg/apply/event/applyeventtype_string.go
@@ -13,11 +13,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[ApplyEventResourceUpdate-0]
 	_ = x[ApplyEventCompleted-1]
+	_ = x[ApplyEventFailed-2]
 }
 
-const _ApplyEventType_name = "ApplyEventResourceUpdateApplyEventCompleted"
+const _ApplyEventType_name = "ApplyEventResourceUpdateApplyEventCompletedApplyEventFailed"
 
-var _ApplyEventType_index = [...]uint8{0, 24, 43}
+var _ApplyEventType_index = [...]uint8{0, 24, 43, 59}
 
 func (i ApplyEventType) String() string {
 	if i < 0 || i >= ApplyEventType(len(_ApplyEventType_index)-1) {

--- a/pkg/apply/event/deleteeventtype_string.go
+++ b/pkg/apply/event/deleteeventtype_string.go
@@ -13,11 +13,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[DeleteEventResourceUpdate-0]
 	_ = x[DeleteEventCompleted-1]
+	_ = x[DeleteEventFailed-2]
 }
 
-const _DeleteEventType_name = "DeleteEventResourceUpdateDeleteEventCompleted"
+const _DeleteEventType_name = "DeleteEventResourceUpdateDeleteEventCompletedDeleteEventFailed"
 
-var _DeleteEventType_index = [...]uint8{0, 25, 45}
+var _DeleteEventType_index = [...]uint8{0, 25, 45, 62}
 
 func (i DeleteEventType) String() string {
 	if i < 0 || i >= DeleteEventType(len(_DeleteEventType_index)-1) {

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -4,7 +4,7 @@
 package event
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -81,6 +81,7 @@ type ApplyEventType int
 const (
 	ApplyEventResourceUpdate ApplyEventType = iota
 	ApplyEventCompleted
+	ApplyEventFailed
 )
 
 //go:generate stringer -type=ApplyEventOperation
@@ -94,9 +95,11 @@ const (
 )
 
 type ApplyEvent struct {
-	Type      ApplyEventType
-	Operation ApplyEventOperation
-	Object    runtime.Object
+	Type       ApplyEventType
+	Operation  ApplyEventOperation
+	Object     *unstructured.Unstructured
+	Identifier object.ObjMetadata
+	Error      error
 }
 
 //go:generate stringer -type=StatusEventType
@@ -110,6 +113,7 @@ const (
 type StatusEvent struct {
 	Type     StatusEventType
 	Resource *pollevent.ResourceStatus
+	Error    error
 }
 
 //go:generate stringer -type=PruneEventType
@@ -118,6 +122,7 @@ type PruneEventType int
 const (
 	PruneEventResourceUpdate PruneEventType = iota
 	PruneEventCompleted
+	PruneEventFailed
 )
 
 //go:generate stringer -type=PruneEventOperation
@@ -129,9 +134,11 @@ const (
 )
 
 type PruneEvent struct {
-	Type      PruneEventType
-	Operation PruneEventOperation
-	Object    runtime.Object
+	Type       PruneEventType
+	Operation  PruneEventOperation
+	Object     *unstructured.Unstructured
+	Identifier object.ObjMetadata
+	Error      error
 }
 
 //go:generate stringer -type=DeleteEventType
@@ -140,6 +147,7 @@ type DeleteEventType int
 const (
 	DeleteEventResourceUpdate DeleteEventType = iota
 	DeleteEventCompleted
+	DeleteEventFailed
 )
 
 //go:generate stringer -type=DeleteEventOperation
@@ -151,7 +159,9 @@ const (
 )
 
 type DeleteEvent struct {
-	Type      DeleteEventType
-	Operation DeleteEventOperation
-	Object    runtime.Object
+	Type       DeleteEventType
+	Operation  DeleteEventOperation
+	Object     *unstructured.Unstructured
+	Identifier object.ObjMetadata
+	Error      error
 }

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -113,7 +113,6 @@ const (
 type StatusEvent struct {
 	Type     StatusEventType
 	Resource *pollevent.ResourceStatus
-	Error    error
 }
 
 //go:generate stringer -type=PruneEventType

--- a/pkg/apply/event/pruneeventtype_string.go
+++ b/pkg/apply/event/pruneeventtype_string.go
@@ -13,11 +13,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[PruneEventResourceUpdate-0]
 	_ = x[PruneEventCompleted-1]
+	_ = x[PruneEventFailed-2]
 }
 
-const _PruneEventType_name = "PruneEventResourceUpdatePruneEventCompleted"
+const _PruneEventType_name = "PruneEventResourceUpdatePruneEventCompletedPruneEventFailed"
 
-var _PruneEventType_index = [...]uint8{0, 24, 43}
+var _PruneEventType_index = [...]uint8{0, 24, 43, 59}
 
 func (i PruneEventType) String() string {
 	if i < 0 || i >= PruneEventType(len(_PruneEventType_index)-1) {

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog"
@@ -188,7 +187,7 @@ func preventDeleteAnnotation(annotations map[string]string) bool {
 }
 
 // createPruneEvent is a helper function to package a prune event.
-func createPruneEvent(obj runtime.Object, op event.PruneEventOperation) event.Event {
+func createPruneEvent(obj *unstructured.Unstructured, op event.PruneEventOperation) event.Event {
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{

--- a/pkg/apply/task/printer_adapter.go
+++ b/pkg/apply/task/printer_adapter.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // KubectlPrinterAdapter is a workaround for capturing progress from
@@ -34,9 +36,10 @@ func (r *resourcePrinterImpl) PrintObj(obj runtime.Object, _ io.Writer) error {
 	r.ch <- event.Event{
 		Type: event.ApplyType,
 		ApplyEvent: event.ApplyEvent{
-			Type:      event.ApplyEventResourceUpdate,
-			Operation: r.applyOperation,
-			Object:    obj,
+			Type:       event.ApplyEventResourceUpdate,
+			Operation:  r.applyOperation,
+			Object:     obj.(*unstructured.Unstructured),
+			Identifier: object.RuntimeToObjMeta(obj),
 		},
 	}
 	return nil

--- a/pkg/apply/task/printer_adapter_test.go
+++ b/pkg/apply/task/printer_adapter_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
@@ -27,14 +26,14 @@ func TestKubectlPrinterAdapter(t *testing.T) {
 	resourcePrinter, err := toPrinterFunc(operation)
 	assert.NoError(t, err)
 
-	deployment := appsv1.Deployment{
-		TypeMeta: v1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "name",
-			Namespace: "namespace",
+	deployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "name",
+				"namespace": "namespace",
+			},
 		},
 	}
 
@@ -44,12 +43,12 @@ func TestKubectlPrinterAdapter(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = resourcePrinter.PrintObj(&deployment, &buffer)
+		err = resourcePrinter.PrintObj(deployment, &buffer)
 	}()
 	msg := <-ch
 	wg.Wait()
 
 	assert.NoError(t, err)
 	assert.Equal(t, event.ServersideApplied, msg.ApplyEvent.Operation)
-	assert.Equal(t, &deployment, msg.ApplyEvent.Object)
+	assert.Equal(t, deployment, msg.ApplyEvent.Object)
 }

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -24,7 +24,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -215,6 +217,15 @@ func UnstructuredToObjMeta(obj *unstructured.Unstructured) ObjMetadata {
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),
 		GroupKind: obj.GroupVersionKind().GroupKind(),
+	}
+}
+
+func RuntimeToObjMeta(obj runtime.Object) ObjMetadata {
+	accessor, _ := meta.Accessor(obj)
+	return ObjMetadata{
+		Namespace: accessor.GetNamespace(),
+		Name:      accessor.GetName(),
+		GroupKind: obj.GetObjectKind().GroupVersionKind().GroupKind(),
 	}
 }
 


### PR DESCRIPTION
This is part of the overall change for ContinueOnError. 
For each object being applied/pruned, the event stream should return an event for it. The event includes enough information for
- GKNN
- the object itself if available
- the error encountered if any