### PR TITLE
capture apply/prune duration for single object in events

### DIFF
--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -151,6 +151,7 @@ func runPruneEventTransformer(eventChannel chan event.Event) (chan event.Event, 
 						Operation:  transformPruneOperation(msg.PruneEvent.Operation),
 						Object:     msg.PruneEvent.Object,
 						Identifier: msg.PruneEvent.Identifier,
+						Duration:   msg.PruneEvent.Duration,
 						Error:      msg.PruneEvent.Error,
 					},
 				}

--- a/pkg/apply/duration/duration.go
+++ b/pkg/apply/duration/duration.go
@@ -1,0 +1,20 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package duration
+
+import "time"
+
+var startTime time.Time
+
+// SetStartTime sets the start time to now.
+func SetStartTime(t time.Time) {
+	startTime = t
+}
+
+// GetDuration computes the duration from  the start time
+// to current time.
+func GetDuration(t time.Time) *time.Duration {
+	d := t.Sub(startTime)
+	return &d
+}

--- a/pkg/apply/duration/duration_test.go
+++ b/pkg/apply/duration/duration_test.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package duration
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSetStartTime(t *testing.T) {
+	start := time.Date(2021, 03, 12, 00, 10, 20, 0, time.UTC)
+	SetStartTime(start)
+	if startTime != start {
+		t.Errorf("expected %v equal to %v", startTime, start)
+	}
+}
+
+func TestGetDuration(t *testing.T) {
+	start := time.Date(2021, 03, 12, 00, 10, 20, 0, time.UTC)
+	SetStartTime(start)
+	end := time.Date(2021, 03, 13, 00, 10, 20, 0, time.UTC)
+	d := GetDuration(end)
+	if *d != 24*time.Hour {
+		t.Errorf("expected %v but got %v", 24*time.Hour, *d)
+	}
+}

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -4,6 +4,8 @@
 package event
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -99,6 +101,7 @@ type ApplyEvent struct {
 	Operation  ApplyEventOperation
 	Object     *unstructured.Unstructured
 	Identifier object.ObjMetadata
+	Duration   *time.Duration
 	Error      error
 }
 
@@ -137,6 +140,7 @@ type PruneEvent struct {
 	Operation  PruneEventOperation
 	Object     *unstructured.Unstructured
 	Identifier object.ObjMetadata
+	Duration   *time.Duration
 	Error      error
 }
 
@@ -162,5 +166,6 @@ type DeleteEvent struct {
 	Operation  DeleteEventOperation
 	Object     *unstructured.Unstructured
 	Identifier object.ObjMetadata
+	Duration   *time.Duration
 	Error      error
 }

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/apply/duration"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -140,7 +142,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 					pruneObj.Namespace, pruneObj.Name, err)
 			}
 			pruneFailures = append(pruneFailures, pruneObj)
-			taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err)
+			taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err, nil)
 			taskContext.CaptureResourceFailure(pruneObj)
 			continue
 		}
@@ -153,7 +155,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 		// Handle lifecycle directive preventing deletion.
 		if !canPrune(localInv, obj, o.InventoryPolicy, uid) {
 			klog.V(4).Infof("skip prune for lifecycle directive %s/%s", pruneObj.Namespace, pruneObj.Name)
-			taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.PruneSkipped)
+			taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.PruneSkipped, nil)
 			pruneFailures = append(pruneFailures, pruneObj)
 			continue
 		}
@@ -163,7 +165,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 			if pruneObj.GroupKind == object.CoreV1Namespace.GroupKind() &&
 				localNamespaces.Has(pruneObj.Name) {
 				klog.V(4).Infof("skip pruning namespace: %s", pruneObj.Name)
-				taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.PruneSkipped)
+				taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.PruneSkipped, nil)
 				pruneFailures = append(pruneFailures, pruneObj)
 				taskContext.CaptureResourceFailure(pruneObj)
 				continue
@@ -176,23 +178,24 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 				if klog.V(4) {
 					klog.Errorf("prune failed for %s/%s (%s)", pruneObj.Namespace, pruneObj.Name, err)
 				}
-				taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err)
+				taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err, nil)
 				pruneFailures = append(pruneFailures, pruneObj)
 				taskContext.CaptureResourceFailure(pruneObj)
 				continue
 			}
+			duration.SetStartTime(time.Now())
 			err = namespacedClient.Delete(context.TODO(), pruneObj.Name, metav1.DeleteOptions{})
 			if err != nil {
 				if klog.V(4) {
 					klog.Errorf("prune failed for %s/%s (%s)", pruneObj.Namespace, pruneObj.Name, err)
 				}
-				taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err)
+				taskContext.EventChannel() <- createPruneFailedEvent(pruneObj, err, duration.GetDuration(time.Now()))
 				pruneFailures = append(pruneFailures, pruneObj)
 				taskContext.CaptureResourceFailure(pruneObj)
 				continue
 			}
 		}
-		taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.Pruned)
+		taskContext.EventChannel() <- createPruneEvent(pruneObj, obj, event.Pruned, duration.GetDuration(time.Now()))
 	}
 	// Final inventory equals applied objects and prune failures.
 	appliedResources := taskContext.AppliedResources()
@@ -246,7 +249,7 @@ func preventDeleteAnnotation(annotations map[string]string) bool {
 }
 
 // createPruneEvent is a helper function to package a prune event.
-func createPruneEvent(id object.ObjMetadata, obj *unstructured.Unstructured, op event.PruneEventOperation) event.Event {
+func createPruneEvent(id object.ObjMetadata, obj *unstructured.Unstructured, op event.PruneEventOperation, d *time.Duration) event.Event {
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
@@ -254,18 +257,20 @@ func createPruneEvent(id object.ObjMetadata, obj *unstructured.Unstructured, op 
 			Operation:  op,
 			Object:     obj,
 			Identifier: id,
+			Duration:   d,
 		},
 	}
 }
 
 // createPruneEvent is a helper function to package a prune event for a failure.
-func createPruneFailedEvent(objMeta object.ObjMetadata, err error) event.Event {
+func createPruneFailedEvent(objMeta object.ObjMetadata, err error, d *time.Duration) event.Event {
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
 			Type:       event.PruneEventFailed,
 			Identifier: objMeta,
 			Error:      err,
+			Duration:   d,
 		},
 	}
 }

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -654,6 +654,7 @@ func TestApplyTaskWithError(t *testing.T) {
 			for i, e := range events {
 				assert.Equal(t, tc.expectedEvents[i].Type, e.Type)
 				assert.Equal(t, tc.expectedEvents[i].ApplyEvent.Error.Error(), e.ApplyEvent.Error.Error())
+				assert.NotNil(t, e.ApplyEvent.Duration)
 			}
 		})
 	}

--- a/pkg/apply/task/printer_adapter.go
+++ b/pkg/apply/task/printer_adapter.go
@@ -6,10 +6,12 @@ package task
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
+	"sigs.k8s.io/cli-utils/pkg/apply/duration"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -40,6 +42,7 @@ func (r *resourcePrinterImpl) PrintObj(obj runtime.Object, _ io.Writer) error {
 			Operation:  r.applyOperation,
 			Object:     obj.(*unstructured.Unstructured),
 			Identifier: object.RuntimeToObjMeta(obj),
+			Duration:   duration.GetDuration(time.Now()),
 		},
 	}
 	return nil

--- a/pkg/apply/task/printer_adapter_test.go
+++ b/pkg/apply/task/printer_adapter_test.go
@@ -7,13 +7,16 @@ import (
 	"bytes"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply/duration"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 )
 
 func TestKubectlPrinterAdapter(t *testing.T) {
+	duration.SetStartTime(time.Now())
 	ch := make(chan event.Event)
 	buffer := bytes.Buffer{}
 	operation := "serverside-applied"
@@ -51,4 +54,8 @@ func TestKubectlPrinterAdapter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, event.ServersideApplied, msg.ApplyEvent.Operation)
 	assert.Equal(t, deployment, msg.ApplyEvent.Object)
+	assert.NotNil(t, msg.ApplyEvent.Duration)
+	if *msg.ApplyEvent.Duration == 0*time.Second {
+		t.Errorf("duration should be greater than 0")
+	}
 }


### PR DESCRIPTION
This change adds a new field `Duration` to ApplyEvent, PruneEvent and DeleteEvent.

The `Duration` is used to capture the time taken by applying/pruning/deleting a single object. 

@seans3  @mortent 