### PR TITLE
Re-organizes pkg/object, adds annotation helpers

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -18,12 +18,9 @@ import (
 	"fmt"
 	"time"
 
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -256,7 +253,7 @@ func splitAfterCRDs(objs []*unstructured.Unstructured) (crdSplitResult, bool) {
 
 	var crds []*unstructured.Unstructured
 	for _, obj := range objs {
-		if IsCRD(obj) {
+		if object.IsCRD(obj) {
 			crds = append(crds, obj)
 			continue
 		}
@@ -272,24 +269,4 @@ func splitAfterCRDs(objs []*unstructured.Unstructured) (crdSplitResult, bool) {
 		after:  after,
 		crds:   crds,
 	}, len(crds) > 0
-}
-
-func IsCRD(info *unstructured.Unstructured) bool {
-	gvk, found := toGVK(info)
-	if !found {
-		return false
-	}
-	if (gvk.Group == v1.SchemeGroupVersion.Group ||
-		gvk.Group == v1beta1.SchemeGroupVersion.Group) &&
-		gvk.Kind == "CustomResourceDefinition" {
-		return true
-	}
-	return false
-}
-
-func toGVK(obj *unstructured.Unstructured) (schema.GroupVersionKind, bool) {
-	if obj != nil {
-		return obj.GroupVersionKind(), true
-	}
-	return schema.GroupVersionKind{}, false
 }

--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/cli-utils/pkg/apply/solver"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -43,7 +43,7 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 
 	// find any crds in the set of resources.
 	for _, obj := range objs {
-		if solver.IsCRD(obj) {
+		if object.IsCRD(obj) {
 			crdObjs = append(crdObjs, obj)
 		}
 	}

--- a/pkg/object/annotations.go
+++ b/pkg/object/annotations.go
@@ -1,0 +1,99 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package object
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+// Depends-on annotation constants.
+const (
+	DependsOnAnnotation = "config.kubernetes.io/depends-on"
+	// Number of fields for a cluster-scoped depends-on object value. Example:
+	//   rbac.authorization.k8s.io/ClusterRole/my-cluster-role-name
+	NumFieldsClusterScoped = 3
+	// Number of fields for a namespace-scoped depends-on object value. Example:
+	//   apps/namespaces/my-namespace/Deployment/my-deployment-name
+	NumFieldsNamespacedScoped = 5
+	// Used to separate multiple depends-on objects.
+	AnnotationSeparator = ","
+	// Used to separate the fields for a depends-on object value.
+	FieldSeparator  = "/"
+	NamespacesField = "namespaces"
+)
+
+// HasAnnotation returns the annotation value and true if the passed annotation
+// is present in the as one of the keys in the annotations map for the passed
+// object; empty string and false otherwise.
+func HasAnnotation(u *unstructured.Unstructured, key string) (string, bool) {
+	if u == nil {
+		return "", false
+	}
+	annotations := u.GetAnnotations()
+	value, found := annotations[key]
+	return value, found
+}
+
+// DependsOnObjs returns the slice of object references (ObjMetadata)
+// that the passed unstructured object depends on based on an
+// annotation within the passed unstructured object.
+func DependsOnObjs(u *unstructured.Unstructured) ([]ObjMetadata, error) {
+	objs := []ObjMetadata{}
+	if u == nil {
+		return objs, nil
+	}
+	objsEncoded, found := HasAnnotation(u, DependsOnAnnotation)
+	if !found {
+		return objs, nil
+	}
+	klog.V(5).Infof("depends-on annotation found for %s/%s: %s\n",
+		u.GetNamespace(), u.GetName(), objsEncoded)
+	return DependsOnAnnotationToObjMetas(objsEncoded)
+}
+
+// annotationToObjMeta parses the passed annotation as an
+// object reference. The fields are separated by '/', and the
+// string can have either three fields (cluster-scoped object)
+// or five fields (namespace-scoped object). Examples are:
+//   Cluster-Scoped: <group>/<kind>/<name> (3 fields)
+//   Namespaced: <group>/namespaces/<namespace>/<kind>/<name> (5 fields)
+// For the "core" group, the string is empty.
+// Return the parsed ObjMetadata object or an error if unable
+// to parse the obj ref annotation string.
+func DependsOnAnnotationToObjMetas(o string) ([]ObjMetadata, error) {
+	objs := []ObjMetadata{}
+	for _, objStr := range strings.Split(o, AnnotationSeparator) {
+		var group, kind, namespace, name string
+		objStr := strings.TrimSpace(objStr)
+		fields := strings.Split(objStr, FieldSeparator)
+		if len(fields) != NumFieldsClusterScoped &&
+			len(fields) != NumFieldsNamespacedScoped {
+			return objs, fmt.Errorf("unable to parse depends on annotation into ObjMetadata: %s", o)
+		}
+		group = fields[0]
+		if len(fields) == 3 {
+			kind = fields[1]
+			name = fields[2]
+		} else {
+			if fields[1] != NamespacesField {
+				return objs, fmt.Errorf("depends on annotation missing 'namespaces' field: %s", o)
+			}
+			namespace = fields[2]
+			kind = fields[3]
+			name = fields[4]
+		}
+		obj, err := CreateObjMetadata(namespace, name, schema.GroupKind{Group: group, Kind: kind})
+		if err != nil {
+			return objs, err
+		}
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}

--- a/pkg/object/annotations_test.go
+++ b/pkg/object/annotations_test.go
@@ -1,0 +1,199 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package object
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	clusterScopedObj = ObjMetadata{Name: "cluster-obj",
+		GroupKind: schema.GroupKind{Group: "test-group", Kind: "test-kind"}}
+	namespacedObj = ObjMetadata{Namespace: "test-namespace", Name: "namespaced-obj",
+		GroupKind: schema.GroupKind{Group: "test-group", Kind: "test-kind"}}
+)
+
+var u1 = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/test-kind/cluster-obj",
+			},
+		},
+	},
+}
+
+var u2 = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj",
+			},
+		},
+	},
+}
+
+var multipleAnnotations = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj, " +
+					"test-group/test-kind/cluster-obj",
+			},
+		},
+	},
+}
+
+var noAnnotations = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+		},
+	},
+}
+
+var badAnnotation = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"name":      "unused",
+			"namespace": "unused",
+			"annotations": map[string]interface{}{
+				DependsOnAnnotation: "test-group:namespaces:test-namespace:test-kind:namespaced-obj",
+			},
+		},
+	},
+}
+
+func TestDependsOnAnnotation(t *testing.T) {
+	testCases := map[string]struct {
+		obj      *unstructured.Unstructured
+		expected []ObjMetadata
+		isError  bool
+	}{
+		"nil object is not found": {
+			obj:      nil,
+			expected: []ObjMetadata{},
+		},
+		"Object with no annotations returns not found": {
+			obj:      noAnnotations,
+			expected: []ObjMetadata{},
+		},
+		"Unparseable depends on annotation returns not found": {
+			obj:      badAnnotation,
+			expected: []ObjMetadata{},
+			isError:  true,
+		},
+		"Cluster-scoped object depends on annotation": {
+			obj:      u1,
+			expected: []ObjMetadata{clusterScopedObj},
+		},
+		"Namespaced object depends on annotation": {
+			obj:      u2,
+			expected: []ObjMetadata{namespacedObj},
+		},
+		"Multiple objects specified in annotation": {
+			obj:      multipleAnnotations,
+			expected: []ObjMetadata{namespacedObj, clusterScopedObj},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := DependsOnObjs(tc.obj)
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error not received")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error received: %s", err)
+				}
+				if !SetEquals(tc.expected, actual) {
+					t.Errorf("expected (%s), got (%s)", tc.expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestAnnotationToObjMetas(t *testing.T) {
+	testCases := map[string]struct {
+		annotation string
+		expected   []ObjMetadata
+		isError    bool
+	}{
+		"empty annotation is error": {
+			annotation: "",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"wrong number of namespace-scoped fields in annotation is error": {
+			annotation: "test-group/test-namespace/test-kind/namespaced-obj",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"wrong number of cluster-scoped fields in annotation is error": {
+			annotation: "test-group/namespaces/test-kind/cluster-obj",
+			expected:   []ObjMetadata{},
+			isError:    true,
+		},
+		"cluster-scoped object annotation": {
+			annotation: "test-group/test-kind/cluster-obj",
+			expected:   []ObjMetadata{clusterScopedObj},
+			isError:    false,
+		},
+		"namespaced object annotation": {
+			annotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj",
+			expected:   []ObjMetadata{namespacedObj},
+			isError:    false,
+		},
+		"namespaced object annotation with whitespace at ends is valid": {
+			annotation: "  test-group/namespaces/test-namespace/test-kind/namespaced-obj\n",
+			expected:   []ObjMetadata{namespacedObj},
+			isError:    false,
+		},
+		"multiple object annotation": {
+			annotation: "test-group/namespaces/test-namespace/test-kind/namespaced-obj," +
+				"test-group/test-kind/cluster-obj",
+			expected: []ObjMetadata{clusterScopedObj, namespacedObj},
+			isError:  false,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			actual, err := DependsOnAnnotationToObjMetas(tc.annotation)
+			if err == nil && tc.isError {
+				t.Fatalf("expected error, but received none")
+			}
+			if err != nil && !tc.isError {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if !SetEquals(tc.expected, actual) {
+				t.Errorf("expected (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -22,13 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/resource"
 )
 
 const (
@@ -49,9 +46,6 @@ var RBACGroupKind = map[schema.GroupKind]bool{
 	{Group: rbacv1.GroupName, Kind: "RoleBinding"}:        true,
 	{Group: rbacv1.GroupName, Kind: "ClusterRoleBinding"}: true,
 }
-
-// CoreV1Namespace is Namespace GVK.
-var CoreV1Namespace = corev1.SchemeGroupVersion.WithKind("Namespace")
 
 // ObjMetadata organizes and stores the indentifying information
 // for an object. This struct (as a string) is stored in a
@@ -163,51 +157,6 @@ func (o *ObjMetadata) String() string {
 		name, fieldSeparator,
 		o.GroupKind.Group, fieldSeparator,
 		o.GroupKind.Kind)
-}
-
-// BuildObjectMetadata returns object metadata (ObjMetadata) for the
-// passed objects (infos).
-func InfosToObjMetas(infos []*resource.Info) ([]ObjMetadata, error) {
-	objMetas := make([]ObjMetadata, 0, len(infos))
-	for _, info := range infos {
-		objMeta, err := InfoToObjMeta(info)
-		if err != nil {
-			return nil, err
-		}
-		objMetas = append(objMetas, objMeta)
-	}
-	return objMetas, nil
-}
-
-// InfoToObjMeta takes information from the provided info and
-// returns an ObjMetadata that identifies the resource.
-func InfoToObjMeta(info *resource.Info) (ObjMetadata, error) {
-	if info == nil || info.Object == nil {
-		return ObjMetadata{}, fmt.Errorf("attempting to transform info, but it is empty")
-	}
-	obj := info.Object
-	gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
-	return CreateObjMetadata(info.Namespace, info.Name, gk)
-}
-
-func UnstructuredsToObjMetas(objs []*unstructured.Unstructured) []ObjMetadata {
-	objMetas := make([]ObjMetadata, 0, len(objs))
-	for _, obj := range objs {
-		objMetas = append(objMetas, ObjMetadata{
-			Name:      obj.GetName(),
-			Namespace: obj.GetNamespace(),
-			GroupKind: obj.GroupVersionKind().GroupKind(),
-		})
-	}
-	return objMetas
-}
-
-func UnstructuredToObjMeta(obj *unstructured.Unstructured) ObjMetadata {
-	return ObjMetadata{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		GroupKind: obj.GroupVersionKind().GroupKind(),
-	}
 }
 
 func RuntimeToObjMeta(obj runtime.Object) ObjMetadata {

--- a/pkg/object/unstructured.go
+++ b/pkg/object/unstructured.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package object
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	CoreNamespace   = CoreV1Namespace.GroupKind()
+	CoreV1Namespace = corev1.SchemeGroupVersion.WithKind("Namespace")
+	ExtensionsCRD   = ExtensionsV1CRD.GroupKind()
+	ExtensionsV1CRD = extensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition")
+)
+
+// UnstructuredsToObjMetas returns a slice of ObjMetadata translated from
+// a slice of Unstructured objects.
+func UnstructuredsToObjMetas(objs []*unstructured.Unstructured) []ObjMetadata {
+	objMetas := make([]ObjMetadata, 0, len(objs))
+	for _, obj := range objs {
+		objMetas = append(objMetas, ObjMetadata{
+			Name:      obj.GetName(),
+			Namespace: obj.GetNamespace(),
+			GroupKind: obj.GroupVersionKind().GroupKind(),
+		})
+	}
+	return objMetas
+}
+
+// UnstructuredsToObjMetas returns an ObjMetadata translated from
+// an Unstructured object.
+func UnstructuredToObjMeta(obj *unstructured.Unstructured) ObjMetadata {
+	return ObjMetadata{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		GroupKind: obj.GroupVersionKind().GroupKind(),
+	}
+}
+
+// IsKindNamespace returns true if the passed Unstructured object is
+// GroupKind == Core/Namespace (no version checked); false otherwise.
+func IsKindNamespace(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return false
+	}
+	gvk := u.GroupVersionKind()
+	return CoreNamespace == gvk.GroupKind()
+}
+
+// IsNamespaced returns true if the passed Unstructured object
+// is namespace-scoped (not cluster-scoped); false otherwise.
+func IsNamespaced(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return false
+	}
+	return u.GetNamespace() != ""
+}
+
+// IsCRD returns true if the passed Unstructured object has
+// GroupKind == Extensions/CustomResourceDefinition; false otherwise.
+func IsCRD(u *unstructured.Unstructured) bool {
+	if u == nil {
+		return false
+	}
+	gvk := u.GroupVersionKind()
+	return ExtensionsCRD == gvk.GroupKind()
+}
+
+// GetCRDGroupKind returns the GroupKind stored in the passed
+// Unstructured CustomResourceDefinition and true if the passed object
+// is a CRD.
+func GetCRDGroupKind(u *unstructured.Unstructured) (schema.GroupKind, bool) {
+	emptyGroupKind := schema.GroupKind{Group: "", Kind: ""}
+	if u == nil {
+		return emptyGroupKind, false
+	}
+	group, found, err := unstructured.NestedString(u.Object, "spec", "group")
+	if found && err == nil {
+		kind, found, err := unstructured.NestedString(u.Object, "spec", "names", "kind")
+		if found && err == nil {
+			return schema.GroupKind{Group: group, Kind: kind}, true
+		}
+	}
+	return emptyGroupKind, false
+}

--- a/pkg/object/unstructured_test.go
+++ b/pkg/object/unstructured_test.go
@@ -1,0 +1,259 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var rbac = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRole",
+		"metadata": map[string]interface{}{
+			"name": "test-cluster-role",
+		},
+	},
+}
+
+var testCRD = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata": map[string]interface{}{
+			"name": "test-crd",
+		},
+		"spec": map[string]interface{}{
+			"group": "example.com",
+			"names": map[string]interface{}{
+				"kind": "crontab",
+			},
+		},
+	},
+}
+
+var testNamespace = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": "test-namespace",
+		},
+	},
+}
+
+var testPod = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "test-pod",
+			"namespace": "test-namespace",
+		},
+	},
+}
+
+var defaultNamespacePod = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]interface{}{
+			"name":      "test-pod",
+			"namespace": "default",
+		},
+	},
+}
+
+func TestUnstructuredToObjMeta(t *testing.T) {
+	tests := map[string]struct {
+		obj      *unstructured.Unstructured
+		expected ObjMetadata
+	}{
+		"test RBAC translation": {
+			obj: rbac,
+			expected: ObjMetadata{
+				Name: "test-cluster-role",
+				GroupKind: schema.GroupKind{
+					Group: "rbac.authorization.k8s.io",
+					Kind:  "ClusterRole",
+				},
+			},
+		},
+		"test CRD translation": {
+			obj: testCRD,
+			expected: ObjMetadata{
+				Name: "test-crd",
+				GroupKind: schema.GroupKind{
+					Group: "apiextensions.k8s.io",
+					Kind:  "CustomResourceDefinition",
+				},
+			},
+		},
+		"test pod translation": {
+			obj: testPod,
+			expected: ObjMetadata{
+				Name:      "test-pod",
+				Namespace: "test-namespace",
+				GroupKind: schema.GroupKind{
+					Group: "",
+					Kind:  "Pod",
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := UnstructuredToObjMeta(tc.obj)
+			if tc.expected != actual {
+				t.Errorf("expected ObjMetadata (%s), got (%s)", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsKindNamespace(t *testing.T) {
+	tests := map[string]struct {
+		obj             *unstructured.Unstructured
+		isKindNamespace bool
+	}{
+		"cluster-scoped RBAC is not a namespace": {
+			obj:             rbac,
+			isKindNamespace: false,
+		},
+		"test namespace is a namespace": {
+			obj:             testNamespace,
+			isKindNamespace: true,
+		},
+		"test pod is not a namespace": {
+			obj:             testPod,
+			isKindNamespace: false,
+		},
+		"default namespaced pod is not a namespace": {
+			obj:             defaultNamespacePod,
+			isKindNamespace: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := IsKindNamespace(tc.obj)
+			if tc.isKindNamespace != actual {
+				t.Errorf("expected IsKindNamespace (%t), got (%t) for (%s)",
+					tc.isKindNamespace, actual, tc.obj)
+			}
+		})
+	}
+}
+
+func TestIsCRD(t *testing.T) {
+	tests := map[string]struct {
+		obj   *unstructured.Unstructured
+		isCRD bool
+	}{
+		"RBAC is not a CRD": {
+			obj:   rbac,
+			isCRD: false,
+		},
+		"test namespace is not a CRD": {
+			obj:   testNamespace,
+			isCRD: false,
+		},
+		"test CRD is a CRD": {
+			obj:   testCRD,
+			isCRD: true,
+		},
+		"test pod is not a CRD": {
+			obj:   testPod,
+			isCRD: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := IsCRD(tc.obj)
+			if tc.isCRD != actual {
+				t.Errorf("expected IsCRD (%t), got (%t) for (%s)", tc.isCRD, actual, tc.obj)
+			}
+		})
+	}
+}
+
+func TestIsNamespaced(t *testing.T) {
+	tests := map[string]struct {
+		obj          *unstructured.Unstructured
+		isNamespaced bool
+	}{
+		"cluster-scoped RBAC is not namespaced": {
+			obj:          rbac,
+			isNamespaced: false,
+		},
+		"a CRD is cluster-scoped": {
+			obj:          testCRD,
+			isNamespaced: false,
+		},
+		"a namespace is cluster-scoped": {
+			obj:          testNamespace,
+			isNamespaced: false,
+		},
+		"pod is namespaced": {
+			obj:          testPod,
+			isNamespaced: true,
+		},
+		"default namespaced pod is namespaced": {
+			obj:          defaultNamespacePod,
+			isNamespaced: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := IsNamespaced(tc.obj)
+			if tc.isNamespaced != actual {
+				t.Errorf("expected namespaced (%t), got (%t) for (%s)",
+					tc.isNamespaced, actual, tc.obj)
+			}
+		})
+	}
+}
+
+func TestGetCRDGroupKind(t *testing.T) {
+	tests := map[string]struct {
+		obj       *unstructured.Unstructured
+		isCRD     bool
+		groupKind string
+	}{
+		"RBAC is not a CRD": {
+			obj:       rbac,
+			isCRD:     false,
+			groupKind: "",
+		},
+		"pod is not a CRD": {
+			obj:       testPod,
+			isCRD:     false,
+			groupKind: "",
+		},
+		"testCRD has example.com/crontab GroupKind": {
+			obj:       testCRD,
+			isCRD:     true,
+			groupKind: "crontab.example.com",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualGroupKind, actualIsCRD := GetCRDGroupKind(tc.obj)
+			if tc.isCRD != actualIsCRD {
+				t.Errorf("expected IsCRD (%t), got (%t) for (%s)", tc.isCRD, actualIsCRD, tc.obj)
+			}
+			if tc.groupKind != actualGroupKind.String() {
+				t.Errorf("expected CRD GroupKind (%s), got (%s) for (%s)",
+					tc.groupKind, actualGroupKind, tc.obj)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Re-organizes `pkg/object` package by moving functions out of `objmetadata.go` and into `infos.go` and new `unstructured.go`.
* Adds helper functions for annotations in `annotations.go`, including upcoming `depends-on` annotation.
* Moves `IsCRD` helper function from `solver.go` to `object` package since it is re-used elsewhere.
* Adds unit tests. Test coverage is now up to 74.7%.