### PR TITLE
Don't emit Prune event for NoMatchError

### DIFF
--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -130,7 +130,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 		obj, err := po.getObject(pruneObj)
 		if err != nil {
 			// Object not found in cluster, so no need to delete it; skip to next object.
-			if apierrors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				klog.V(5).Infof("%s/%s not found in cluster--skipping",
 					pruneObj.Namespace, pruneObj.Name)
 				continue

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -138,6 +138,20 @@ var role = &unstructured.Unstructured{
 	},
 }
 
+var unknownCR = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "cli-utils.test/v1",
+		"kind":       "Unknown",
+		"metadata": map[string]interface{}{
+			"name":      "test",
+			"namespace": "default",
+			"annotations": map[string]interface{}{
+				"config.k8s.io/owning-inventory": testInventoryLabel,
+			},
+		},
+	},
+}
+
 // Returns a inventory object with the inventory set from
 // the passed "children".
 func createInventoryInfo(children ...*unstructured.Unstructured) inventory.InventoryInfo {
@@ -230,6 +244,13 @@ func TestPrune(t *testing.T) {
 			prunedObjs:       []*unstructured.Unstructured{pdb},
 			finalClusterObjs: []*unstructured.Unstructured{namespace, pod},
 			pruneEventObjs:   []*unstructured.Unstructured{pdb, namespace},
+		},
+		"unknown type doesn't emit prune failed event": {
+			pastObjs:         []*unstructured.Unstructured{unknownCR},
+			currentObjs:      []*unstructured.Unstructured{},
+			prunedObjs:       []*unstructured.Unstructured{unknownCR},
+			finalClusterObjs: []*unstructured.Unstructured{},
+			pruneEventObjs:   []*unstructured.Unstructured{},
 		},
 	}
 	for name, tc := range tests {


### PR DESCRIPTION
The existing prune has a bug when handling the following case:
1. The inventory list contains a CR
2. The CRD is deleted from the cluster. Consequently the CR is also deleted from the cluster.
3. Then remove the configuration for the CR from the local directory
4. Apply the directory, since the CR is in the previously applied set and not in the current apply set. The CR should be pruned.
5. When getting the CR from the cluster, an error is get since no type is not matched since the CRD is deleted.
6. It emits a PruneEvent with this error.

Since the CR doesn't exist in step 5, we actually don't need to trigger the deletion for it. Emitting the PruneEvent with an error doesn't make sense either. It only needs to remove the GKNN of the CR from the inventory list, which is already done by the current code.

This PR checks if the error from step 5 is a NoMatchError. It it is, continue to the next object.