### PR TITLE
More reusable BaseListPrinter

### DIFF
--- a/cmd/printers/events/printer.go
+++ b/cmd/printers/events/printer.go
@@ -6,12 +6,14 @@ package events
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/cmd/printers/printer"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
 )
 
 func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
 	return &list.BaseListPrinter{
-		IOStreams:        ioStreams,
-		FormatterFactory: NewFormatter,
+		FormatterFactory: func(previewStrategy common.DryRunStrategy) list.Formatter {
+			return NewFormatter(ioStreams, previewStrategy)
+		},
 	}
 }

--- a/cmd/printers/json/printer.go
+++ b/cmd/printers/json/printer.go
@@ -6,12 +6,14 @@ package json
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/cmd/printers/printer"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
 )
 
 func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
 	return &list.BaseListPrinter{
-		IOStreams:        ioStreams,
-		FormatterFactory: NewFormatter,
+		FormatterFactory: func(previewStrategy common.DryRunStrategy) list.Formatter {
+			return NewFormatter(ioStreams, previewStrategy)
+		},
 	}
 }

--- a/cmd/printers/printers.go
+++ b/cmd/printers/printers.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/printers/json"
 	"sigs.k8s.io/cli-utils/cmd/printers/printer"
 	"sigs.k8s.io/cli-utils/cmd/printers/table"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
 )
 
@@ -26,8 +27,9 @@ func GetPrinter(printerType string, ioStreams genericclioptions.IOStreams) print
 		}
 	case JSONPrinter:
 		return &list.BaseListPrinter{
-			IOStreams:        ioStreams,
-			FormatterFactory: json.NewFormatter,
+			FormatterFactory: func(previewStrategy common.DryRunStrategy) list.Formatter {
+				return json.NewFormatter(ioStreams, previewStrategy)
+			},
 		}
 	default:
 		return events.NewPrinter(ioStreams)

--- a/pkg/print/list/base.go
+++ b/pkg/print/list/base.go
@@ -6,7 +6,6 @@ package list
 import (
 	"fmt"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -21,12 +20,10 @@ type Formatter interface {
 	FormatActionGroupEvent(age event.ActionGroupEvent, ags []event.ActionGroup, as *ApplyStats, ps *PruneStats, ds *DeleteStats, c Collector) error
 }
 
-type FormatterFactory func(ioStreams genericclioptions.IOStreams,
-	previewStrategy common.DryRunStrategy) Formatter
+type FormatterFactory func(previewStrategy common.DryRunStrategy) Formatter
 
 type BaseListPrinter struct {
 	FormatterFactory FormatterFactory
-	IOStreams        genericclioptions.IOStreams
 }
 
 type ApplyStats struct {
@@ -127,7 +124,7 @@ func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.Dr
 		latestStatus: make(map[object.ObjMetadata]event.StatusEvent),
 	}
 	printStatus := false
-	formatter := b.FormatterFactory(b.IOStreams, previewStrategy)
+	formatter := b.FormatterFactory(previewStrategy)
 	for e := range ch {
 		switch e.Type {
 		case event.InitType:


### PR DESCRIPTION
Make `BaseListPrinter` more reusable by hiding IO streams from it. Formatter owns the output, so it can fully encapsulate it. That way a formatter can print to e.g. a logger, not to a raw stream and that would not require ignoring the passed IO streams.

I'd like to make a formatter, that prints to a logger. But I'd still like to use `BaseListPrinter` to call it. By making this change my custom formatter factory would not need to ignore IO streams.