### PR TITLE
Adds Reason to ValidationFilter and skipped events

### DIFF
--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -137,7 +137,9 @@ type PruneEvent struct {
 	Identifier object.ObjMetadata
 	Operation  PruneEventOperation
 	Object     *unstructured.Unstructured
-	Error      error
+	// If prune is skipped, this reason string explains why
+	Reason string
+	Error  error
 }
 
 //go:generate stringer -type=DeleteEventOperation
@@ -153,5 +155,7 @@ type DeleteEvent struct {
 	Identifier object.ObjMetadata
 	Operation  DeleteEventOperation
 	Object     *unstructured.Unstructured
-	Error      error
+	// If delete is skipped, this reason string explains why
+	Reason string
+	Error  error
 }

--- a/pkg/apply/filter/current-uids-filter.go
+++ b/pkg/apply/filter/current-uids-filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -24,10 +26,11 @@ func (cuf CurrentUIDFilter) Name() string {
 // because the it is a namespace that objects still reside in; otherwise
 // returns false. This filter should not be added to the list of filters
 // for "destroying", since every object is being deletet. Never returns an error.
-func (cuf CurrentUIDFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+func (cuf CurrentUIDFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
 	uid := string(obj.GetUID())
 	if cuf.CurrentUIDs.Has(uid) {
-		return true, nil
+		reason := fmt.Sprintf("object removal prevented; UID just applied: %s", uid)
+		return true, reason, nil
 	}
-	return false, nil
+	return false, "", nil
 }

--- a/pkg/apply/filter/current-uids-filter_test.go
+++ b/pkg/apply/filter/current-uids-filter_test.go
@@ -50,12 +50,18 @@ func TestCurrentUIDFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetUID(types.UID(tc.objUID))
-			actual, err := filter.Filter(obj)
+			actual, reason, err := filter.Filter(obj)
 			if err != nil {
 				t.Fatalf("CurrentUIDFilter unexpected error (%s)", err)
 			}
 			if tc.filtered != actual {
 				t.Errorf("CurrentUIDFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+			if tc.filtered && len(reason) == 0 {
+				t.Errorf("CurrentUIDFilter filtered; expected but missing Reason")
+			}
+			if !tc.filtered && len(reason) > 0 {
+				t.Errorf("CurrentUIDFilter not filtered; received unexpected Reason: %s", reason)
 			}
 		})
 	}

--- a/pkg/apply/filter/filter.go
+++ b/pkg/apply/filter/filter.go
@@ -14,6 +14,8 @@ import (
 type ValidationFilter interface {
 	// Name returns a filter name (usually for logging).
 	Name() string
-	// Filter returns true if validation fails or an error.
-	Filter(obj *unstructured.Unstructured) (bool, error)
+	// Filter returns true if validation fails. If true a
+	// reason string is included in the return. If an error happens
+	// during filtering it is returned.
+	Filter(obj *unstructured.Unstructured) (bool, string, error)
 }

--- a/pkg/apply/filter/inventory-policy-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-filter_test.go
@@ -89,12 +89,18 @@ func TestInventoryPolicyFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(objIDAnnotation)
-			actual, err := filter.Filter(obj)
+			actual, reason, err := filter.Filter(obj)
 			if err != nil {
 				t.Fatalf("InventoryPolicyFilter unexpected error (%s)", err)
 			}
 			if tc.filtered != actual {
 				t.Errorf("InventoryPolicyFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+			if tc.filtered && len(reason) == 0 {
+				t.Errorf("InventoryPolicyFilter filtered; expected but missing Reason")
+			}
+			if !tc.filtered && len(reason) > 0 {
+				t.Errorf("InventoryPolicyFilter not filtered; received unexpected Reason: %s", reason)
 			}
 		})
 	}

--- a/pkg/apply/filter/local-namespaces-filter.go
+++ b/pkg/apply/filter/local-namespaces-filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -25,11 +27,12 @@ func (lnf LocalNamespacesFilter) Name() string {
 // because the it is a namespace that objects still reside in; otherwise
 // returns false. This filter should not be added to the list of filters
 // for "destroying", since every object is being delete. Never returns an error.
-func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
 	id := object.UnstructuredToObjMeta(obj)
 	if id.GroupKind == object.CoreV1Namespace.GroupKind() &&
 		lnf.LocalNamespaces.Has(id.Name) {
-		return true, nil
+		reason := fmt.Sprintf("namespace removal prevented; still in use: %s", id.Name)
+		return true, reason, nil
 	}
-	return false, nil
+	return false, "", nil
 }

--- a/pkg/apply/filter/local-namespaces-filter_test.go
+++ b/pkg/apply/filter/local-namespaces-filter_test.go
@@ -50,12 +50,18 @@ func TestLocalNamespacesFilter(t *testing.T) {
 			}
 			namespace := testNamespace.DeepCopy()
 			namespace.SetName(tc.namespace)
-			actual, err := filter.Filter(namespace)
+			actual, reason, err := filter.Filter(namespace)
 			if err != nil {
 				t.Fatalf("LocalNamespacesFilter unexpected error (%s)", err)
 			}
 			if tc.filtered != actual {
 				t.Errorf("LocalNamespacesFilter expected filter (%t), got (%t)", tc.filtered, actual)
+			}
+			if tc.filtered && len(reason) == 0 {
+				t.Errorf("LocalNamespacesFilter filtered; expected but missing Reason")
+			}
+			if !tc.filtered && len(reason) > 0 {
+				t.Errorf("LocalNamespacesFilter not filtered; received unexpected Reason: %s", reason)
 			}
 		})
 	}

--- a/pkg/apply/filter/prevent-remove-filter.go
+++ b/pkg/apply/filter/prevent-remove-filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/common"
 )
@@ -22,11 +24,12 @@ func (prf PreventRemoveFilter) Name() string {
 // Filter returns true if the passed object should NOT be pruned (deleted)
 // because the "prevent remove" annotation is present; otherwise returns
 // false. Never returns an error.
-func (prf PreventRemoveFilter) Filter(obj *unstructured.Unstructured) (bool, error) {
+func (prf PreventRemoveFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
 	for annotation, value := range obj.GetAnnotations() {
 		if common.NoDeletion(annotation, value) {
-			return true, nil
+			reason := fmt.Sprintf("object removal prevented; delete annotation: %s/%s", annotation, value)
+			return true, reason, nil
 		}
 	}
-	return false, nil
+	return false, "", nil
 }

--- a/pkg/apply/filter/prevent-remove-filter_test.go
+++ b/pkg/apply/filter/prevent-remove-filter_test.go
@@ -71,12 +71,18 @@ func TestPreventDeleteAnnotation(t *testing.T) {
 			filter := PreventRemoveFilter{}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(tc.annotations)
-			actual, err := filter.Filter(obj)
+			actual, reason, err := filter.Filter(obj)
 			if err != nil {
 				t.Fatalf("PreventRemoveFilter unexpected error (%s)", err)
 			}
 			if tc.expected != actual {
 				t.Errorf("PreventRemoveFilter expected (%t), got (%t)", tc.expected, actual)
+			}
+			if tc.expected && len(reason) == 0 {
+				t.Errorf("PreventRemoveFilter expected Reason, but none found")
+			}
+			if !tc.expected && len(reason) > 0 {
+				t.Errorf("PreventRemoveFilter expected no Reason, but found (%s)", reason)
 			}
 		})
 	}

--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -14,7 +14,7 @@ import (
 // events for pruning or deleting.
 type EventFactory interface {
 	CreateSuccessEvent(obj *unstructured.Unstructured) event.Event
-	CreateSkippedEvent(obj *unstructured.Unstructured) event.Event
+	CreateSkippedEvent(obj *unstructured.Unstructured, reason string) event.Event
 	CreateFailedEvent(id object.ObjMetadata, err error) event.Event
 }
 
@@ -42,13 +42,14 @@ func (pef PruneEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) 
 	}
 }
 
-func (pef PruneEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured) event.Event {
+func (pef PruneEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured, reason string) event.Event {
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
 			Operation:  event.PruneSkipped,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMeta(obj),
+			Reason:     reason,
 		},
 	}
 }
@@ -78,13 +79,14 @@ func (def DeleteEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured)
 	}
 }
 
-func (def DeleteEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured) event.Event {
+func (def DeleteEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured, reason string) event.Event {
 	return event.Event{
 		Type: event.DeleteType,
 		DeleteEvent: event.DeleteEvent{
 			Operation:  event.DeleteSkipped,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMeta(obj),
+			Reason:     reason,
 		},
 	}
 }

--- a/pkg/apply/prune/event-factory_test.go
+++ b/pkg/apply/prune/event-factory_test.go
@@ -63,7 +63,7 @@ func TestEventFactory(t *testing.T) {
 				t.Errorf("success event expected nil error, got (%s)", err)
 			}
 			// Validate the "skipped" event"
-			actualEvent = eventFactory.CreateSkippedEvent(tc.obj)
+			actualEvent = eventFactory.CreateSkippedEvent(tc.obj, "fake reason")
 			if tc.expectedType != actualEvent.Type {
 				t.Errorf("skipped event expected type (%s), got (%s)",
 					tc.expectedType, actualEvent.Type)

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -97,10 +97,11 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 		klog.V(5).Infof("attempting prune: %s", pruneID)
 		// Check filters to see if we're prevented from pruning/deleting object.
 		var filtered bool
+		var reason string
 		var err error
 		for _, filter := range pruneFilters {
 			klog.V(6).Infof("prune filter %s: %s", filter.Name(), pruneID)
-			filtered, err = filter.Filter(pruneObj)
+			filtered, reason, err = filter.Filter(pruneObj)
 			if err != nil {
 				if klog.V(5).Enabled() {
 					klog.Errorf("error during %s, (%s): %s", filter.Name(), pruneID, err)
@@ -111,7 +112,7 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 			}
 			if filtered {
 				klog.V(4).Infof("prune filtered by %s: %s", filter.Name(), pruneID)
-				taskContext.EventChannel() <- eventFactory.CreateSkippedEvent(pruneObj)
+				taskContext.EventChannel() <- eventFactory.CreateSkippedEvent(pruneObj, reason)
 				taskContext.CapturePruneFailure(pruneID)
 				break
 			}

--- a/pkg/inventory/policy.go
+++ b/pkg/inventory/policy.go
@@ -77,7 +77,7 @@ const (
 	NoMatch
 )
 
-func inventoryIDMatch(inv InventoryInfo, obj *unstructured.Unstructured) inventoryIDMatchStatus {
+func InventoryIDMatch(inv InventoryInfo, obj *unstructured.Unstructured) inventoryIDMatchStatus {
 	annotations := obj.GetAnnotations()
 	value, found := annotations[owningInventoryKey]
 	if !found {
@@ -93,7 +93,7 @@ func CanApply(inv InventoryInfo, obj *unstructured.Unstructured, policy Inventor
 	if obj == nil {
 		return true, nil
 	}
-	matchStatus := inventoryIDMatch(inv, obj)
+	matchStatus := InventoryIDMatch(inv, obj)
 	switch matchStatus {
 	case Empty:
 		if policy != InventoryPolicyMustMatch {
@@ -118,7 +118,7 @@ func CanPrune(inv InventoryInfo, obj *unstructured.Unstructured, policy Inventor
 	if obj == nil {
 		return false
 	}
-	matchStatus := inventoryIDMatch(inv, obj)
+	matchStatus := InventoryIDMatch(inv, obj)
 	switch matchStatus {
 	case Empty:
 		return policy == AdoptIfNoInventory || policy == AdoptAll

--- a/pkg/inventory/policy_test.go
+++ b/pkg/inventory/policy_test.go
@@ -75,7 +75,7 @@ func TestInventoryIDMatch(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		actual := inventoryIDMatch(tc.inv, tc.obj)
+		actual := InventoryIDMatch(tc.inv, tc.obj)
 		if actual != tc.expected {
 			t.Errorf("expected %v, but got %v", tc.expected, actual)
 		}


### PR DESCRIPTION
* Adds reason string in return of `Filter` interface function to provide an explanation for prune/delete filtering.
* Implements reason return string for each `ValidationFilter` and unit tests.
* Adds `Reason` field to `PruneEvent` and `DeleteEvent` to store prune/delete skipping explanation.
* Exports `InventoryIDMatch()` function for better prune/delete reason string in the `InventoryPolicyFilter`.
* Does **NOT** surface the `Reason` in printing yet.
