### PR TITLE
Expose ManifestReader helper functions to users

### DIFF
--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -137,8 +137,8 @@ func FilterLocalConfig(objs []*unstructured.Unstructured) []*unstructured.Unstru
 	return filteredObjs
 }
 
-// removeAnnotations removes the specified kioutil annotations from the resource.
-func removeAnnotations(n *yaml.RNode, annotations ...kioutil.AnnotationKey) error {
+// RemoveAnnotations removes the specified kioutil annotations from the resource.
+func RemoveAnnotations(n *yaml.RNode, annotations ...kioutil.AnnotationKey) error {
 	for _, a := range annotations {
 		err := n.PipeE(yaml.ClearAnnotation(a))
 		if err != nil {
@@ -148,9 +148,9 @@ func removeAnnotations(n *yaml.RNode, annotations ...kioutil.AnnotationKey) erro
 	return nil
 }
 
-// kyamlNodeToUnstructured take a resource represented as a kyaml RNode and
+// KyamlNodeToUnstructured take a resource represented as a kyaml RNode and
 // turns it into an Unstructured object.
-func kyamlNodeToUnstructured(n *yaml.RNode) (*unstructured.Unstructured, error) {
+func KyamlNodeToUnstructured(n *yaml.RNode) (*unstructured.Unstructured, error) {
 	b, err := n.MarshalJSON()
 	if err != nil {
 		return nil, err

--- a/pkg/manifestreader/common_test.go
+++ b/pkg/manifestreader/common_test.go
@@ -309,7 +309,7 @@ metadata:
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			node := tc.node
-			err := removeAnnotations(node, tc.removeAnnotations...)
+			err := RemoveAnnotations(node, tc.removeAnnotations...)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/pkg/manifestreader/path.go
+++ b/pkg/manifestreader/path.go
@@ -32,11 +32,11 @@ func (p *PathManifestReader) Read() ([]*unstructured.Unstructured, error) {
 	}
 
 	for _, n := range nodes {
-		err = removeAnnotations(n, kioutil.IndexAnnotation)
+		err = RemoveAnnotations(n, kioutil.IndexAnnotation)
 		if err != nil {
 			return objs, err
 		}
-		u, err := kyamlNodeToUnstructured(n)
+		u, err := KyamlNodeToUnstructured(n)
 		if err != nil {
 			return objs, err
 		}

--- a/pkg/manifestreader/stream.go
+++ b/pkg/manifestreader/stream.go
@@ -35,11 +35,11 @@ func (r *StreamManifestReader) Read() ([]*unstructured.Unstructured, error) {
 	}
 
 	for _, n := range nodes {
-		err = removeAnnotations(n, kioutil.IndexAnnotation)
+		err = RemoveAnnotations(n, kioutil.IndexAnnotation)
 		if err != nil {
 			return objs, err
 		}
-		u, err := kyamlNodeToUnstructured(n)
+		u, err := KyamlNodeToUnstructured(n)
 		if err != nil {
 			return objs, err
 		}


### PR DESCRIPTION
These are useful for users who wants to write their own implementation of the ManifestReader.