### PR TITLE
Better final inventory calculation during errors

### DIFF
--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -258,6 +258,11 @@ func TestPrune(t *testing.T) {
 				// the events that can be put on it.
 				eventChannel := make(chan event.Event, len(tc.pastObjs)+1) // Add one for inventory object
 				taskContext := taskrunner.NewTaskContext(eventChannel)
+				for _, u := range tc.currentObjs {
+					o := object.UnstructuredToObjMeta(u)
+					uid := u.GetUID()
+					taskContext.ResourceApplied(o, uid, 0)
+				}
 				err := func() error {
 					defer close(eventChannel)
 					// Run the prune and validate.

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -309,10 +309,11 @@ func getType(task taskrunner.Task) reflect.Type {
 }
 
 type fakeResourceObjects struct {
-	objsForApply []*unstructured.Unstructured
-	inventory    inventory.InventoryInfo
-	idsForApply  []object.ObjMetadata
-	idsForPrune  []object.ObjMetadata
+	objsForApply  []*unstructured.Unstructured
+	inventory     inventory.InventoryInfo
+	idsForApply   []object.ObjMetadata
+	idsForPrune   []object.ObjMetadata
+	idsForPrevInv []object.ObjMetadata
 }
 
 func (f *fakeResourceObjects) ObjsForApply() []*unstructured.Unstructured {
@@ -329,6 +330,10 @@ func (f *fakeResourceObjects) IdsForApply() []object.ObjMetadata {
 
 func (f *fakeResourceObjects) IdsForPrune() []object.ObjMetadata {
 	return f.idsForPrune
+}
+
+func (f *fakeResourceObjects) IdsForPrevInv() []object.ObjMetadata {
+	return f.idsForPrevInv
 }
 
 func ignoreErrInfoToObjMeta(info *unstructured.Unstructured) object.ObjMetadata {

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -4,6 +4,8 @@
 package taskrunner
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -60,12 +62,25 @@ func (tc *TaskContext) ResourceUID(id object.ObjMetadata) (types.UID, bool) {
 	return ai.uid, true
 }
 
+// AppliedResources returns all the objects (as ObjMetadata) that
+// were added as applied resources to the TaskContext.
+func (tc *TaskContext) AppliedResources() []object.ObjMetadata {
+	all := make([]object.ObjMetadata, 0, len(tc.appliedResources))
+	for r := range tc.appliedResources {
+		all = append(all, r)
+	}
+	return all
+}
+
 // AllResourceUIDs returns a set with the UIDs of all the resources in the
 // context.
 func (tc *TaskContext) AllResourceUIDs() sets.String {
 	uids := sets.NewString()
 	for _, ai := range tc.appliedResources {
-		uids.Insert(string(ai.uid))
+		uid := strings.TrimSpace(string(ai.uid))
+		if uid != "" {
+			uids.Insert(uid)
+		}
 	}
 	return uids
 }


### PR DESCRIPTION
* More accurate final inventory set calculation when errors occur.
* Pass through the set of previous inventory objs from `applier` to `apply_task`.
* The previous inventory is used to determine if an object currently exists in the cluster. If it does, and an error occurs, we want to keep this object in the inventory.
* Updates the `apply_task.Start()` function to better determine inclusion/exclusion in final inventory set.
* Adds unit tests for `apply_task.Start()`