### PR TITLE
Custom inventory type e2e test

### DIFF
--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -139,9 +139,10 @@ func runPruneEventTransformer(eventChannel chan event.Event) (chan event.Event, 
 			eventChannel <- event.Event{
 				Type: event.DeleteType,
 				DeleteEvent: event.DeleteEvent{
-					Type:      event.DeleteEventResourceUpdate,
-					Operation: transformPruneOperation(msg.PruneEvent.Operation),
-					Object:    msg.PruneEvent.Object,
+					Type:       event.DeleteEventResourceUpdate,
+					Operation:  transformPruneOperation(msg.PruneEvent.Operation),
+					Object:     msg.PruneEvent.Object,
+					Identifier: msg.PruneEvent.Identifier,
 				},
 			}
 		}

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -67,16 +67,8 @@ func applyAndDestroyTest(c client.Client, inventoryName, namespaceName string) {
 
 	By("Destroy resources")
 	destroyer := newDestroyer()
-	err = destroyer.Initialize()
-	Expect(err).NotTo(HaveOccurred())
 
-	destroyCh := destroyer.Run(inv)
-
-	var destroyerEvents []event.Event
-	for e := range destroyCh {
-		Expect(e.Type).NotTo(Equal(event.ErrorType))
-		destroyerEvents = append(destroyerEvents, e)
-	}
+	destroyerEvents := runCollectNoErr(destroyer.Run(inv))
 	err = verifyEvents([]expEvent{
 		{
 			eventType: event.DeleteType,

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -103,10 +103,8 @@ func crdTest(_ client.Client, inventoryName, namespaceName string) {
 			deleteEvent: &expDeleteEvent{
 				deleteEventType: event.DeleteEventResourceUpdate,
 				operation:       event.Deleted,
-				// TODO(mortent): The identifier isn't populated in the Delete
-				// events. This should be fixed.
-				// identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
-				error: nil,
+				identifier:      object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				error:           nil,
 			},
 		},
 	}, destroyerEvents)

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -1,0 +1,176 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func crdTest(_ client.Client, inventoryName, namespaceName string) {
+	By("apply a set of resources that includes both a crd and a cr")
+	applier := newApplier()
+
+	inv := inventory.WrapInventoryInfoObj(cmInventoryManifest(inventoryName, namespaceName, "test"))
+
+	resources := []*unstructured.Unstructured{
+		deploymentManifest(namespaceName),
+		manifestToUnstructured(cr),
+		manifestToUnstructured(crd),
+	}
+
+	ch := applier.Run(context.TODO(), inv, resources, apply.Options{
+		ReconcileTimeout: 2 * time.Minute,
+		EmitStatusEvents: true,
+	})
+
+	var applierEvents []event.Event
+	for e := range ch {
+		Expect(e.Type).NotTo(Equal(event.ErrorType))
+		applierEvents = append(applierEvents, e)
+	}
+	err := verifyEvents([]expEvent{
+		{
+			eventType: event.ApplyType,
+			applyEvent: &expApplyEvent{
+				applyEventType: event.ApplyEventResourceUpdate,
+				operation:      event.Created,
+				identifier:     object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				error:          nil,
+			},
+		},
+		{
+			eventType: event.StatusType,
+			statusEvent: &expStatusEvent{
+				statusEventType: event.StatusEventResourceUpdate,
+				identifier:      object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				status:          status.CurrentStatus,
+				error:           nil,
+			},
+		},
+		{
+			eventType: event.ApplyType,
+			applyEvent: &expApplyEvent{
+				applyEventType: event.ApplyEventResourceUpdate,
+				operation:      event.Created,
+			},
+		},
+		{
+			eventType: event.ApplyType,
+			applyEvent: &expApplyEvent{
+				applyEventType: event.ApplyEventResourceUpdate,
+				operation:      event.Created,
+			},
+		},
+	}, applierEvents)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("destroy the resources, including the crd")
+	destroyer := newDestroyer()
+	destroyerEvents := runCollectNoErr(destroyer.Run(inv))
+	err = verifyEvents([]expEvent{
+		{
+			eventType: event.DeleteType,
+			deleteEvent: &expDeleteEvent{
+				deleteEventType: event.DeleteEventResourceUpdate,
+				operation:       event.Deleted,
+				error:           nil,
+			},
+		},
+		{
+			eventType: event.DeleteType,
+			deleteEvent: &expDeleteEvent{
+				deleteEventType: event.DeleteEventResourceUpdate,
+				operation:       event.Deleted,
+				error:           nil,
+			},
+		},
+		{
+			eventType: event.DeleteType,
+			deleteEvent: &expDeleteEvent{
+				deleteEventType: event.DeleteEventResourceUpdate,
+				operation:       event.Deleted,
+				// TODO(mortent): The identifier isn't populated in the Delete
+				// events. This should be fixed.
+				// identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				error: nil,
+			},
+		},
+	}, destroyerEvents)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+var crd = []byte(strings.TrimSpace(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.cli-utils.example.io
+spec:
+  conversion:
+    strategy: None
+  group: cli-utils.example.io
+  names:
+    kind: Example
+    listKind: ExampleList
+    plural: examples
+    singular: example
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Example for cli-utils e2e tests
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Example for cli-utils e2e tests
+            properties:
+              replicas:
+                description: Number of replicas 
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+`))
+
+var cr = []byte(strings.TrimSpace(`
+apiVersion: cli-utils.example.io/v1alpha1
+kind: Example
+metadata:
+  name: example-cr
+spec:
+  replicas: 4
+`))
+
+func manifestToUnstructured(manifest []byte) *unstructured.Unstructured {
+	u := make(map[string]interface{})
+	err := yaml.Unmarshal(manifest, &u)
+	if err != nil {
+		panic(err)
+	}
+	return &unstructured.Unstructured{
+		Object: u,
+	}
+}

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -1,0 +1,185 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package customprovider
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/provider"
+)
+
+var InventoryCRD = []byte(strings.TrimSpace(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inventories.cli-utils.example.io
+spec:
+  conversion:
+    strategy: None
+  group: cli-utils.example.io
+  names:
+    kind: Inventory
+    listKind: InventoryList
+    plural: inventories
+    singular: inventory
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Example for cli-utils e2e tests
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              inventory:
+                items:
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - namespace
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+`))
+
+var InventoryGVK = schema.GroupVersionKind{
+	Group:   "cli-utils.example.io",
+	Version: "v1alpha1",
+	Kind:    "Inventory",
+}
+
+var _ provider.Provider = &CustomProvider{}
+
+func NewCustomProvider(f util.Factory) provider.Provider {
+	return &CustomProvider{
+		factory: f,
+	}
+}
+
+type CustomProvider struct {
+	factory util.Factory
+}
+
+func (c *CustomProvider) Factory() util.Factory {
+	return c.factory
+}
+
+func (c *CustomProvider) InventoryClient() (inventory.InventoryClient, error) {
+	return inventory.NewInventoryClient(c.factory, WrapInventoryObj, invToUnstructuredFunc)
+}
+
+func invToUnstructuredFunc(inv inventory.InventoryInfo) *unstructured.Unstructured {
+	switch invInfo := inv.(type) {
+	case *InventoryCustomType:
+		return invInfo.inv
+	default:
+		return nil
+	}
+}
+
+func WrapInventoryObj(obj *unstructured.Unstructured) inventory.Inventory {
+	return &InventoryCustomType{inv: obj}
+}
+
+func WrapInventoryInfoObj(obj *unstructured.Unstructured) inventory.InventoryInfo {
+	return &InventoryCustomType{inv: obj}
+}
+
+var _ inventory.Inventory = &InventoryCustomType{}
+var _ inventory.InventoryInfo = &InventoryCustomType{}
+
+type InventoryCustomType struct {
+	inv *unstructured.Unstructured
+}
+
+func (i InventoryCustomType) Namespace() string {
+	return i.inv.GetNamespace()
+}
+
+func (i InventoryCustomType) Name() string {
+	return i.inv.GetName()
+}
+
+func (i InventoryCustomType) ID() string {
+	labels := i.inv.GetLabels()
+	id, found := labels[common.InventoryLabel]
+	if !found {
+		return ""
+	}
+	return id
+}
+
+func (i InventoryCustomType) Load() ([]object.ObjMetadata, error) {
+	var inv []object.ObjMetadata
+	s, found, err := unstructured.NestedSlice(i.inv.Object, "spec", "inventory")
+	if err != nil {
+		return inv, err
+	}
+	if !found {
+		return inv, nil
+	}
+	for _, item := range s {
+		m := item.(map[string]interface{})
+		namespace, _, _ := unstructured.NestedString(m, "namespace")
+		name, _, _ := unstructured.NestedString(m, "name")
+		group, _, _ := unstructured.NestedString(m, "group")
+		kind, _, _ := unstructured.NestedString(m, "kind")
+		obj, err := object.CreateObjMetadata(namespace, name, schema.GroupKind{
+			Group: group,
+			Kind:  kind,
+		})
+		if err != nil {
+			return inv, err
+		}
+		inv = append(inv, obj)
+	}
+	return inv, nil
+}
+
+func (i InventoryCustomType) Store(objs []object.ObjMetadata) error {
+	var inv []interface{}
+	for _, obj := range objs {
+		inv = append(inv, map[string]interface{}{
+			"group":     obj.GroupKind.Group,
+			"kind":      obj.GroupKind.Kind,
+			"namespace": obj.Namespace,
+			"name":      obj.Name,
+		})
+	}
+	if len(inv) > 0 {
+		return unstructured.SetNestedSlice(i.inv.Object, inv, "spec", "inventory")
+	}
+	unstructured.RemoveNestedField(i.inv.Object, "spec")
+	return nil
+}
+
+func (i InventoryCustomType) GetObject() (*unstructured.Unstructured, error) {
+	return i.inv, nil
+}

--- a/test/e2e/inventory_policy_test.go
+++ b/test/e2e/inventory_policy_test.go
@@ -31,7 +31,7 @@ func inventoryPolicyMustMatchTest(c client.Client, namespaceName string) {
 		deploymentManifest(namespaceName),
 	}
 
-	applyWithNoErr(applier.Run(context.TODO(), firstInv, firstResources, apply.Options{
+	runWithNoErr(applier.Run(context.TODO(), firstInv, firstResources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 	}))
@@ -162,7 +162,7 @@ func inventoryPolicyAdoptAllTest(c client.Client, namespaceName string) {
 		deploymentManifest(namespaceName),
 	}
 
-	applyWithNoErr(applier.Run(context.TODO(), firstInv, firstResources, apply.Options{
+	runWithNoErr(applier.Run(context.TODO(), firstInv, firstResources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 	}))


### PR DESCRIPTION
This adds an example custom type for holding the inventory and a provider that uses the type. All the e2e tests will be run using both the default ConfigMap inventory object and this custom type.

Must merge after https://github.com/kubernetes-sigs/cli-utils/pull/310