### PR TITLE
Decouple manifest reader from cli

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -113,7 +113,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), flagutils.PathFromArgs(args))
 	if err != nil {
 		return err
 	}

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -72,7 +72,7 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Retrieve the inventory object.
-	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), flagutils.PathFromArgs(args))
 	if err != nil {
 		return err
 	}

--- a/cmd/flagutils/utils.go
+++ b/cmd/flagutils/utils.go
@@ -26,3 +26,12 @@ func ConvertInventoryPolicy(policy string) (inventory.InventoryPolicy, error) {
 			"inventory policy must be one of strict, adopt")
 	}
 }
+
+// PathFromArgs returns the path which is a positional arg from args list
+// returns "-" if there is length of args is 0, which implies no path is provided
+func PathFromArgs(args []string) string {
+	if len(args) == 0 {
+		return "-"
+	}
+	return args[0]
+}

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -103,7 +103,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), flagutils.PathFromArgs(args))
 	if err != nil {
 		return err
 	}

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/cmd/flagutils"
 	"sigs.k8s.io/cli-utils/cmd/status/printers"
 	"sigs.k8s.io/cli-utils/pkg/apply/poller"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -77,7 +78,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), args)
+	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), flagutils.PathFromArgs(args))
 	if err != nil {
 		return err
 	}

--- a/pkg/manifestreader/fake-loader.go
+++ b/pkg/manifestreader/fake-loader.go
@@ -27,7 +27,7 @@ func NewFakeLoader(f util.Factory, objs []object.ObjMetadata) *fakeLoader {
 	}
 }
 
-func (f *fakeLoader) ManifestReader(reader io.Reader, _ []string) (ManifestReader, error) {
+func (f *fakeLoader) ManifestReader(reader io.Reader, _ string) (ManifestReader, error) {
 	mapper, err := f.factory.ToRESTMapper()
 	if err != nil {
 		return nil, err

--- a/pkg/manifestreader/manifestloader_test.go
+++ b/pkg/manifestreader/manifestloader_test.go
@@ -1,0 +1,79 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package manifestreader
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestMReader_Read(t *testing.T) {
+	testCases := map[string]struct {
+		manifests        map[string]string
+		namespace        string
+		enforceNamespace bool
+		validate         bool
+		path             string
+
+		infosCount int
+		namespaces []string
+	}{
+		"path mReader: namespace should be set if not already present": {
+			namespace:        "foo",
+			enforceNamespace: true,
+			path:             "${reader-test-dir}",
+			infosCount:       1,
+			namespaces:       []string{"foo"},
+		},
+		"stream mReader: namespace should be set if not already present": {
+			namespace:        "foo",
+			enforceNamespace: true,
+			path:             "-",
+			infosCount:       1,
+			namespaces:       []string{"foo"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+			defer tf.Cleanup()
+
+			mapper, err := tf.ToRESTMapper()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			dir, err := ioutil.TempDir("", "reader-test")
+			assert.NoError(t, err)
+			p := filepath.Join(dir, "dep.yaml")
+			err = ioutil.WriteFile(p, []byte(depManifest), 0600)
+			assert.NoError(t, err)
+			stringReader := strings.NewReader(depManifest)
+
+			if tc.path == "${reader-test-dir}" {
+				tc.path = dir
+			}
+
+			objs, err := mReader(tc.path, stringReader, ReaderOptions{
+				Mapper:           mapper,
+				Namespace:        tc.namespace,
+				EnforceNamespace: tc.enforceNamespace,
+				Validate:         tc.validate,
+			}).Read()
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(objs), tc.infosCount)
+
+			for i, obj := range objs {
+				assert.Equal(t, tc.namespaces[i], obj.GetNamespace())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is to decouple manifest reader api from cli. Manifest reader needs `args` argument currently which makes it tightly coupled with cli. This PR removes that dependency and passes the path argument to the manifest reader instead of cobra args. With this, the cmd folder has all the cobra related code and the rest of the api is just a library.

This doesn't change the behavior of kapply cli.