### PR TITLE
update printer for events

### DIFF
--- a/cmd/printers/events/formatter_test.go
+++ b/cmd/printers/events/formatter_test.go
@@ -31,27 +31,27 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 		"resource created without no dryrun": {
 			previewStrategy: common.DryRunNone,
 			event: event.ApplyEvent{
-				Operation: event.Created,
-				Type:      event.ApplyEventResourceUpdate,
-				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+				Operation:  event.Created,
+				Type:       event.ApplyEventResourceUpdate,
+				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
 			expected: "deployment.apps/my-dep created",
 		},
 		"resource updated with client dryrun": {
 			previewStrategy: common.DryRunClient,
 			event: event.ApplyEvent{
-				Operation: event.Configured,
-				Type:      event.ApplyEventResourceUpdate,
-				Object:    createObject("apps", "Deployment", "", "my-dep"),
+				Operation:  event.Configured,
+				Type:       event.ApplyEventResourceUpdate,
+				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 			},
 			expected: "deployment.apps/my-dep configured (preview)",
 		},
 		"resource updated with server dryrun": {
 			previewStrategy: common.DryRunServer,
 			event: event.ApplyEvent{
-				Operation: event.Configured,
-				Type:      event.ApplyEventResourceUpdate,
-				Object:    createObject("batch", "CronJob", "foo", "my-cron"),
+				Operation:  event.Configured,
+				Type:       event.ApplyEventResourceUpdate,
+				Identifier: createIdentifier("batch", "CronJob", "foo", "my-cron"),
 			},
 			expected: "cronjob.batch/my-cron configured (preview-server)",
 		},
@@ -81,7 +81,7 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 				},
 			},
 			expected: `
-1 resource(s) applied. 0 created, 0 unchanged, 0 configured, 1 serverside applied
+1 resource(s) applied. 0 created, 0 unchanged, 0 configured, 0 failed, 1 serverside applied
 deployment.apps/my-dep is Current: Resource is Current
 `,
 		},
@@ -149,18 +149,18 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 		"resource pruned without no dryrun": {
 			previewStrategy: common.DryRunNone,
 			event: event.PruneEvent{
-				Operation: event.Pruned,
-				Type:      event.PruneEventResourceUpdate,
-				Object:    createObject("apps", "Deployment", "default", "my-dep"),
+				Operation:  event.Pruned,
+				Type:       event.PruneEventResourceUpdate,
+				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
 			expected: "deployment.apps/my-dep pruned",
 		},
 		"resource skipped with client dryrun": {
 			previewStrategy: common.DryRunClient,
 			event: event.PruneEvent{
-				Operation: event.PruneSkipped,
-				Type:      event.PruneEventResourceUpdate,
-				Object:    createObject("apps", "Deployment", "", "my-dep"),
+				Operation:  event.PruneSkipped,
+				Type:       event.PruneEventResourceUpdate,
+				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 			},
 			expected: "deployment.apps/my-dep prune skipped (preview)",
 		},
@@ -173,7 +173,7 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 				Pruned:  1,
 				Skipped: 2,
 			},
-			expected: "1 resource(s) pruned, 2 skipped",
+			expected: "1 resource(s) pruned, 2 skipped, 0 failed",
 		},
 	}
 
@@ -249,6 +249,17 @@ func createObject(group, kind, namespace, name string) *unstructured.Unstructure
 				"name":      name,
 				"namespace": namespace,
 			},
+		},
+	}
+}
+
+func createIdentifier(group, kind, namespace, name string) object.ObjMetadata {
+	return object.ObjMetadata{
+		Namespace: namespace,
+		Name:      name,
+		GroupKind: schema.GroupKind{
+			Group: group,
+			Kind:  kind,
 		},
 	}
 }

--- a/cmd/printers/table/collector.go
+++ b/cmd/printers/table/collector.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"sync"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	pe "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -193,7 +191,7 @@ func (r *ResourceStateCollector) processStatusEvent(e event.StatusEvent) {
 // processApplyEvent handles events relating to apply operations
 func (r *ResourceStateCollector) processApplyEvent(e event.ApplyEvent) {
 	if e.Type == event.ApplyEventResourceUpdate {
-		identifier := toIdentifier(e.Object)
+		identifier := e.Identifier
 		previous, found := r.resourceInfos[identifier]
 		if !found {
 			return
@@ -205,23 +203,12 @@ func (r *ResourceStateCollector) processApplyEvent(e event.ApplyEvent) {
 // processPruneEvent handles event related to prune operations.
 func (r *ResourceStateCollector) processPruneEvent(e event.PruneEvent) {
 	if e.Type == event.PruneEventResourceUpdate {
-		identifier := toIdentifier(e.Object)
+		identifier := e.Identifier
 		previous, found := r.resourceInfos[identifier]
 		if !found {
 			return
 		}
 		previous.PruneOpResult = &e.Operation
-	}
-}
-
-// toIdentifier extracts the identifying information from an
-// object.
-func toIdentifier(o runtime.Object) object.ObjMetadata {
-	accessor, _ := meta.Accessor(o)
-	return object.ObjMetadata{
-		GroupKind: o.GetObjectKind().GroupVersionKind().GroupKind(),
-		Namespace: accessor.GetNamespace(),
-		Name:      accessor.GetName(),
 	}
 }
 

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -163,11 +163,11 @@ Run preview to check which commands will be executed
 ```
 kapply preview $BASE > $OUTPUT/status
 
-expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured (preview)"
+expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured, 0 failed (preview)"
 
 kapply preview $BASE --server-side > $OUTPUT/status
 
-expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured, 3 serverside applied (preview-server)"
+expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured, 0 failed, 3 serverside applied (preview-server)"
 
 # Verify that preview didn't create any resources.
 kubectl get all -n hellospace > $OUTPUT/status 2>&1

--- a/go.sum
+++ b/go.sum
@@ -706,8 +706,6 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.9.4 h1:DDuzZtjIzFqp2IPy4DTyCI69Cl3bDgcJODjI6sjF9NY=
-sigs.k8s.io/kustomize/kyaml v0.9.4/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/pkg/apply/event/applyeventoperation_string.go
+++ b/pkg/apply/event/applyeventoperation_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[Created-1]
 	_ = x[Unchanged-2]
 	_ = x[Configured-3]
+	_ = x[Failed-4]
 }
 
-const _ApplyEventOperation_name = "ServersideAppliedCreatedUnchangedConfigured"
+const _ApplyEventOperation_name = "ServersideAppliedCreatedUnchangedConfiguredFailed"
 
-var _ApplyEventOperation_index = [...]uint8{0, 17, 24, 33, 43}
+var _ApplyEventOperation_index = [...]uint8{0, 17, 24, 33, 43, 49}
 
 func (i ApplyEventOperation) String() string {
 	if i < 0 || i >= ApplyEventOperation(len(_ApplyEventOperation_index)-1) {

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -91,6 +91,7 @@ const (
 	Created
 	Unchanged
 	Configured
+	Failed
 )
 
 type ApplyEvent struct {

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -113,7 +113,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			info, err := a.InfoHelper.BuildInfo(obj)
 			if err != nil {
 				taskContext.EventChannel() <- createApplyEvent(
-					object.UnstructuredToObjMeta(obj), event.Unchanged, applyerror.NewUnknownTypeError(err))
+					object.UnstructuredToObjMeta(obj), event.Failed, applyerror.NewUnknownTypeError(err))
 				continue
 			}
 			infos = append(infos, info)
@@ -121,7 +121,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			err = ao.Run()
 			if err != nil {
 				taskContext.EventChannel() <- createApplyEvent(
-					object.UnstructuredToObjMeta(obj), event.Unchanged, applyerror.NewApplyRunError(err))
+					object.UnstructuredToObjMeta(obj), event.Failed, applyerror.NewApplyRunError(err))
 			}
 		}
 
@@ -296,6 +296,6 @@ func createApplyEvent(id object.ObjMetadata, operation event.ApplyEventOperation
 func sendBatchApplyEvents(taskContext *taskrunner.TaskContext, objects []*unstructured.Unstructured, err error) {
 	for _, obj := range objects {
 		taskContext.EventChannel() <- createApplyEvent(
-			object.UnstructuredToObjMeta(obj), event.Unchanged, applyerror.NewInitializeApplyOptionError(err))
+			object.UnstructuredToObjMeta(obj), event.Failed, applyerror.NewInitializeApplyOptionError(err))
 	}
 }


### PR DESCRIPTION
To fix #282.

After we add the continue on error in the applier, the event includes a new field `Identifier`. This field will be always assigned during applying/pruning. The existing field `Object` is sometimes nil. So the printer should relay on `Identifier` instead of the `Object` for ApplyEvent/PruneEvent/DeleteEvent.

Another change is that we added a `failedCount` in the printer for apply/prune event. Here is an example of the output
```
$ kapply apply .
namespace/test-namespace created
service/helloworld-gke created
deployment.apps/helloworld-gke1 failed
deployment.apps/helloworld-gke2 created
4 resource(s) applied. 3 created, 0 unchanged, 0 configured, 1 failed
0 resource(s) pruned, 0 skipped, 0 failed
```