### PR TITLE
[WIP] Add depends-on annotation and apply sort order

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,6 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.10.14 h1:8zftx3bT0r2355kE/cZfwCMq9SlTWMBvadwwtl+jcbU=
-sigs.k8s.io/kustomize/kyaml v0.10.14/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=
 sigs.k8s.io/kustomize/kyaml v0.10.16 h1:4rn0PTEK4STOA5kbpz72oGskjpKYlmwru4YRgVQFv+c=
 sigs.k8s.io/kustomize/kyaml v0.10.16/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/pkg/object/graph/graph.go
+++ b/pkg/object/graph/graph.go
@@ -1,0 +1,143 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// This package provides a graph data struture
+// and graph functionality using ObjMetadata as
+// vertices in the graph.
+package graph
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// Graph is contains a directed set of edges, implemented as
+// an adjacency list (map key is "from" vertex, slice are "to"
+// vertices).
+type Graph struct {
+	// map "from" vertex -> list of "to" vertices
+	edges map[object.ObjMetadata][]object.ObjMetadata
+}
+
+// Edge encapsulates a pair of vertices describing a
+// directed edge.
+type Edge struct {
+	From object.ObjMetadata
+	To   object.ObjMetadata
+}
+
+// New returns a pointer to an empty Graph data structure.
+func New() *Graph {
+	g := &Graph{}
+	g.edges = make(map[object.ObjMetadata][]object.ObjMetadata)
+	return g
+}
+
+// AddVertex adds an ObjMetadata vertex to the graph, with
+// an initial empty set of edges from added vertex.
+func (g *Graph) AddVertex(v object.ObjMetadata) {
+	if _, exists := g.edges[v]; !exists {
+		g.edges[v] = []object.ObjMetadata{}
+	}
+}
+
+// AddEdge adds a edge from one ObjMetadata vertex to another. The
+// direction of the edge is "from" -> "to".
+func (g *Graph) AddEdge(from object.ObjMetadata, to object.ObjMetadata) {
+	// Add "from" vertex if it doesn't already exist.
+	if _, exists := g.edges[from]; !exists {
+		g.edges[from] = []object.ObjMetadata{}
+	}
+	// Add "to" vertex if it doesn't already exist.
+	if _, exists := g.edges[to]; !exists {
+		g.edges[to] = []object.ObjMetadata{}
+	}
+	// Add edge "from" -> "to" if it doesn't already exist
+	// into the adjacency list.
+	if !g.isAdjacent(from, to) {
+		g.edges[from] = append(g.edges[from], to)
+	}
+}
+
+// GetEdges returns the slice of vertex pairs which are
+// the directed edges of the graph.
+func (g *Graph) GetEdges() []Edge {
+	edges := []Edge{}
+	for from, toList := range g.edges {
+		for _, to := range toList {
+			edge := Edge{From: from, To: to}
+			edges = append(edges, edge)
+		}
+	}
+	return edges
+}
+
+// isAdjacent returns true if an edge "from" vertex -> "to" vertex exists;
+// false otherwise.
+func (g *Graph) isAdjacent(from object.ObjMetadata, to object.ObjMetadata) bool {
+	// If "from" vertex does not exist, it is impossible edge exists; return false.
+	if _, exists := g.edges[from]; !exists {
+		return false
+	}
+	// Iterate through adjacency list to see if "to" vertex is adjacent.
+	for _, vertex := range g.edges[from] {
+		if vertex == to {
+			return true
+		}
+	}
+	return false
+}
+
+// Size returns the number of vertices in the graph.
+func (g *Graph) Size() int {
+	return len(g.edges)
+}
+
+// removeVertex removes the passed vertex as well as any edges
+// into the vertex.
+func (g *Graph) removeVertex(r object.ObjMetadata) {
+	// First, remove the object from all adjacency lists.
+	for v, adj := range g.edges {
+		for i, a := range adj {
+			if a == r {
+				g.edges[v] = removeObj(adj, i)
+				break
+			}
+		}
+	}
+	// Finally, remove the vertex
+	delete(g.edges, r)
+}
+
+// removeObj removes the object at index "i" from the passed
+// list of vertices, returning the new list.
+func removeObj(adj []object.ObjMetadata, i int) []object.ObjMetadata {
+	adj[len(adj)-1], adj[i] = adj[i], adj[len(adj)-1]
+	return adj[:len(adj)-1]
+}
+
+// Sort returns the ordered set of vertices after
+// a topological sort.
+func (g *Graph) Sort() ([][]object.ObjMetadata, error) {
+	sorted := [][]object.ObjMetadata{}
+	for g.Size() > 0 {
+		// Identify all the leaf vertices.
+		leafVertices := []object.ObjMetadata{}
+		for v, adj := range g.edges {
+			if len(adj) == 0 {
+				leafVertices = append(leafVertices, v)
+			}
+		}
+		// No leaf vertices means cycle in the directed graph.
+		if len(leafVertices) == 0 {
+			return sorted, fmt.Errorf("cycle in directed graph")
+		}
+		// Remove all edges to leaf vertices.
+		for _, v := range leafVertices {
+			g.removeVertex(v)
+		}
+		sorted = append(sorted, leafVertices)
+	}
+	return sorted, nil
+}

--- a/pkg/object/graph/graph_test.go
+++ b/pkg/object/graph/graph_test.go
@@ -1,0 +1,126 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// This package provides a graph data struture
+// and graph functionality.
+package graph
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+var (
+	o1 = object.ObjMetadata{Name: "obj1", GroupKind: schema.GroupKind{Group: "test", Kind: "foo"}}
+	o2 = object.ObjMetadata{Name: "obj2", GroupKind: schema.GroupKind{Group: "test", Kind: "foo"}}
+	o3 = object.ObjMetadata{Name: "obj3", GroupKind: schema.GroupKind{Group: "test", Kind: "foo"}}
+	o4 = object.ObjMetadata{Name: "obj4", GroupKind: schema.GroupKind{Group: "test", Kind: "foo"}}
+	o5 = object.ObjMetadata{Name: "obj5", GroupKind: schema.GroupKind{Group: "test", Kind: "foo"}}
+)
+
+var (
+	e1 Edge = Edge{From: o1, To: o2}
+	e2 Edge = Edge{From: o2, To: o3}
+	e3 Edge = Edge{From: o1, To: o3}
+	e4 Edge = Edge{From: o3, To: o4}
+	e5 Edge = Edge{From: o2, To: o4}
+	e6 Edge = Edge{From: o2, To: o1}
+	e7 Edge = Edge{From: o3, To: o1}
+	e8 Edge = Edge{From: o4, To: o5}
+)
+
+func TestObjectGraphSort(t *testing.T) {
+	testCases := map[string]struct {
+		vertices []object.ObjMetadata
+		edges    []Edge
+		expected [][]object.ObjMetadata
+		isError  bool
+	}{
+		"one edge": {
+			vertices: []object.ObjMetadata{o1, o2},
+			edges:    []Edge{e1},
+			expected: [][]object.ObjMetadata{{o2}, {o1}},
+			isError:  false,
+		},
+		"two edges": {
+			vertices: []object.ObjMetadata{o1, o2, o3},
+			edges:    []Edge{e1, e2},
+			expected: [][]object.ObjMetadata{{o3}, {o2}, {o1}},
+			isError:  false,
+		},
+		"three edges": {
+			vertices: []object.ObjMetadata{o1, o2, o3},
+			edges:    []Edge{e1, e3, e2},
+			expected: [][]object.ObjMetadata{{o3}, {o2}, {o1}},
+			isError:  false,
+		},
+		"four edges": {
+			vertices: []object.ObjMetadata{o1, o2, o3, o4},
+			edges:    []Edge{e1, e2, e4, e5},
+			expected: [][]object.ObjMetadata{{o4}, {o3}, {o2}, {o1}},
+			isError:  false,
+		},
+		"five edges": {
+			vertices: []object.ObjMetadata{o1, o2, o3, o4},
+			edges:    []Edge{e5, e1, e3, e2, e4},
+			expected: [][]object.ObjMetadata{{o4}, {o3}, {o2}, {o1}},
+			isError:  false,
+		},
+		"no edges means all in the same first set": {
+			vertices: []object.ObjMetadata{o1, o2, o3, o4},
+			edges:    []Edge{},
+			expected: [][]object.ObjMetadata{{o4, o3, o2, o1}},
+			isError:  false,
+		},
+		"multiple objects in first set": {
+			vertices: []object.ObjMetadata{o1, o2, o3, o4, o5},
+			edges:    []Edge{e1, e2, e5, e8},
+			expected: [][]object.ObjMetadata{{o5, o3}, {o4}, {o2}, {o1}},
+			isError:  false,
+		},
+		"simple cycle in graph is an error": {
+			vertices: []object.ObjMetadata{o1, o2},
+			edges:    []Edge{e1, e6},
+			expected: [][]object.ObjMetadata{},
+			isError:  true,
+		},
+		"multi-edge cycle in graph is an error": {
+			vertices: []object.ObjMetadata{o1, o2, o3},
+			edges:    []Edge{e1, e2, e7},
+			expected: [][]object.ObjMetadata{},
+			isError:  true,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			g := New()
+			for _, vertex := range tc.vertices {
+				g.AddVertex(vertex)
+			}
+			for _, edge := range tc.edges {
+				g.AddEdge(edge.From, edge.To)
+			}
+			actual, err := g.Sort()
+			if err == nil && tc.isError {
+				t.Fatalf("expected error, but received none")
+			}
+			if err != nil && !tc.isError {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if !tc.isError {
+				if len(actual) != len(tc.expected) {
+					t.Errorf("expected (%s), got (%s)", tc.expected, actual)
+				}
+				for i, actualSet := range actual {
+					expectedSet := tc.expected[i]
+					if !object.SetEquals(expectedSet, actualSet) {
+						t.Errorf("expected sorted objects (%s), got (%s)", tc.expected, actual)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -505,6 +506,180 @@ func TestSetEquals(t *testing.T) {
 			actual := SetEquals(tc.setA, tc.setB)
 			if tc.isEqual != actual {
 				t.Errorf("SetEqual expected (%t), got (%t)", tc.isEqual, actual)
+			}
+		})
+	}
+}
+
+var (
+	clusterScopedObj = ObjMetadata{Name: "cluster-obj", GroupKind: schema.GroupKind{Group: "test-group", Kind: "test-kind"}}
+	namespacedObj    = ObjMetadata{Namespace: "test-namespace", Name: "namespaced-obj", GroupKind: schema.GroupKind{Group: "test-group", Kind: "test-kind"}}
+)
+
+var u1 = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/test-kind/cluster-obj",
+			},
+		},
+	},
+}
+
+var u2 = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj",
+			},
+		},
+	},
+}
+
+var multipleAnnotations = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj, " +
+					"test-group/test-kind/cluster-obj",
+			},
+		},
+	},
+}
+
+var noAnnotations = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+		},
+	},
+}
+
+var badAnnotation = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group:namespaces:test-namespace:test-kind:namespaced-obj",
+			},
+		},
+	},
+}
+
+func TestDependsOnAnnotation(t *testing.T) {
+	testCases := map[string]struct {
+		obj      *unstructured.Unstructured
+		expected []ObjMetadata
+	}{
+		"nil object is not found": {
+			obj:      nil,
+			expected: []ObjMetadata{},
+		},
+		"Object with no annotations returns not found": {
+			obj:      noAnnotations,
+			expected: []ObjMetadata{},
+		},
+		"Unparseable depends on annotation returns not found": {
+			obj:      badAnnotation,
+			expected: []ObjMetadata{},
+		},
+		"Cluster-scoped object depends on annotation": {
+			obj:      u1,
+			expected: []ObjMetadata{clusterScopedObj},
+		},
+		"Namespaced object depends on annotation": {
+			obj:      u2,
+			expected: []ObjMetadata{namespacedObj},
+		},
+		"Multiple objects specified in annotation": {
+			obj:      multipleAnnotations,
+			expected: []ObjMetadata{namespacedObj, clusterScopedObj},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actual := DependsOnObjs(tc.obj)
+			if !SetEquals(tc.expected, actual) {
+				t.Errorf("expected (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestAnnotationToObjMetas(t *testing.T) {
+	testCases := map[string]struct {
+		annotation string
+		expected   []ObjMetadata
+		isError    bool
+	}{
+		"empty annotation is error": {
+			annotation: "",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"wrong number of namespace-scoped fields in annotation is error": {
+			annotation: "test-group/test-namespace/test-kind/namespaced-obj",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"wrong number of cluster-scoped fields in annotation is error": {
+			annotation: "test-group/namespaces/test-kind/cluster-obj",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"cluster-scoped object annotation": {
+			annotation: "test-group/test-kind/cluster-obj",
+			expected:   []ObjMetadata{clusterScopedObj},
+			isError:    false,
+		},
+		"namespaced object annotation": {
+			annotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj",
+			expected:   []ObjMetadata{namespacedObj},
+			isError:    false,
+		},
+		"namespaced object annotation with whitespace at ends is valid": {
+			annotation: "  test-group/namespaces/test-namespace/test-kind/namespaced-obj\n",
+			expected:   []ObjMetadata{namespacedObj},
+			isError:    false,
+		},
+		"multiple object annotation": {
+			annotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj," +
+				"test-group/test-kind/cluster-obj",
+			expected: []ObjMetadata{clusterScopedObj, namespacedObj},
+			isError:  false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := AnnotationToObjMetas(tc.annotation)
+			if err == nil && tc.isError {
+				t.Fatalf("expected error, but received none")
+			}
+			if err != nil && !tc.isError {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if !SetEquals(tc.expected, actual) {
+				t.Errorf("expected (%s), got (%s)", tc.expected, actual)
 			}
 		})
 	}

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -67,13 +67,6 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 				operation:      event.Created,
 			},
 		},
-		{
-			eventType: event.ApplyType,
-			applyEvent: &expApplyEvent{
-				applyEventType: event.ApplyEventResourceUpdate,
-				operation:      event.Created,
-			},
-		},
 	}, applierEvents)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
* Using `depends-on` annotation, sort apply objects. Insert `WaitTask` between `ApplyTask`s to ensure a successful apply before running the next apply.
* Without the `depends-on`annotation, the functionality does **not** change.
* Adds an object graph and unit tests, where `ObjMetadata` are the vertices, and directed edges show an object depends on another object.
* Adds a topological `Sort()` to the object graph to generate an ordering of object apply sets.
* Adds implicit object ordering for CRD's and namespaces.
