### PR TITLE
Provide the DryRunStrategy through the destroyer options

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -86,7 +86,7 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if r.PreProcess != nil {
-		inventoryPolicy, err = r.PreProcess(inv, r.Destroyer.DryRunStrategy)
+		inventoryPolicy, err = r.PreProcess(inv, common.DryRunNone)
 		if err != nil {
 			return err
 		}
@@ -106,5 +106,5 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, r.Destroyer.DryRunStrategy)
+	return printer.Print(ch, common.DryRunNone)
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -94,10 +94,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		drs = common.DryRunServer
 	}
 
-	if previewDestroy {
-		r.Destroyer.DryRunStrategy = drs
-	}
-
 	inventoryPolicy, err := flagutils.ConvertInventoryPolicy(r.inventoryPolicy)
 	if err != nil {
 		return err
@@ -126,7 +122,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// if destroy flag is set in preview, transmit it to destroyer DryRunStrategy flag
 	// and pivot execution to destroy with dry-run
-	if !r.Destroyer.DryRunStrategy.ClientOrServerDryRun() {
+	if !previewDestroy {
 		err = r.Applier.Initialize()
 		if err != nil {
 			return err
@@ -156,6 +152,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		}
 		option := &apply.DestroyerOption{
 			InventoryPolicy: inventoryPolicy,
+			DryRunStrategy:  drs,
 		}
 		ch = r.Destroyer.Run(inv, option)
 	}


### PR DESCRIPTION
Providing the DryRunStrategy by setting it as a property on the Destroyer is awkward and makes it hard to use an interface to represent the Deployer. This makes the DryRunStrategy part of the DestroyOptions using the same pattern as the Applier.