### PR TITLE
Use a specific error type when encountering unknown types

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,6 +15,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 )
 
 const (
@@ -48,6 +49,14 @@ Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{print
 
 {{- range .err.TimedOutResources}}
 {{printf "%s/%s %s %s" .Identifier.GroupKind.Kind .Identifier.Name .Status .Message }}
+{{- end}}
+`
+
+	errorMsgForType[reflect.TypeOf(manifestreader.UnknownTypesError{})] = `
+Unknown type(s) encountered. Every type must either be already installed in the cluster or the CRD must be among the applied manifests.
+
+{{- range .err.GroupKinds}}
+{{ printf "%s" . }}
 {{- end}}
 `
 

--- a/pkg/manifestreader/common_test.go
+++ b/pkg/manifestreader/common_test.go
@@ -129,6 +129,21 @@ func TestSetNamespaces(t *testing.T) {
 			enforceNamespace:   true,
 			expectedNamespaces: []string{"", "bar"},
 		},
+		"unknown types in CRs": {
+			objs: []*unstructured.Unstructured{
+				toUnstructured(schema.GroupVersionKind{
+					Group:   "custom.io",
+					Version: "v1",
+					Kind:    "Custom",
+				}, ""),
+				toUnstructured(schema.GroupVersionKind{
+					Group:   "custom.io",
+					Version: "v1",
+					Kind:    "AnotherCustom",
+				}, ""),
+			},
+			expectedErrText: "unknown resource types: Custom.custom.io,AnotherCustom.custom.io",
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
The error message to users when we encounter a resource type that can't be found in the cluster or among the applied CRDs is not very helpful. This introduces a specific type for this error and a more helpful error message.