### PR TITLE
Destroyer calculates emit status events

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -115,6 +115,7 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 		DeleteTimeout:           r.deleteTimeout,
 		DeletePropagationPolicy: deletePropPolicy,
 		InventoryPolicy:         inventoryPolicy,
+		EmitStatusEvents:        r.deleteTimeout != time.Duration(0),
 	})
 
 	// The printer will print updates from the channel. It will block

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -130,6 +130,7 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 			handleError(eventChannel, err)
 			return
 		}
+		klog.V(4).Infof("calculated %d apply objs; %d prune objs", len(applyObjs), len(pruneObjs))
 		mapper, err := a.factory.ToRESTMapper()
 		if err != nil {
 			handleError(eventChannel, err)

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -73,6 +73,10 @@ type DestroyerOptions struct {
 	// that should be used. If this is not provided, the default is to
 	// use the Background policy.
 	DeletePropagationPolicy metav1.DeletionPropagation
+
+	// EmitStatusEvents defines whether status events should be
+	// emitted on the eventChannel to the caller.
+	EmitStatusEvents bool
 }
 
 // Run performs the destroy step. Passes the inventory object. This
@@ -139,7 +143,7 @@ func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <
 		err = runner.Run(context.Background(), taskQueue.ToChannel(), eventChannel, taskrunner.Options{
 			UseCache:         true,
 			PollInterval:     poller.DefaultPollInterval,
-			EmitStatusEvents: true,
+			EmitStatusEvents: options.EmitStatusEvents,
 		})
 		if err != nil {
 			handleError(eventChannel, err)


### PR DESCRIPTION
* `Destroyer` now dynamically chooses whether to emit status events on the event channel (previously hard-coded). The first pass of this choice is to only emit status events when the `--delete-timeout` is set.
* Adds single log statement to `applier.go`