### PR TITLE
Improve the Applier tests

### DIFF
--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -54,7 +54,7 @@ type ClusterInventoryClient struct {
 	dryRunStrategy        common.DryRunStrategy
 	InventoryFactoryFunc  InventoryFactoryFunc
 	invToUnstructuredFunc InventoryToUnstructuredFunc
-	infoHelper            info.InfoHelper
+	InfoHelper            info.InfoHelper
 }
 
 var _ InventoryClient = &ClusterInventoryClient{}
@@ -82,7 +82,7 @@ func NewInventoryClient(factory cmdutil.Factory,
 		dryRunStrategy:        common.DryRunNone,
 		InventoryFactoryFunc:  invFunc,
 		invToUnstructuredFunc: invToUnstructuredFunc,
-		infoHelper:            info.NewInfoHelper(factory),
+		InfoHelper:            info.NewInfoHelper(factory),
 	}
 	return &clusterInventoryClient, nil
 }
@@ -444,7 +444,7 @@ func (cic *ClusterInventoryClient) ApplyInventoryNamespace(obj *unstructured.Uns
 }
 
 func (cic *ClusterInventoryClient) toInfo(obj *unstructured.Unstructured) (*resource.Info, error) {
-	return cic.infoHelper.BuildInfo(obj)
+	return cic.InfoHelper.BuildInfo(obj)
 }
 
 // helperFromInfo returns the resource.Helper to talk to the APIServer based


### PR DESCRIPTION
This updates the `Applier` tests to (mostly) avoid using mocks of `Applier` components, but instead rely on the client stubs. With this change, the handling of the inventory object is part of the tests.

With the exception of changing a field to be published, it only contains changes to the test code.

It also adds additional tests.