### PR TITLE
Refactor destroyer to use tasks

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -89,7 +88,7 @@ type ApplyRunner struct {
 }
 
 func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
-	prunePropPolicy, err := convertPropagationPolicy(r.prunePropagationPolicy)
+	prunePropPolicy, err := flagutils.ConvertPropagationPolicy(r.prunePropagationPolicy)
 	if err != nil {
 		return err
 	}
@@ -157,20 +156,4 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
 	return printer.Print(ch, common.DryRunNone)
-}
-
-// convertPropagationPolicy converts a propagationPolicy described as a
-// string to a DeletionPropagation type that is passed into the Applier.
-func convertPropagationPolicy(propagationPolicy string) (metav1.DeletionPropagation, error) {
-	switch propagationPolicy {
-	case string(metav1.DeletePropagationForeground):
-		return metav1.DeletePropagationForeground, nil
-	case string(metav1.DeletePropagationBackground):
-		return metav1.DeletePropagationBackground, nil
-	case string(metav1.DeletePropagationOrphan):
-		return metav1.DeletePropagationOrphan, nil
-	default:
-		return metav1.DeletePropagationBackground, fmt.Errorf(
-			"prune propagation policy must be one of Background, Foreground, Orphan")
-	}
 }

--- a/cmd/flagutils/utils.go
+++ b/cmd/flagutils/utils.go
@@ -6,6 +6,7 @@ package flagutils
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
 
@@ -14,6 +15,22 @@ const (
 	InventoryPolicyStrict = "strict"
 	InventoryPolicyAdopt  = "adopt"
 )
+
+// ConvertPropagationPolicy converts a propagationPolicy described as a
+// string to a DeletionPropagation type that is passed into the Applier.
+func ConvertPropagationPolicy(propagationPolicy string) (metav1.DeletionPropagation, error) {
+	switch propagationPolicy {
+	case string(metav1.DeletePropagationForeground):
+		return metav1.DeletePropagationForeground, nil
+	case string(metav1.DeletePropagationBackground):
+		return metav1.DeletePropagationBackground, nil
+	case string(metav1.DeletePropagationOrphan):
+		return metav1.DeletePropagationOrphan, nil
+	default:
+		return metav1.DeletePropagationBackground, fmt.Errorf(
+			"prune propagation policy must be one of Background, Foreground, Orphan")
+	}
+}
 
 func ConvertInventoryPolicy(policy string) (inventory.InventoryPolicy, error) {
 	switch policy {

--- a/examples/alphaTestExamples/MultipleServices.md
+++ b/examples/alphaTestExamples/MultipleServices.md
@@ -114,6 +114,8 @@ expectedOutputLine "service/wordpress deleted"
 
 expectedOutputLine "deployment.apps/wordpress deleted"
 
+expectedOutputLine "2 resource(s) deleted, 0 skipped"
+
 # Verify that we still have the mysql resources in the cluster.
 kubectl get all --no-headers --selector=app=mysql | wc -l | xargs > $OUTPUT/status
 expectedOutputLine "4"

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -254,5 +254,8 @@ expectedOutputLine "configmap/the-map2 deleted"
 
 expectedOutputLine "service/the-service deleted"
 
+expectedOutputLine "3 resource(s) deleted, 0 skipped"
+expectedNotFound "resource(s) pruned"
+
 kind delete cluster;
 ```

--- a/examples/alphaTestExamples/pruneAndDelete.md
+++ b/examples/alphaTestExamples/pruneAndDelete.md
@@ -119,6 +119,9 @@ expectedOutputLine "configmap/firstmap deleted"
 
 expectedOutputLine "configmap/secondmap delete skipped"
 
+expectedOutputLine "1 resource(s) deleted, 1 skipped"
+expectedNotFound "resource(s) pruned"
+
 kubectl get cm --no-headers | awk '{print $1}' > $OUTPUT/status
 expectedOutputLine "secondmap"
 ```

--- a/pkg/apply/poller/poller.go
+++ b/pkg/apply/poller/poller.go
@@ -5,11 +5,14 @@ package poller
 
 import (
 	"context"
+	"time"
 
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
+
+const DefaultPollInterval = 2 * time.Second
 
 // Poller defines the interface the applier needs to poll for status of resources.
 // The context is the preferred way to shut down the poller.

--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -1,0 +1,100 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package prune
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// EventFactory is an abstract interface describing functions to generate
+// events for pruning or deleting.
+type EventFactory interface {
+	CreateSuccessEvent(obj *unstructured.Unstructured) event.Event
+	CreateSkippedEvent(obj *unstructured.Unstructured) event.Event
+	CreateFailedEvent(id object.ObjMetadata, err error) event.Event
+}
+
+// CreateEventFactory returns the correct concrete version of
+// an EventFactory based on the passed boolean.
+func CreateEventFactory(isDelete bool) EventFactory {
+	if isDelete {
+		return DeleteEventFactory{}
+	}
+	return PruneEventFactory{}
+}
+
+// PruneEventFactory implements EventFactory interface as a concrete
+// representation of for prune events.
+type PruneEventFactory struct{}
+
+func (pef PruneEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) event.Event {
+	return event.Event{
+		Type: event.PruneType,
+		PruneEvent: event.PruneEvent{
+			Operation:  event.Pruned,
+			Object:     obj,
+			Identifier: object.UnstructuredToObjMeta(obj),
+		},
+	}
+}
+
+func (pef PruneEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured) event.Event {
+	return event.Event{
+		Type: event.PruneType,
+		PruneEvent: event.PruneEvent{
+			Operation:  event.PruneSkipped,
+			Object:     obj,
+			Identifier: object.UnstructuredToObjMeta(obj),
+		},
+	}
+}
+
+func (pef PruneEventFactory) CreateFailedEvent(id object.ObjMetadata, err error) event.Event {
+	return event.Event{
+		Type: event.PruneType,
+		PruneEvent: event.PruneEvent{
+			Identifier: id,
+			Error:      err,
+		},
+	}
+}
+
+// DeleteEventFactory implements EventFactory interface as a concrete
+// representation of for delete events.
+type DeleteEventFactory struct{}
+
+func (def DeleteEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) event.Event {
+	return event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Operation:  event.Deleted,
+			Object:     obj,
+			Identifier: object.UnstructuredToObjMeta(obj),
+		},
+	}
+}
+
+func (def DeleteEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured) event.Event {
+	return event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Operation:  event.DeleteSkipped,
+			Object:     obj,
+			Identifier: object.UnstructuredToObjMeta(obj),
+		},
+	}
+}
+
+func (def DeleteEventFactory) CreateFailedEvent(id object.ObjMetadata, err error) event.Event {
+	return event.Event{
+		Type: event.DeleteType,
+		DeleteEvent: event.DeleteEvent{
+			Identifier: id,
+			Error:      err,
+		},
+	}
+}

--- a/pkg/apply/prune/event-factory_test.go
+++ b/pkg/apply/prune/event-factory_test.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package prune
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestEventFactory(t *testing.T) {
+	tests := map[string]struct {
+		destroy      bool
+		obj          *unstructured.Unstructured
+		err          error
+		expectedType event.Type
+	}{
+		"prune events": {
+			destroy:      false,
+			obj:          pod,
+			expectedType: event.PruneType,
+		},
+		"delete events": {
+			destroy:      true,
+			obj:          pdb,
+			expectedType: event.DeleteType,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			id := object.UnstructuredToObjMeta(tc.obj)
+			eventFactory := CreateEventFactory(tc.destroy)
+			// Validate the "success" event"
+			actualEvent := eventFactory.CreateSuccessEvent(tc.obj)
+			if tc.expectedType != actualEvent.Type {
+				t.Errorf("success event expected type (%s), got (%s)",
+					tc.expectedType, actualEvent.Type)
+			}
+			var actualObj *unstructured.Unstructured
+			var err error
+			if tc.expectedType == event.PruneType {
+				if event.Pruned != actualEvent.PruneEvent.Operation {
+					t.Errorf("success event expected operation (Pruned), got (%s)",
+						actualEvent.PruneEvent.Operation)
+				}
+				actualObj = actualEvent.PruneEvent.Object
+				err = actualEvent.PruneEvent.Error
+			} else {
+				if event.Deleted != actualEvent.DeleteEvent.Operation {
+					t.Errorf("success event expected operation (Deleted), got (%s)",
+						actualEvent.DeleteEvent.Operation)
+				}
+				actualObj = actualEvent.DeleteEvent.Object
+				err = actualEvent.DeleteEvent.Error
+			}
+			if tc.obj != actualObj {
+				t.Errorf("expected event object (%v), got (%v)", tc.obj, actualObj)
+			}
+			if err != nil {
+				t.Errorf("success event expected nil error, got (%s)", err)
+			}
+			// Validate the "skipped" event"
+			actualEvent = eventFactory.CreateSkippedEvent(tc.obj)
+			if tc.expectedType != actualEvent.Type {
+				t.Errorf("skipped event expected type (%s), got (%s)",
+					tc.expectedType, actualEvent.Type)
+			}
+			if tc.expectedType == event.PruneType {
+				if event.PruneSkipped != actualEvent.PruneEvent.Operation {
+					t.Errorf("skipped event expected operation (PruneSkipped), got (%s)",
+						actualEvent.PruneEvent.Operation)
+				}
+				actualObj = actualEvent.PruneEvent.Object
+				err = actualEvent.PruneEvent.Error
+			} else {
+				if event.DeleteSkipped != actualEvent.DeleteEvent.Operation {
+					t.Errorf("skipped event expected operation (DeleteSkipped), got (%s)",
+						actualEvent.DeleteEvent.Operation)
+				}
+				actualObj = actualEvent.DeleteEvent.Object
+				err = actualEvent.DeleteEvent.Error
+			}
+			if tc.obj != actualObj {
+				t.Errorf("expected event object (%v), got (%v)", tc.obj, actualObj)
+			}
+			if err != nil {
+				t.Errorf("skipped event expected nil error, got (%s)", err)
+			}
+			// Validate the "failed" event"
+			actualEvent = eventFactory.CreateFailedEvent(id, tc.err)
+			if tc.expectedType != actualEvent.Type {
+				t.Errorf("failed event expected type (%s), got (%s)",
+					tc.expectedType, actualEvent.Type)
+			}
+			if tc.expectedType != actualEvent.Type {
+				t.Errorf("failed event expected type (%s), got (%s)",
+					tc.expectedType, actualEvent.Type)
+			}
+			if tc.expectedType == event.PruneType {
+				err = actualEvent.PruneEvent.Error
+			} else {
+				err = actualEvent.DeleteEvent.Error
+			}
+			if tc.err != err {
+				t.Errorf("failed event expected error (%s), got (%s)", tc.err, err)
+			}
+		})
+	}
+}

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
@@ -122,6 +121,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 	klog.V(4).Infof("prune: %d objects to prune (clusterInv - localIds)", len(pruneObjs))
 	// Sort the resources in reverse order using the same rules as is
 	// used for apply.
+	eventFactory := CreateEventFactory(po.Destroy)
 	sort.Sort(sort.Reverse(ordering.SortableMetas(pruneObjs)))
 	for _, pruneObj := range pruneObjs {
 		klog.V(5).Infof("attempting prune: %s", pruneObj)
@@ -137,11 +137,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 				klog.Errorf("prune obj (%s/%s) UID retrival error: %s",
 					pruneObj.Namespace, pruneObj.Name, err)
 			}
-			e := createPruneFailedEvent(pruneObj, err)
-			if po.Destroy {
-				e = createDeleteFailedEvent(pruneObj, err)
-			}
-			taskContext.EventChannel() <- e
+			taskContext.EventChannel() <- eventFactory.CreateFailedEvent(pruneObj, err)
 			taskContext.CapturePruneFailure(pruneObj)
 			continue
 		}
@@ -154,12 +150,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 		// Handle lifecycle directive preventing deletion.
 		if !canPrune(localInv, obj, o.InventoryPolicy, uid) {
 			klog.V(4).Infof("skip prune for lifecycle directive %s/%s", pruneObj.Namespace, pruneObj.Name)
-			// TODO(seans): Clean up this prune/delete event checking code.
-			e := createPruneEvent(pruneObj, obj, event.PruneSkipped)
-			if po.Destroy {
-				e = createDeleteEvent(pruneObj, obj, event.DeleteSkipped)
-			}
-			taskContext.EventChannel() <- e
+			taskContext.EventChannel() <- eventFactory.CreateSkippedEvent(obj)
 			taskContext.CapturePruneFailure(pruneObj)
 			continue
 		}
@@ -169,11 +160,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 			if pruneObj.GroupKind == object.CoreV1Namespace.GroupKind() &&
 				localNamespaces.Has(pruneObj.Name) {
 				klog.V(4).Infof("skip pruning namespace: %s", pruneObj.Name)
-				e := createPruneEvent(pruneObj, obj, event.PruneSkipped)
-				if po.Destroy {
-					e = createDeleteEvent(pruneObj, obj, event.DeleteSkipped)
-				}
-				taskContext.EventChannel() <- e
+				taskContext.EventChannel() <- eventFactory.CreateSkippedEvent(obj)
 				taskContext.CapturePruneFailure(pruneObj)
 				continue
 			}
@@ -185,11 +172,7 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 				if klog.V(4).Enabled() {
 					klog.Errorf("prune failed for %s/%s (%s)", pruneObj.Namespace, pruneObj.Name, err)
 				}
-				e := createPruneFailedEvent(pruneObj, err)
-				if po.Destroy {
-					e = createDeleteFailedEvent(pruneObj, err)
-				}
-				taskContext.EventChannel() <- e
+				taskContext.EventChannel() <- eventFactory.CreateFailedEvent(pruneObj, err)
 				taskContext.CapturePruneFailure(pruneObj)
 				continue
 			}
@@ -198,20 +181,12 @@ func (po *PruneOptions) Prune(localInv inventory.InventoryInfo,
 				if klog.V(4).Enabled() {
 					klog.Errorf("prune failed for %s/%s (%s)", pruneObj.Namespace, pruneObj.Name, err)
 				}
-				e := createPruneFailedEvent(pruneObj, err)
-				if po.Destroy {
-					e = createDeleteFailedEvent(pruneObj, err)
-				}
-				taskContext.EventChannel() <- e
+				taskContext.EventChannel() <- eventFactory.CreateFailedEvent(pruneObj, err)
 				taskContext.CapturePruneFailure(pruneObj)
 				continue
 			}
 		}
-		e := createPruneEvent(pruneObj, obj, event.Pruned)
-		if po.Destroy {
-			e = createDeleteEvent(pruneObj, obj, event.Deleted)
-		}
-		taskContext.EventChannel() <- e
+		taskContext.EventChannel() <- eventFactory.CreateSuccessEvent(obj)
 	}
 	return nil
 }
@@ -259,52 +234,6 @@ func preventDeleteAnnotation(annotations map[string]string) bool {
 		}
 	}
 	return false
-}
-
-// createPruneEvent is a helper function to package a prune event.
-func createPruneEvent(id object.ObjMetadata, obj *unstructured.Unstructured, op event.PruneEventOperation) event.Event {
-	return event.Event{
-		Type: event.PruneType,
-		PruneEvent: event.PruneEvent{
-			Operation:  op,
-			Object:     obj,
-			Identifier: id,
-		},
-	}
-}
-
-// createDeleteEvent is a helper function to package a delete event.
-func createDeleteEvent(id object.ObjMetadata, obj *unstructured.Unstructured, op event.DeleteEventOperation) event.Event {
-	return event.Event{
-		Type: event.DeleteType,
-		DeleteEvent: event.DeleteEvent{
-			Operation:  op,
-			Object:     obj,
-			Identifier: id,
-		},
-	}
-}
-
-// createPruneFailedEvent is a helper function to package a prune event for a failure.
-func createPruneFailedEvent(objMeta object.ObjMetadata, err error) event.Event {
-	return event.Event{
-		Type: event.PruneType,
-		PruneEvent: event.PruneEvent{
-			Identifier: objMeta,
-			Error:      err,
-		},
-	}
-}
-
-// createDeleteFailedEvent is a helper function to package a delete event for a failure.
-func createDeleteFailedEvent(objMeta object.ObjMetadata, err error) event.Event {
-	return event.Event{
-		Type: event.DeleteType,
-		DeleteEvent: event.DeleteEvent{
-			Identifier: objMeta,
-			Error:      err,
-		},
-	}
 }
 
 func canPrune(localInv inventory.InventoryInfo, obj *unstructured.Unstructured,

--- a/pkg/apply/task/delete_inv_task.go
+++ b/pkg/apply/task/delete_inv_task.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// DeleteInvTask encapsulates structures necessary to delete
+// the inventory object from the cluster. Implements
+// the Task interface. This task should happen after all
+// resources have been deleted.
+type DeleteInvTask struct {
+	TaskName  string
+	InvClient inventory.InventoryClient
+	InvInfo   inventory.InventoryInfo
+}
+
+func (i *DeleteInvTask) Name() string {
+	return i.TaskName
+}
+
+func (i *DeleteInvTask) Action() event.ResourceAction {
+	return event.InventoryAction
+}
+
+func (i *DeleteInvTask) Identifiers() []object.ObjMetadata {
+	return []object.ObjMetadata{}
+}
+
+// Start deletes the inventory object from the cluster.
+func (i *DeleteInvTask) Start(taskContext *taskrunner.TaskContext) {
+	go func() {
+		klog.V(4).Infof("delete inventory object (%s/%s)", i.InvInfo.Namespace(), i.InvInfo.Name())
+		err := i.InvClient.DeleteInventoryObj(i.InvInfo)
+		taskContext.TaskChannel() <- taskrunner.TaskResult{Err: err}
+	}()
+}
+
+// ClearTimeout is not supported by the DeleteInvTask.
+func (i *DeleteInvTask) ClearTimeout() {}

--- a/pkg/apply/task/delete_inv_task_test.go
+++ b/pkg/apply/task/delete_inv_task_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package task
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestDeleteInvTask(t *testing.T) {
+	client := inventory.NewFakeInventoryClient([]object.ObjMetadata{})
+	eventChannel := make(chan event.Event)
+	context := taskrunner.NewTaskContext(eventChannel)
+	task := DeleteInvTask{
+		TaskName:  taskName,
+		InvClient: client,
+		InvInfo:   localInv,
+	}
+	if taskName != task.Name() {
+		t.Errorf("expected task name (%s), got (%s)", taskName, task.Name())
+	}
+	task.Start(context)
+	result := <-context.TaskChannel()
+	if result.Err != nil {
+		t.Errorf("unexpected error running DeleteInvTask: %s", result.Err)
+	}
+}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -33,7 +33,11 @@ func (p *PruneTask) Name() string {
 }
 
 func (p *PruneTask) Action() event.ResourceAction {
-	return event.PruneAction
+	action := event.PruneAction
+	if p.PruneOptions.Destroy {
+		action = event.DeleteAction
+	}
+	return action
 }
 
 func (p *PruneTask) Identifiers() []object.ObjMetadata {


### PR DESCRIPTION
* Refactors `destroyer` to delete objects using tasks, which will allow us to order the deletions.
* Refactors `TaskQueueSolver` to `TaskQueueBuilder` now using the `Builder` pattern for reuse in the `destroyer`.
* Adds task to delete inventory object (and unit test).
* Adds `EventFactory` interface to abstract prune/delete event generation.
* Adds e2e mdrip tests to validate destroy behavior.