### PR TITLE
enable InventoryPolicy in applier

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
@@ -137,6 +138,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		DryRunStrategy:         common.DryRunNone,
 		PrunePropagationPolicy: prunePropPolicy,
 		PruneTimeout:           r.pruneTimeout,
+		InventoryPolicy:        inventory.AdoptIfNoInventory,
 	})
 
 	// The printer will print updates from the channel. It will block

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
@@ -133,6 +134,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 			NoPrune:           noPrune,
 			DryRunStrategy:    drs,
 			ServerSideOptions: r.serverSideOptions,
+			InventoryPolicy:   inventory.AdoptIfNoInventory,
 		})
 	} else {
 		err = r.Destroyer.Initialize()

--- a/go.sum
+++ b/go.sum
@@ -706,8 +706,6 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.9.4 h1:DDuzZtjIzFqp2IPy4DTyCI69Cl3bDgcJODjI6sjF9NY=
-sigs.k8s.io/kustomize/kyaml v0.9.4/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -207,6 +207,7 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 			DryRunStrategy:         options.DryRunStrategy,
 			PrunePropagationPolicy: options.PrunePropagationPolicy,
 			PruneTimeout:           options.PruneTimeout,
+			InventoryPolicy:        options.InventoryPolicy,
 		})
 
 		// Send event to inform the caller about the resources that
@@ -313,6 +314,7 @@ func inventoryNamespaceInSet(inv inventory.InventoryInfo, objs []*unstructured.U
 		acc, _ := meta.Accessor(obj)
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		if gvk == object.CoreV1Namespace && acc.GetName() == invNamespace {
+			inventory.AddInventoryIDAnnotation(obj, inv)
 			return obj
 		}
 	}

--- a/pkg/apply/error/error.go
+++ b/pkg/apply/error/error.go
@@ -26,18 +26,6 @@ func NewApplyRunError(err error) *ApplyRunError {
 	return &ApplyRunError{err: err}
 }
 
-type InventoryOverlapError struct {
-	err error
-}
-
-func (e *InventoryOverlapError) Error() string {
-	return e.err.Error()
-}
-
-func NewInventoryOverlapError(err error) *InventoryOverlapError {
-	return &InventoryOverlapError{err: err}
-}
-
 type InitializeApplyOptionError struct {
 	err error
 }

--- a/pkg/apply/error/error.go
+++ b/pkg/apply/error/error.go
@@ -26,6 +26,18 @@ func NewApplyRunError(err error) *ApplyRunError {
 	return &ApplyRunError{err: err}
 }
 
+type InventoryOverlapError struct {
+	err error
+}
+
+func (e *InventoryOverlapError) Error() string {
+	return e.err.Error()
+}
+
+func NewInventoryOverlapError(err error) *InventoryOverlapError {
+	return &InventoryOverlapError{err: err}
+}
+
 type InitializeApplyOptionError struct {
 	err error
 }

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -33,28 +33,6 @@ type infoHelper struct {
 	factory util.Factory
 }
 
-func (ih *infoHelper) UpdateInfos(infos []*resource.Info) error {
-	mapper, err := ih.factory.ToRESTMapper()
-	if err != nil {
-		return err
-	}
-	for _, info := range infos {
-		gvk := info.Object.GetObjectKind().GroupVersionKind()
-		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil {
-			return err
-		}
-		info.Mapping = mapping
-
-		c, err := ih.getClient(gvk.GroupVersion())
-		if err != nil {
-			return err
-		}
-		info.Client = c
-	}
-	return nil
-}
-
 func (ih *infoHelper) UpdateInfo(info *resource.Info) error {
 	mapper, err := ih.factory.ToRESTMapper()
 	if err != nil {
@@ -73,18 +51,6 @@ func (ih *infoHelper) UpdateInfo(info *resource.Info) error {
 	}
 	info.Client = c
 	return nil
-}
-
-func (ih *infoHelper) BuildInfos(objs []*unstructured.Unstructured) ([]*resource.Info, error) {
-	infos, err := object.UnstructuredsToInfos(objs)
-	if err != nil {
-		return nil, err
-	}
-	err = ih.UpdateInfos(infos)
-	if err != nil {
-		return nil, err
-	}
-	return infos, nil
 }
 
 func (ih *infoHelper) BuildInfo(obj *unstructured.Unstructured) (*resource.Info, error) {

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -144,8 +144,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo, localObjs []*uns
 			continue
 		}
 		// Handle lifecycle directive preventing deletion.
-		if preventDeleteAnnotation(metadata.GetAnnotations()) {
-			klog.V(4).Infof("prune object lifecycle directive; do not prune: %s", uid)
+		if !canPrune(localInv, obj, o.InventoryPolicy, uid) {
 			eventChannel <- createPruneEvent(clusterObj, obj, event.PruneSkipped)
 			localIds = append(localIds, clusterObj)
 			continue
@@ -160,13 +159,6 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo, localObjs []*uns
 				localIds = append(localIds, clusterObj)
 				continue
 			}
-		}
-		if !inventory.CanPrune(localInv, obj, o.InventoryPolicy) {
-			klog.V(4).Infof("skip pruning object that doesn't belong to current inventory: %s/%s",
-				clusterObj.Namespace, clusterObj.Name)
-			eventChannel <- createPruneEvent(clusterObj, obj, event.PruneSkipped)
-			localIds = append(localIds, clusterObj)
-			continue
 		}
 		if !o.DryRunStrategy.ClientOrServerDryRun() {
 			klog.V(4).Infof("prune object delete: %s/%s", clusterObj.Namespace, clusterObj.Name)
@@ -230,4 +222,17 @@ func createPruneFailedEvent(objMeta object.ObjMetadata, err error) event.Event {
 			Error:      err,
 		},
 	}
+}
+
+func canPrune(localInv inventory.InventoryInfo, obj *unstructured.Unstructured,
+	policy inventory.InventoryPolicy, uid string) bool {
+	if !inventory.CanPrune(localInv, obj, policy) {
+		klog.V(4).Infof("skip pruning object that doesn't belong to current inventory: %s", uid)
+		return false
+	}
+	if preventDeleteAnnotation(obj.GetAnnotations()) {
+		klog.V(4).Infof("prune object lifecycle directive; do not prune: %s", uid)
+		return false
+	}
+	return true
 }

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -161,6 +161,13 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo, localObjs []*uns
 				continue
 			}
 		}
+		if !inventory.CanPrune(localInv, obj, o.InventoryPolicy) {
+			klog.V(4).Infof("skip pruning object that doesn't belong to current inventory: %s/%s",
+				clusterObj.Namespace, clusterObj.Name)
+			eventChannel <- createPruneEvent(clusterObj, obj, event.PruneSkipped)
+			localIds = append(localIds, clusterObj)
+			continue
+		}
 		if !o.DryRunStrategy.ClientOrServerDryRun() {
 			klog.V(4).Infof("prune object delete: %s/%s", clusterObj.Namespace, clusterObj.Name)
 			err = namespacedClient.Delete(context.TODO(), clusterObj.Name, metav1.DeleteOptions{})

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -55,6 +55,9 @@ var namespace = &unstructured.Unstructured{
 		"metadata": map[string]interface{}{
 			"name": testNamespace,
 			"uid":  "uid-namespace",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }
@@ -67,6 +70,9 @@ var pod = &unstructured.Unstructured{
 			"name":      podName,
 			"namespace": testNamespace,
 			"uid":       "uid1",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }
@@ -79,6 +85,9 @@ var pdb = &unstructured.Unstructured{
 			"name":      pdbName,
 			"namespace": testNamespace,
 			"uid":       "uid2",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }
@@ -91,6 +100,9 @@ var pdbGetFailure = &unstructured.Unstructured{
 			"name":      pdbName + "get-failure",
 			"namespace": testNamespace,
 			"uid":       "uid2",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }
@@ -103,6 +115,9 @@ var pdbDeleteFailure = &unstructured.Unstructured{
 			"name":      pdbName + "delete-failure",
 			"namespace": testNamespace,
 			"uid":       "uid2",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }
@@ -115,6 +130,9 @@ var role = &unstructured.Unstructured{
 			"name":      roleName,
 			"namespace": testNamespace,
 			"uid":       "uid3",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
 		},
 	},
 }

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -48,6 +48,7 @@ type Options struct {
 	DryRunStrategy         common.DryRunStrategy
 	PrunePropagationPolicy metav1.DeletionPropagation
 	PruneTimeout           time.Duration
+	InventoryPolicy        inventory.InventoryPolicy
 }
 
 type resourceObjects interface {
@@ -75,6 +76,8 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			InfoHelper:        t.InfoHelper,
 			Factory:           t.Factory,
 			Mapper:            t.Mapper,
+			InventoryPolicy:   o.InventoryPolicy,
+			InvInfo:           ro.Inventory(),
 		})
 		if !o.DryRunStrategy.ClientOrServerDryRun() {
 			objs := object.UnstructuredsToObjMetas(crdSplitRes.crds)
@@ -98,6 +101,8 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 			InfoHelper:        t.InfoHelper,
 			Factory:           t.Factory,
 			Mapper:            t.Mapper,
+			InventoryPolicy:   o.InventoryPolicy,
+			InvInfo:           ro.Inventory(),
 		},
 		&task.SendEventTask{
 			Event: event.Event{
@@ -134,6 +139,7 @@ func (t *TaskQueueSolver) BuildTaskQueue(ro resourceObjects,
 				PruneOptions:      t.PruneOptions,
 				PropagationPolicy: o.PrunePropagationPolicy,
 				DryRunStrategy:    o.DryRunStrategy,
+				InventoryPolicy:   o.InventoryPolicy,
 			},
 			&task.SendEventTask{
 				Event: event.Event{

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -130,15 +130,20 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			clusterObj, err := getClusterObj(dynamic, info)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
-					canApply, err := inventory.CanApply(a.InvInfo, clusterObj, a.InventoryPolicy)
-					if !canApply {
-						taskContext.EventChannel() <- createApplyEvent(
-							object.UnstructuredToObjMeta(obj),
-							event.Unchanged,
-							err)
-						continue
-					}
+					taskContext.EventChannel() <- createApplyEvent(
+						object.UnstructuredToObjMeta(obj),
+						event.Unchanged,
+						err)
+					continue
 				}
+			}
+			canApply, err := inventory.CanApply(a.InvInfo, clusterObj, a.InventoryPolicy)
+			if !canApply {
+				taskContext.EventChannel() <- createApplyEvent(
+					object.UnstructuredToObjMeta(obj),
+					event.Unchanged,
+					err)
+				continue
 			}
 			// add the inventory annotation to the resource being applied.
 			inventory.AddInventoryIDAnnotation(obj, a.InvInfo)

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -135,7 +135,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 						taskContext.EventChannel() <- createApplyEvent(
 							object.UnstructuredToObjMeta(obj),
 							event.Unchanged,
-							applyerror.NewInventoryOverlapError(err))
+							err)
 						continue
 					}
 				}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -21,6 +21,7 @@ type PruneTask struct {
 	Objects           []*unstructured.Unstructured
 	DryRunStrategy    common.DryRunStrategy
 	PropagationPolicy metav1.DeletionPropagation
+	InventoryPolicy   inventory.InventoryPolicy
 }
 
 // Start creates a new goroutine that will invoke
@@ -34,6 +35,7 @@ func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 			currentUIDs, taskContext.EventChannel(), prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,
+				InventoryPolicy:   p.InventoryPolicy,
 			})
 		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,

--- a/pkg/inventory/policy.go
+++ b/pkg/inventory/policy.go
@@ -97,7 +97,7 @@ func CanApply(inv InventoryInfo, obj *unstructured.Unstructured, policy Inventor
 		if policy != InventoryPolicyMustMatch {
 			return true, nil
 		}
-		err := fmt.Errorf("%v can't adopt an object without the annotation %s", InventoryPolicyMustMatch, owningInventoryKey)
+		err := fmt.Errorf("can't adopt an object without the annotation %s", owningInventoryKey)
 		return false, NewNeedAdoptionError(err)
 	case Match:
 		return true, nil

--- a/pkg/inventory/policy_test.go
+++ b/pkg/inventory/policy_test.go
@@ -157,7 +157,7 @@ func TestCanApply(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actual := CanApply(tc.inv, tc.obj, tc.policy)
+		actual, _ := CanApply(tc.inv, tc.obj, tc.policy)
 		if actual != tc.canApply {
 			t.Errorf("expected %v, but got %v", tc.canApply, actual)
 		}


### PR DESCRIPTION
This change enables the InventoryPolicy in applier. 

For each resource in the ApplyTask, it first check if the resource exists in the cluster. It then checks if the resource can be applied with the current inventory info. If it can, apply the resource; otherwise, send an event with the proper error.

Also updated the unit tests for ApplyTask and PruneTask.

It should be merged after #289 

