### PR TITLE
Fix printing with continue-on-error

### DIFF
--- a/cmd/printers/events/formatter.go
+++ b/cmd/printers/events/formatter.go
@@ -46,8 +46,13 @@ func (ef *formatter) FormatApplyEvent(ae event.ApplyEvent, as *list.ApplyStats, 
 	case event.ApplyEventResourceUpdate:
 		gk := ae.Identifier.GroupKind
 		name := ae.Identifier.Name
-		ef.print("%s %s", resourceIDToString(gk, name),
-			strings.ToLower(ae.Operation.String()))
+		if ae.Error != nil {
+			ef.print("%s failed: %s", resourceIDToString(gk, name),
+				ae.Error.Error())
+		} else {
+			ef.print("%s %s", resourceIDToString(gk, name),
+				strings.ToLower(ae.Operation.String()))
+		}
 	}
 	return nil
 }
@@ -68,12 +73,13 @@ func (ef *formatter) FormatPruneEvent(pe event.PruneEvent, ps *list.PruneStats) 
 		gk := pe.Identifier.GroupKind
 		switch pe.Operation {
 		case event.Pruned:
-			ef.print("%s %s", resourceIDToString(gk, pe.Identifier.Name), "pruned")
+			ef.print("%s pruned", resourceIDToString(gk, pe.Identifier.Name))
 		case event.PruneSkipped:
-			ef.print("%s %s", resourceIDToString(gk, pe.Identifier.Name), "prune skipped")
+			ef.print("%s prune skipped", resourceIDToString(gk, pe.Identifier.Name))
 		}
 	case event.PruneEventFailed:
-		ef.print("%s %s", resourceIDToString(pe.Identifier.GroupKind, pe.Identifier.Name), "prune failed")
+		ef.print("%s prune failed: %s", resourceIDToString(pe.Identifier.GroupKind, pe.Identifier.Name),
+			pe.Error.Error())
 	}
 	return nil
 }
@@ -88,12 +94,13 @@ func (ef *formatter) FormatDeleteEvent(de event.DeleteEvent, ds *list.DeleteStat
 		name := getName(obj)
 		switch de.Operation {
 		case event.Deleted:
-			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "deleted")
+			ef.print("%s deleted", resourceIDToString(gvk.GroupKind(), name))
 		case event.DeleteSkipped:
-			ef.print("%s %s", resourceIDToString(gvk.GroupKind(), name), "delete skipped")
+			ef.print("%s delete skipped", resourceIDToString(gvk.GroupKind(), name))
 		}
 	case event.DeleteEventFailed:
-		ef.print("%s %s", resourceIDToString(de.Identifier.GroupKind, de.Identifier.Name), "deletion failed")
+		ef.print("%s deletion failed: %s", resourceIDToString(de.Identifier.GroupKind, de.Identifier.Name),
+			de.Error.Error())
 	}
 	return nil
 }

--- a/cmd/printers/json/formatter.go
+++ b/cmd/printers/json/formatter.go
@@ -49,13 +49,18 @@ func (jf *formatter) FormatApplyEvent(ae event.ApplyEvent, as *list.ApplyStats, 
 		}
 	case event.ApplyEventResourceUpdate:
 		gk := ae.Identifier.GroupKind
-		return jf.printEvent("apply", "resourceApplied", map[string]interface{}{
+		eventInfo := map[string]interface{}{
 			"group":     gk.Group,
 			"kind":      gk.Kind,
 			"namespace": ae.Identifier.Namespace,
 			"name":      ae.Identifier.Name,
 			"operation": ae.Operation.String(),
-		})
+		}
+		if ae.Error != nil {
+			eventInfo["error"] = ae.Error.Error()
+		}
+
+		return jf.printEvent("apply", "resourceApplied", eventInfo)
 	}
 	return nil
 }

--- a/pkg/print/list/base.go
+++ b/pkg/print/list/base.go
@@ -178,5 +178,9 @@ func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.Dr
 			}
 		}
 	}
+	failedSum := applyStats.Failed + pruneStats.Failed + deleteStats.Failed
+	if failedSum > 0 {
+		return fmt.Errorf("%d resources failed", failedSum)
+	}
 	return nil
 }


### PR DESCRIPTION
When we changed the apply algorithm to continue on errors, it also changed the way we report errors through events. Errors that aren't fatal are no longer reported with an `ErrorEvent`, but rather attached to a `Apply|Prune|DeleteEvent`. 

This PR updates the printer logic to look for errors attached to the specific events and also makes sure we exit with a non-zero exit code if there are any errors. 

This fixes the issue report in https://github.com/GoogleContainerTools/kpt/issues/1470. The output from the example will now be:
```
$ kapply apply . --server-side              
configmap/ConfigMap failed: ConfigMap "ConfigMap" is invalid: metadata.name: Invalid value: "ConfigMap": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
1 resource(s) applied. 0 created, 0 unchanged, 0 configured, 1 failed
0 resource(s) pruned, 0 skipped, 0 failed
error: 1 resources failed

$ echo $?
1
```