### PR TITLE
add ids in the apply task into taskContext

### DIFF
--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -137,6 +137,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 					continue
 				}
 			}
+			infos = append(infos, info)
 			canApply, err := inventory.CanApply(a.InvInfo, clusterObj, a.InventoryPolicy)
 			if !canApply {
 				taskContext.EventChannel() <- createApplyEvent(
@@ -147,7 +148,6 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			}
 			// add the inventory annotation to the resource being applied.
 			inventory.AddInventoryIDAnnotation(obj, a.InvInfo)
-			infos = append(infos, info)
 			ao.SetObjects([]*resource.Info{info})
 			err = ao.Run()
 			if err != nil {

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -611,6 +611,8 @@ func TestApplyTaskWithDifferentInventoryAnnotation(t *testing.T) {
 				assert.Equal(t, tc.expectedEvents[i].Type, e.Type)
 				assert.Equal(t, tc.expectedEvents[i].ApplyEvent.Error.Error(), e.ApplyEvent.Error.Error())
 			}
+			actualUids := taskContext.AllResourceUIDs()
+			assert.Equal(t, len(actualUids), 1)
 		})
 	}
 }


### PR DESCRIPTION
The existing code doesn't add the id into the taskContext when the resource has a different owning-inventory. As a result, the resource was included in the prune task incorrectly. This change is to fix that.

/assign @mortent 