### PR TITLE
change apply to continue on error

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -708,43 +708,35 @@ type fakeInfoHelper struct {
 // TODO(mortent): This has too much code in common with the
 // infoHelper implementation. We need to find a better way to structure
 // this.
-func (f *fakeInfoHelper) UpdateInfos(infos []*resource.Info) error {
+func (f *fakeInfoHelper) UpdateInfo(info *resource.Info) error {
 	mapper, err := f.factory.ToRESTMapper()
 	if err != nil {
 		return err
 	}
-	for _, info := range infos {
-		gvk := info.Object.GetObjectKind().GroupVersionKind()
-		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil {
-			return err
-		}
-		info.Mapping = mapping
-
-		c, err := f.getClient(gvk.GroupVersion())
-		if err != nil {
-			return err
-		}
-		info.Client = c
+	gvk := info.Object.GetObjectKind().GroupVersionKind()
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return err
 	}
+	info.Mapping = mapping
+
+	c, err := f.getClient(gvk.GroupVersion())
+	if err != nil {
+		return err
+	}
+	info.Client = c
 	return nil
 }
 
-func (f *fakeInfoHelper) BuildInfos(objs []*unstructured.Unstructured) ([]*resource.Info, error) {
-	var infos []*resource.Info
-	for _, obj := range objs {
-		infos = append(infos, &resource.Info{
-			Name:      obj.GetName(),
-			Namespace: obj.GetNamespace(),
-			Source:    "unstructured",
-			Object:    obj,
-		})
+func (f *fakeInfoHelper) BuildInfo(obj *unstructured.Unstructured) (*resource.Info, error) {
+	info := &resource.Info{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Source:    "unstructured",
+		Object:    obj,
 	}
-	err := f.UpdateInfos(infos)
-	if err != nil {
-		return nil, err
-	}
-	return infos, nil
+	err := f.UpdateInfo(info)
+	return info, err
 }
 
 func (f *fakeInfoHelper) getClient(gv schema.GroupVersion) (resource.RESTClient, error) {

--- a/pkg/apply/error/error.go
+++ b/pkg/apply/error/error.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+package error
+
+type UnknwonTypeError struct {
+	err error
+}
+
+func (e *UnknwonTypeError) Error() string {
+	return e.err.Error()
+}
+
+func NewUnknwonTypeError(err error) *UnknwonTypeError {
+	return &UnknwonTypeError{err: err}
+}
+
+type ApplyRunError struct {
+	err error
+}
+
+func (e *ApplyRunError) Error() string {
+	return e.err.Error()
+}
+
+func NewApplyRunError(err error) *ApplyRunError {
+	return &ApplyRunError{err: err}
+}
+
+type InitializeApplyOptionError struct {
+	err error
+}
+
+func (e *InitializeApplyOptionError) Error() string {
+	return e.err.Error()
+}
+
+func NewInitializeApplyOptionError(err error) *InitializeApplyOptionError {
+	return &InitializeApplyOptionError{err: err}
+}

--- a/pkg/apply/error/error.go
+++ b/pkg/apply/error/error.go
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package error
 
-type UnknwonTypeError struct {
+type UnknownTypeError struct {
 	err error
 }
 
-func (e *UnknwonTypeError) Error() string {
+func (e *UnknownTypeError) Error() string {
 	return e.err.Error()
 }
 
-func NewUnknwonTypeError(err error) *UnknwonTypeError {
-	return &UnknwonTypeError{err: err}
+func NewUnknownTypeError(err error) *UnknownTypeError {
+	return &UnknownTypeError{err: err}
 }
 
 type ApplyRunError struct {

--- a/pkg/apply/event/applyeventtype_string.go
+++ b/pkg/apply/event/applyeventtype_string.go
@@ -13,12 +13,11 @@ func _() {
 	var x [1]struct{}
 	_ = x[ApplyEventResourceUpdate-0]
 	_ = x[ApplyEventCompleted-1]
-	_ = x[ApplyEventFailed-2]
 }
 
-const _ApplyEventType_name = "ApplyEventResourceUpdateApplyEventCompletedApplyEventFailed"
+const _ApplyEventType_name = "ApplyEventResourceUpdateApplyEventCompleted"
 
-var _ApplyEventType_index = [...]uint8{0, 24, 43, 59}
+var _ApplyEventType_index = [...]uint8{0, 24, 43}
 
 func (i ApplyEventType) String() string {
 	if i < 0 || i >= ApplyEventType(len(_ApplyEventType_index)-1) {

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -81,7 +81,6 @@ type ApplyEventType int
 const (
 	ApplyEventResourceUpdate ApplyEventType = iota
 	ApplyEventCompleted
-	ApplyEventFailed
 )
 
 //go:generate stringer -type=ApplyEventOperation

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -16,9 +16,9 @@ import (
 // InfoHelper provides functions for interacting with Info objects.
 type InfoHelper interface {
 	// UpdateInfo sets the mapping and client for the provided Info
-	// objects. This must be called at a time when all needed resource
+	// object. This must be called at a time when all needed resource
 	// types are available in the RESTMapper.
-	UpdateInfo(infos *resource.Info) error
+	UpdateInfo(info *resource.Info) error
 
 	BuildInfo(obj *unstructured.Unstructured) (*resource.Info, error)
 }

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -444,11 +444,7 @@ func (cic *ClusterInventoryClient) ApplyInventoryNamespace(obj *unstructured.Uns
 }
 
 func (cic *ClusterInventoryClient) toInfo(obj *unstructured.Unstructured) (*resource.Info, error) {
-	invInfos, err := cic.infoHelper.BuildInfos([]*unstructured.Unstructured{obj})
-	if err != nil {
-		return nil, err
-	}
-	return invInfos[0], nil
+	return cic.infoHelper.BuildInfo(obj)
 }
 
 // helperFromInfo returns the resource.Helper to talk to the APIServer based


### PR DESCRIPTION
- Update the apply task to not return error so that it can always proceed to the next apply task or the prune task.
-  Change the ApplyOptions.Run to multiple calls. Each time only one object is applied. This change is to have better control of the return error, which will be consumed by ConfigSync. So ConfigSync will know

   - if a single resource is applied successfully
   - if the apply failure is due to an unknown type


- Add a unit test for applying two resources. One of them failed, we should get the expected event.