### PR TITLE
Make DIR optional for live commands

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -89,6 +89,10 @@ type ApplyRunner struct {
 }
 
 func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// default to the current working directory if no args are provided
+		args = append(args, ".")
+	}
 	prunePropPolicy, err := convertPropagationPolicy(r.prunePropagationPolicy)
 	if err != nil {
 		return err

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -66,6 +66,10 @@ type DestroyRunner struct {
 }
 
 func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// default to the current working directory if no args are provided
+		args = append(args, ".")
+	}
 	inventoryPolicy, err := flagutils.ConvertInventoryPolicy(r.inventoryPolicy)
 	if err != nil {
 		return err

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -87,6 +87,10 @@ type PreviewRunner struct {
 
 // RunE is the function run from the cobra command.
 func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// default to the current working directory if no args are provided
+		args = append(args, ".")
+	}
 	var ch <-chan event.Event
 
 	drs := common.DryRunClient

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -72,6 +72,10 @@ type StatusRunner struct {
 // poller to compute status for each of the resources. One of the printer
 // implementations takes care of printing the output.
 func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// default to the current working directory if no args are provided
+		args = append(args, ".")
+	}
 	_, err := common.DemandOneDirectory(args)
 	if err != nil {
 		return err

--- a/pkg/manifestreader/manifestloader.go
+++ b/pkg/manifestreader/manifestloader.go
@@ -59,8 +59,14 @@ func (f *manifestLoader) ManifestReader(reader io.Reader, args []string) (Manife
 		EnforceNamespace: enforceNamespace,
 	}
 
+	return mReader(args, reader, readerOptions), nil
+}
+
+// mReader returns the ManifestReader based in the input args
+func mReader(args []string, reader io.Reader, readerOptions ReaderOptions) ManifestReader {
 	var mReader ManifestReader
-	if len(args) == 0 {
+	// Read from stdin if "-" is specified, similar to kubectl
+	if args[0] == "-" {
 		mReader = &StreamManifestReader{
 			ReaderName:    "stdin",
 			Reader:        reader,
@@ -72,5 +78,5 @@ func (f *manifestLoader) ManifestReader(reader io.Reader, args []string) (Manife
 			ReaderOptions: readerOptions,
 		}
 	}
-	return mReader, nil
+	return mReader
 }

--- a/pkg/manifestreader/manifestloader_test.go
+++ b/pkg/manifestreader/manifestloader_test.go
@@ -1,0 +1,79 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestMReader_Read(t *testing.T) {
+	testCases := map[string]struct {
+		manifests        map[string]string
+		namespace        string
+		enforceNamespace bool
+		validate         bool
+		args             []string
+
+		infosCount int
+		namespaces []string
+	}{
+		"path mReader: namespace should be set if not already present": {
+			namespace:        "foo",
+			enforceNamespace: true,
+			args:             []string{"${reader-test-dir}"},
+			infosCount:       1,
+			namespaces:       []string{"foo"},
+		},
+		"stream mReader: namespace should be set if not already present": {
+			namespace:        "foo",
+			enforceNamespace: true,
+			args:             []string{"-"},
+			infosCount:       1,
+			namespaces:       []string{"foo"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+			defer tf.Cleanup()
+
+			mapper, err := tf.ToRESTMapper()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			dir, err := ioutil.TempDir("", "reader-test")
+			assert.NoError(t, err)
+			p := filepath.Join(dir, "dep.yaml")
+			err = ioutil.WriteFile(p, []byte(depManifest), 0600)
+			assert.NoError(t, err)
+			stringReader := strings.NewReader(depManifest)
+
+			if tc.args[0] == "${reader-test-dir}" {
+				tc.args = []string{dir}
+			}
+
+			objs, err := mReader(tc.args, stringReader, ReaderOptions{
+				Mapper:           mapper,
+				Namespace:        tc.namespace,
+				EnforceNamespace: tc.enforceNamespace,
+				Validate:         tc.validate,
+			}).Read()
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(objs), tc.infosCount)
+
+			for i, obj := range objs {
+				assert.Equal(t, tc.namespaces[i], obj.GetNamespace())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is to make DIR argument optional for live commands and default to current working directory. Commands must accept stdin iff `-` is provided as argument similar to kubectl.