### PR TITLE
Fix missing identifier delete event

### DIFF
--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -139,9 +139,10 @@ func runPruneEventTransformer(eventChannel chan event.Event) (chan event.Event, 
 			eventChannel <- event.Event{
 				Type: event.DeleteType,
 				DeleteEvent: event.DeleteEvent{
-					Type:      event.DeleteEventResourceUpdate,
-					Operation: transformPruneOperation(msg.PruneEvent.Operation),
-					Object:    msg.PruneEvent.Object,
+					Type:       event.DeleteEventResourceUpdate,
+					Operation:  transformPruneOperation(msg.PruneEvent.Operation),
+					Object:     msg.PruneEvent.Object,
+					Identifier: msg.PruneEvent.Identifier,
 				},
 			}
 		}

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -103,10 +103,8 @@ func crdTest(_ client.Client, inventoryName, namespaceName string) {
 			deleteEvent: &expDeleteEvent{
 				deleteEventType: event.DeleteEventResourceUpdate,
 				operation:       event.Deleted,
-				// TODO(mortent): The identifier isn't populated in the Delete
-				// events. This should be fixed.
-				// identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
-				error: nil,
+				identifier:      object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				error:           nil,
 			},
 		},
 	}, destroyerEvents)


### PR DESCRIPTION
This addresses an issue where the identifier was not copied over from the `PruneEvent` to the `DeleteEvent`.