### PR TITLE
Refactor prune/delete using ValidationFilter interface

### DIFF
--- a/pkg/apply/filter/current-uids-filter.go
+++ b/pkg/apply/filter/current-uids-filter.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// CurrentUIDFilter implements ValidationFilter interface to determine
+// if an object should not be pruned (deleted) because it has recently
+// been applied.
+type CurrentUIDFilter struct {
+	CurrentUIDs sets.String
+}
+
+// Name returns a filter identifier for logging.
+func (cuf CurrentUIDFilter) Name() string {
+	return "CurrentUIDFilter"
+}
+
+// Filter returns true if the passed object should NOT be pruned (deleted)
+// because the it is a namespace that objects still reside in; otherwise
+// returns false. This filter should not be added to the list of filters
+// for "destroying", since every object is being deletet. Never returns an error.
+func (cuf CurrentUIDFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+	uid := string(obj.GetUID())
+	if cuf.CurrentUIDs.Has(uid) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/apply/filter/current-uids-filter_test.go
+++ b/pkg/apply/filter/current-uids-filter_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestCurrentUIDFilter(t *testing.T) {
+	tests := map[string]struct {
+		filterUIDs sets.String
+		objUID     string
+		filtered   bool
+	}{
+		"Empty filter UIDs, object is not filtered": {
+			filterUIDs: sets.NewString(),
+			objUID:     "bar",
+			filtered:   false,
+		},
+		"Empty object UID, object is not filtered": {
+			filterUIDs: sets.NewString("foo"),
+			objUID:     "",
+			filtered:   false,
+		},
+		"Object UID not in filter UID set, object is not filtered": {
+			filterUIDs: sets.NewString("foo", "baz"),
+			objUID:     "bar",
+			filtered:   false,
+		},
+		"Object UID is in filter UID set, object is filtered": {
+			filterUIDs: sets.NewString("foo"),
+			objUID:     "foo",
+			filtered:   true,
+		},
+		"Object UID is among several filter UIDs, object is filtered": {
+			filterUIDs: sets.NewString("foo", "bar", "baz"),
+			objUID:     "foo",
+			filtered:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			filter := CurrentUIDFilter{
+				CurrentUIDs: tc.filterUIDs,
+			}
+			obj := defaultObj.DeepCopy()
+			obj.SetUID(types.UID(tc.objUID))
+			actual, err := filter.Filter(obj)
+			if err != nil {
+				t.Fatalf("CurrentUIDFilter unexpected error (%s)", err)
+			}
+			if tc.filtered != actual {
+				t.Errorf("CurrentUIDFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+		})
+	}
+}

--- a/pkg/apply/filter/filter.go
+++ b/pkg/apply/filter/filter.go
@@ -1,0 +1,19 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ValidationFilter interface decouples apply/prune validation
+// from the concrete structs used for validation. The apply/prune
+// functionality will run validation filters to remove objects
+// which should not be applied or pruned.
+type ValidationFilter interface {
+	// Name returns a filter name (usually for logging).
+	Name() string
+	// Filter returns true if validation fails or an error.
+	Filter(obj *unstructured.Unstructured) (bool, error)
+}

--- a/pkg/apply/filter/inventory-policy-filter.go
+++ b/pkg/apply/filter/inventory-policy-filter.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+// InventoryPolicyFilter implements ValidationFilter interface to determine
+// if an object should be pruned (deleted) because of the InventoryPolicy
+// and if the objects owning inventory identifier matchs the inventory id.
+type InventoryPolicyFilter struct {
+	Inv       inventory.InventoryInfo
+	InvPolicy inventory.InventoryPolicy
+}
+
+// Name returns a filter identifier for logging.
+func (ipf InventoryPolicyFilter) Name() string {
+	return "InventoryPolictyFilter"
+}
+
+// Filter returns true if the passed object should NOT be pruned (deleted)
+// because the "prevent remove" annotation is present; otherwise returns
+// false. Never returns an error.
+func (ipf InventoryPolicyFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+	// Check the inventory id "match" and the adopt policy to determine
+	// if an object should be pruned (deleted).
+	if !inventory.CanPrune(ipf.Inv, obj, ipf.InvPolicy) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/apply/filter/inventory-policy-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-filter_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+var inventoryObj = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "inventory-name",
+			"namespace": "inventory-namespace",
+		},
+	},
+}
+
+func TestInventoryPolicyFilter(t *testing.T) {
+	tests := map[string]struct {
+		inventoryID    string
+		objInventoryID string
+		policy         inventory.InventoryPolicy
+		filtered       bool
+	}{
+		"inventory and object ids match, not filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "foo",
+			policy:         inventory.InventoryPolicyMustMatch,
+			filtered:       false,
+		},
+		"inventory and object ids match and adopt, not filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "foo",
+			policy:         inventory.AdoptIfNoInventory,
+			filtered:       false,
+		},
+		"inventory and object ids do no match and policy must match, filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "bar",
+			policy:         inventory.InventoryPolicyMustMatch,
+			filtered:       true,
+		},
+		"inventory and object ids do no match and adopt if no inventory, filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "bar",
+			policy:         inventory.AdoptIfNoInventory,
+			filtered:       true,
+		},
+		"inventory and object ids do no match and adopt all, not filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "bar",
+			policy:         inventory.AdoptAll,
+			filtered:       false,
+		},
+		"object id empty and adopt all, not filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "",
+			policy:         inventory.AdoptAll,
+			filtered:       false,
+		},
+		"object id empty and policy must match, filtered": {
+			inventoryID:    "foo",
+			objInventoryID: "",
+			policy:         inventory.InventoryPolicyMustMatch,
+			filtered:       true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			invIDLabel := map[string]string{
+				common.InventoryLabel: tc.inventoryID,
+			}
+			invObj := inventoryObj.DeepCopy()
+			invObj.SetLabels(invIDLabel)
+			filter := InventoryPolicyFilter{
+				Inv:       inventory.WrapInventoryInfoObj(invObj),
+				InvPolicy: tc.policy,
+			}
+			objIDAnnotation := map[string]string{
+				"config.k8s.io/owning-inventory": tc.objInventoryID,
+			}
+			obj := defaultObj.DeepCopy()
+			obj.SetAnnotations(objIDAnnotation)
+			actual, err := filter.Filter(obj)
+			if err != nil {
+				t.Fatalf("InventoryPolicyFilter unexpected error (%s)", err)
+			}
+			if tc.filtered != actual {
+				t.Errorf("InventoryPolicyFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+		})
+	}
+}

--- a/pkg/apply/filter/local-namespaces-filter.go
+++ b/pkg/apply/filter/local-namespaces-filter.go
@@ -1,0 +1,35 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// LocalNamespacesFilter encapsulates the set of namespaces
+// that are currently in use. Used to ensure we do not delete
+// namespaces with currently applied objects in them.
+type LocalNamespacesFilter struct {
+	LocalNamespaces sets.String
+}
+
+// Name returns a filter identifier for logging.
+func (lnf LocalNamespacesFilter) Name() string {
+	return "LocalNamespacesFilter"
+}
+
+// Filter returns true if the passed object should NOT be pruned (deleted)
+// because the it is a namespace that objects still reside in; otherwise
+// returns false. This filter should not be added to the list of filters
+// for "destroying", since every object is being delete. Never returns an error.
+func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+	id := object.UnstructuredToObjMeta(obj)
+	if id.GroupKind == object.CoreV1Namespace.GroupKind() &&
+		lnf.LocalNamespaces.Has(id.Name) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/apply/filter/local-namespaces-filter_test.go
+++ b/pkg/apply/filter/local-namespaces-filter_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var testNamespace = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": "test-namespace",
+		},
+	},
+}
+
+func TestLocalNamespacesFilter(t *testing.T) {
+	tests := map[string]struct {
+		localNamespaces sets.String
+		namespace       string
+		filtered        bool
+	}{
+		"No local namespaces, namespace is not filtered": {
+			localNamespaces: sets.NewString(),
+			namespace:       "test-namespace",
+			filtered:        false,
+		},
+		"Namespace not in local namespaces, namespace is not filtered": {
+			localNamespaces: sets.NewString("foo", "bar"),
+			namespace:       "test-namespace",
+			filtered:        false,
+		},
+		"Namespace is in local namespaces, namespace is filtered": {
+			localNamespaces: sets.NewString("foo", "test-namespace", "bar"),
+			namespace:       "test-namespace",
+			filtered:        true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			filter := LocalNamespacesFilter{
+				LocalNamespaces: tc.localNamespaces,
+			}
+			namespace := testNamespace.DeepCopy()
+			namespace.SetName(tc.namespace)
+			actual, err := filter.Filter(namespace)
+			if err != nil {
+				t.Fatalf("LocalNamespacesFilter unexpected error (%s)", err)
+			}
+			if tc.filtered != actual {
+				t.Errorf("LocalNamespacesFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+		})
+	}
+}

--- a/pkg/apply/filter/prevent-remove-filter.go
+++ b/pkg/apply/filter/prevent-remove-filter.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/common"
+)
+
+// PreventRemoveFilter implements ValidationFilter interface to determine
+// if an object should not be pruned (deleted) because of a
+// "prevent remove" annotation.
+type PreventRemoveFilter struct{}
+
+// Name returns the preferred name for the filter. Usually
+// used for logging.
+func (prf PreventRemoveFilter) Name() string {
+	return "PreventRemoveFilter"
+}
+
+// Filter returns true if the passed object should NOT be pruned (deleted)
+// because the "prevent remove" annotation is present; otherwise returns
+// false. Never returns an error.
+func (prf PreventRemoveFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+	for annotation, value := range obj.GetAnnotations() {
+		if common.NoDeletion(annotation, value) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/apply/filter/prevent-remove-filter_test.go
+++ b/pkg/apply/filter/prevent-remove-filter_test.go
@@ -1,0 +1,83 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/common"
+)
+
+var defaultObj = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "pod-name",
+			"namespace": "test-namespace",
+		},
+	},
+}
+
+func TestPreventDeleteAnnotation(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		expected    bool
+	}{
+		"Nil map returns false": {
+			annotations: nil,
+			expected:    false,
+		},
+		"Empty map returns false": {
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		"Wrong annotation key/value is false": {
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			expected: false,
+		},
+		"Annotation key without value is false": {
+			annotations: map[string]string{
+				common.OnRemoveAnnotation: "bar",
+			},
+			expected: false,
+		},
+		"Annotation key and value is true": {
+			annotations: map[string]string{
+				common.OnRemoveAnnotation: common.OnRemoveKeep,
+			},
+			expected: true,
+		},
+		"Annotation key client.lifecycle.config.k8s.io/deletion without value is false": {
+			annotations: map[string]string{
+				common.LifecycleDeleteAnnotation: "any",
+			},
+			expected: false,
+		},
+		"Annotation key client.lifecycle.config.k8s.io/deletion and value is true": {
+			annotations: map[string]string{
+				common.LifecycleDeleteAnnotation: common.PreventDeletion,
+			},
+			expected: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			filter := PreventRemoveFilter{}
+			obj := defaultObj.DeepCopy()
+			obj.SetAnnotations(tc.annotations)
+			actual, err := filter.Filter(obj)
+			if err != nil {
+				t.Fatalf("PreventRemoveFilter unexpected error (%s)", err)
+			}
+			if tc.expected != actual {
+				t.Errorf("PreventRemoveFilter expected (%t), got (%t)", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/apply/filter"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/task"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
@@ -267,7 +268,7 @@ func TestTaskQueueBuilder_BuildTaskQueue(t *testing.T) {
 			tq := tqb.
 				AppendInvAddTask(localInv, tc.objs).
 				AppendApplyWaitTasks(localInv, tc.objs, tc.options).
-				AppendPruneWaitTasks(localInv, emptyPruneObjs, tc.options).
+				AppendPruneWaitTasks(emptyPruneObjs, []filter.ValidationFilter{}, tc.options).
 				AppendInvSetTask(localInv).
 				Build()
 

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -837,7 +837,7 @@ func TestApplyTaskWithDifferentInventoryAnnotation(t *testing.T) {
 				assert.Equal(t, tc.expectedEvents[i].Type, e.Type)
 				assert.Equal(t, tc.expectedEvents[i].ApplyEvent.Error.Error(), e.ApplyEvent.Error.Error())
 			}
-			actualUids := taskContext.AllResourceUIDs()
+			actualUids := taskContext.AppliedResourceUIDs()
 			assert.Equal(t, len(actualUids), 1)
 		})
 	}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -52,7 +52,7 @@ func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 		// Create filter to prevent deletion of currently applied
 		// objects. Must be done here to wait for applied UIDs.
 		uidFilter := filter.CurrentUIDFilter{
-			CurrentUIDs: taskContext.AllResourceUIDs(),
+			CurrentUIDs: taskContext.AppliedResourceUIDs(),
 		}
 		p.Filters = append(p.Filters, uidFilter)
 		err := p.PruneOptions.Prune(p.Objects,

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -76,9 +76,9 @@ func (tc *TaskContext) AppliedResources() []object.ObjMetadata {
 	return all
 }
 
-// AllResourceUIDs returns a set with the UIDs of all the resources in the
-// context.
-func (tc *TaskContext) AllResourceUIDs() sets.String {
+// AppliedResourceUIDs returns a set with the UIDs of all the
+// successfully applied resources.
+func (tc *TaskContext) AppliedResourceUIDs() sets.String {
 	uids := sets.NewString()
 	for _, ai := range tc.appliedResources {
 		uid := strings.TrimSpace(string(ai.uid))


### PR DESCRIPTION
* Creates `ValidationFilter` interface to abstract operations for prune (deletion) permission. This interface decouples prune/delete dependencies including on `inventory` and `InventoryPolicy`.
* Creates several filters which implement this `ValidationFilter` interface, including `PreventDeleteFilter`, `InventoryPolicyFilter`, `CurrentUIDFilter`, and `LocalNamespacesFilter`.
* Integrates these new filters into the prune and delete functionality.
* Adds unit tests for all the new filters.
* Changes `TaskContext.AllResourceUIDs()` function name to `TaskContext.AppliedResourceUIDs()` because it is more accurate.