### PR TITLE
add preprocess function in commands

### DIFF
--- a/cmd/flagutils/utils_test.go
+++ b/cmd/flagutils/utils_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package flagutils
+
+import (
+	"fmt"
+	"testing"
+
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+func TestConvertInventoryPolicy(t *testing.T) {
+	testcases := []struct {
+		value  string
+		policy inventory.InventoryPolicy
+		err    error
+	}{
+		{
+			value:  "strict",
+			policy: inventory.InventoryPolicyMustMatch,
+		},
+		{
+			value:  "adopt",
+			policy: inventory.AdoptIfNoInventory,
+		},
+		{
+			value: "random",
+			err:   fmt.Errorf("inventory policy must be one of strict, adopt"),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.value, func(t *testing.T) {
+			policy, err := ConvertInventoryPolicy(tc.value)
+			if tc.err == nil {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				}
+				if policy != tc.policy {
+					t.Errorf("expected %v but got %v", policy, tc.policy)
+				}
+			}
+			if err == nil && tc.err != nil {
+				t.Errorf("expected an error, but not happened")
+			}
+		})
+	}
+}

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -85,3 +85,7 @@ func (fic *FakeInventoryClient) ClearError() {
 func (fic *FakeInventoryClient) GetClusterInventoryInfo(inv InventoryInfo) (*unstructured.Unstructured, error) {
 	return nil, nil
 }
+
+func (fic *FakeInventoryClient) UpdateLabels(inv InventoryInfo, labels map[string]string) error {
+	return nil
+}

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -44,6 +44,8 @@ type InventoryClient interface {
 	ApplyInventoryNamespace(invNamespace *unstructured.Unstructured) error
 	// GetClusterInventoryInfo returns the cluster inventory object.
 	GetClusterInventoryInfo(inv InventoryInfo) (*unstructured.Unstructured, error)
+	// UpdateLabels updates the labels of the cluster inventory object if it exists.
+	UpdateLabels(InventoryInfo, map[string]string) error
 }
 
 // ClusterInventoryClient is a concrete implementation of the
@@ -268,6 +270,18 @@ func (cic *ClusterInventoryClient) GetClusterInventoryInfo(inv InventoryInfo) (*
 		}
 	}
 	return clusterInv, nil
+}
+
+func (cic *ClusterInventoryClient) UpdateLabels(inv InventoryInfo, labels map[string]string) error {
+	obj, err := cic.GetClusterInventoryInfo(inv)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	obj.SetLabels(labels)
+	return cic.applyInventoryObj(obj)
 }
 
 // mergeClusterInventory merges the inventory of multiple inventory objects


### PR DESCRIPTION
This change adds the following
- add a preprocess function so that the inventoryPolicy can be adjusted
- add a function in InventoryClient to update the inventory object labels if the cluster inventory object exists

This change should be merged after #313 