### PR TITLE
Better validation of resources prior to actuation

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -230,7 +230,7 @@ func TestApplier(t *testing.T) {
 				namespace: "default",
 				id:        "test",
 				list: []object.ObjMetadata{
-					object.UnstructuredToObjMeta(
+					object.UnstructuredToObjMetaOrDie(
 						testutil.Unstructured(t, resources["deployment"]),
 					),
 				},
@@ -303,10 +303,10 @@ func TestApplier(t *testing.T) {
 				namespace: "default",
 				id:        "test",
 				list: []object.ObjMetadata{
-					object.UnstructuredToObjMeta(
+					object.UnstructuredToObjMetaOrDie(
 						testutil.Unstructured(t, resources["deployment"]),
 					),
-					object.UnstructuredToObjMeta(
+					object.UnstructuredToObjMetaOrDie(
 						testutil.Unstructured(t, resources["secret"]),
 					),
 				},
@@ -425,7 +425,7 @@ func TestApplier(t *testing.T) {
 				namespace: "default",
 				id:        "test",
 				list: []object.ObjMetadata{
-					object.UnstructuredToObjMeta(
+					object.UnstructuredToObjMetaOrDie(
 						testutil.Unstructured(t, resources["deployment"]),
 					),
 				},
@@ -468,7 +468,7 @@ func TestApplier(t *testing.T) {
 				namespace: "default",
 				id:        "test",
 				list: []object.ObjMetadata{
-					object.UnstructuredToObjMeta(
+					object.UnstructuredToObjMetaOrDie(
 						testutil.Unstructured(t, resources["deployment"]),
 					),
 				},
@@ -517,14 +517,14 @@ func TestApplier(t *testing.T) {
 
 			objMap := make(map[object.ObjMetadata]resourceInfo)
 			for _, r := range tc.resources {
-				objMeta := object.UnstructuredToObjMeta(r)
+				objMeta := object.UnstructuredToObjMetaOrDie(r)
 				objMap[objMeta] = resourceInfo{
 					resource: r,
 					exists:   false,
 				}
 			}
 			for _, r := range tc.clusterObjs {
-				objMeta := object.UnstructuredToObjMeta(r)
+				objMeta := object.UnstructuredToObjMetaOrDie(r)
 				objMap[objMeta] = resourceInfo{
 					resource: r,
 					exists:   true,
@@ -721,7 +721,7 @@ func TestReadAndPrepareObjects(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// Set up objects already stored in cluster inventory.
-			clusterObjs := object.UnstructuredsToObjMetas(tc.clusterObjs)
+			clusterObjs := object.UnstructuredsToObjMetasOrDie(tc.clusterObjs)
 			fakeInvClient := inventory.NewFakeInventoryClient(clusterObjs)
 			// Set up the fake dynamic client to recognize all objects, and the RESTMapper.
 			objs := make([]runtime.Object, 0, len(tc.clusterObjs))
@@ -1042,11 +1042,11 @@ func objSetsEqual(setA []*unstructured.Unstructured, setB []*unstructured.Unstru
 		return false
 	}
 	mapA := map[string]bool{}
-	objMetasA := object.UnstructuredsToObjMetas(setA)
+	objMetasA := object.UnstructuredsToObjMetasOrDie(setA)
 	for _, objMetaA := range objMetasA {
 		mapA[objMetaA.String()] = true
 	}
-	objMetasB := object.UnstructuredsToObjMetas(setB)
+	objMetasB := object.UnstructuredsToObjMetasOrDie(setB)
 	for _, objMetaB := range objMetasB {
 		if _, ok := mapA[objMetaB.String()]; !ok {
 			return false

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -130,7 +130,7 @@ func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <
 		}
 		// Create a new TaskStatusRunner to execute the taskQueue.
 		klog.V(4).Infoln("destroyer building TaskStatusRunner...")
-		deleteIds := object.UnstructuredsToObjMetas(deleteObjs)
+		deleteIds := object.UnstructuredsToObjMetasOrDie(deleteObjs)
 		runner := taskrunner.NewTaskStatusRunner(deleteIds, d.statusPoller)
 		klog.V(4).Infoln("destroyer running TaskStatusRunner...")
 		// TODO(seans): Make the poll interval configurable like the applier.

--- a/pkg/apply/filter/local-namespaces-filter.go
+++ b/pkg/apply/filter/local-namespaces-filter.go
@@ -28,7 +28,7 @@ func (lnf LocalNamespacesFilter) Name() string {
 // returns false. This filter should not be added to the list of filters
 // for "destroying", since every object is being delete. Never returns an error.
 func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
-	id := object.UnstructuredToObjMeta(obj)
+	id := object.UnstructuredToObjMetaOrDie(obj)
 	if id.GroupKind == object.CoreV1Namespace.GroupKind() &&
 		lnf.LocalNamespaces.Has(id.Name) {
 		reason := fmt.Sprintf("namespace removal prevented; still in use: %s", id.Name)

--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -37,7 +37,7 @@ func (pef PruneEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) 
 		PruneEvent: event.PruneEvent{
 			Operation:  event.Pruned,
 			Object:     obj,
-			Identifier: object.UnstructuredToObjMeta(obj),
+			Identifier: object.UnstructuredToObjMetaOrDie(obj),
 		},
 	}
 }
@@ -48,7 +48,7 @@ func (pef PruneEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured, 
 		PruneEvent: event.PruneEvent{
 			Operation:  event.PruneSkipped,
 			Object:     obj,
-			Identifier: object.UnstructuredToObjMeta(obj),
+			Identifier: object.UnstructuredToObjMetaOrDie(obj),
 			Reason:     reason,
 		},
 	}
@@ -74,7 +74,7 @@ func (def DeleteEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured)
 		DeleteEvent: event.DeleteEvent{
 			Operation:  event.Deleted,
 			Object:     obj,
-			Identifier: object.UnstructuredToObjMeta(obj),
+			Identifier: object.UnstructuredToObjMetaOrDie(obj),
 		},
 	}
 }
@@ -85,7 +85,7 @@ func (def DeleteEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured,
 		DeleteEvent: event.DeleteEvent{
 			Operation:  event.DeleteSkipped,
 			Object:     obj,
-			Identifier: object.UnstructuredToObjMeta(obj),
+			Identifier: object.UnstructuredToObjMetaOrDie(obj),
 			Reason:     reason,
 		},
 	}

--- a/pkg/apply/prune/event-factory_test.go
+++ b/pkg/apply/prune/event-factory_test.go
@@ -6,6 +6,7 @@ package prune
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -31,7 +32,8 @@ func TestEventFactory(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			id := object.UnstructuredToObjMeta(tc.obj)
+			id, err := object.UnstructuredToObjMeta(tc.obj)
+			require.NoError(t, err)
 			eventFactory := CreateEventFactory(tc.destroy)
 			// Validate the "success" event"
 			actualEvent := eventFactory.CreateSuccessEvent(tc.obj)
@@ -40,7 +42,6 @@ func TestEventFactory(t *testing.T) {
 					tc.expectedType, actualEvent.Type)
 			}
 			var actualObj *unstructured.Unstructured
-			var err error
 			if tc.expectedType == event.PruneType {
 				if event.Pruned != actualEvent.PruneEvent.Operation {
 					t.Errorf("success event expected operation (Pruned), got (%s)",

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -93,7 +93,7 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 	// Iterate through objects to prune (delete). If an object is not pruned
 	// and we need to keep it in the inventory, we must capture the prune failure.
 	for _, pruneObj := range pruneObjs {
-		pruneID := object.UnstructuredToObjMeta(pruneObj)
+		pruneID := object.UnstructuredToObjMetaOrDie(pruneObj)
 		klog.V(5).Infof("attempting prune: %s", pruneID)
 		// Check filters to see if we're prevented from pruning/deleting object.
 		var filtered bool
@@ -153,7 +153,7 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 // if one occurs.
 func (po *PruneOptions) GetPruneObjs(inv inventory.InventoryInfo,
 	localObjs []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
-	localIds := object.UnstructuredsToObjMetas(localObjs)
+	localIds := object.UnstructuredsToObjMetasOrDie(localObjs)
 	prevInvIds, err := po.InvClient.GetClusterObjs(inv)
 	if err != nil {
 		return nil, err

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -207,14 +207,14 @@ func (t *TaskQueueBuilder) AppendApplyWaitTasks(inv inventory.InventoryInfo, app
 	if hasCRDs {
 		t.AppendApplyTask(inv, append(crdSplitRes.before, crdSplitRes.crds...), crdSplitRes, o)
 		if !o.DryRunStrategy.ClientOrServerDryRun() {
-			waitIds := object.UnstructuredsToObjMetas(crdSplitRes.crds)
+			waitIds := object.UnstructuredsToObjMetasOrDie(crdSplitRes.crds)
 			t.AppendWaitTask(waitIds)
 		}
 		applyObjs = crdSplitRes.after
 	}
 	t.AppendApplyTask(inv, applyObjs, crdSplitRes, o)
 	if !o.DryRunStrategy.ClientOrServerDryRun() && o.ReconcileTimeout != time.Duration(0) {
-		waitIds := object.UnstructuredsToObjMetas(applyObjs)
+		waitIds := object.UnstructuredsToObjMetasOrDie(applyObjs)
 		t.AppendWaitTask(waitIds)
 	}
 	return t
@@ -228,7 +228,7 @@ func (t *TaskQueueBuilder) AppendPruneWaitTasks(pruneObjs []*unstructured.Unstru
 	if o.Prune {
 		t.AppendPruneTask(pruneObjs, pruneFilters, o)
 		if !o.DryRunStrategy.ClientOrServerDryRun() && o.PruneTimeout != time.Duration(0) {
-			pruneIds := object.UnstructuredsToObjMetas(pruneObjs)
+			pruneIds := object.UnstructuredsToObjMetasOrDie(pruneObjs)
 			t.AppendWaitTask(pruneIds)
 		}
 	}

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -257,7 +257,7 @@ func TestTaskQueueBuilder_BuildTaskQueue(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			applyIds := object.UnstructuredsToObjMetas(tc.objs)
+			applyIds := object.UnstructuredsToObjMetasOrDie(tc.objs)
 			fakeInvClient := inventory.NewFakeInventoryClient(applyIds)
 			tqb := TaskQueueBuilder{
 				PruneOptions: pruneOptions,
@@ -341,6 +341,6 @@ func getType(task taskrunner.Task) reflect.Type {
 }
 
 func ignoreErrInfoToObjMeta(info *unstructured.Unstructured) object.ObjMetadata {
-	objMeta := object.UnstructuredToObjMeta(info)
+	objMeta := object.UnstructuredToObjMetaOrDie(info)
 	return objMeta
 }

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -77,7 +77,7 @@ func (a *ApplyTask) Action() event.ResourceAction {
 }
 
 func (a *ApplyTask) Identifiers() []object.ObjMetadata {
-	return object.UnstructuredsToObjMetas(a.Objects)
+	return object.UnstructuredsToObjMetasOrDie(a.Objects)
 }
 
 // Start creates a new goroutine that will invoke
@@ -112,7 +112,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			// Created event since the type didn't already exist in the
 			// cluster.
 			for _, obj := range objsWithCRD {
-				taskContext.EventChannel() <- createApplyEvent(object.UnstructuredToObjMeta(obj), event.Created, nil)
+				taskContext.EventChannel() <- createApplyEvent(object.UnstructuredToObjMetaOrDie(obj), event.Created, nil)
 			}
 			// Update the resource set to no longer include the CRs.
 			klog.V(4).Infof("after dry-run filtering custom resources, %d objects left", len(objs))
@@ -148,7 +148,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			// Set the client and mapping fields on the provided
 			// info so they can be applied to the cluster.
 			info, err := a.InfoHelper.BuildInfo(obj)
-			id := object.UnstructuredToObjMeta(obj)
+			id := object.UnstructuredToObjMetaOrDie(obj)
 			if err != nil {
 				if klog.V(4).Enabled() {
 					klog.Errorf("unable to convert obj to info for %s/%s (%s)--continue",
@@ -412,7 +412,7 @@ func createApplyFailedEvent(id object.ObjMetadata, err error) event.Event {
 // a list of resources when failed to initialize the apply process.
 func sendBatchApplyEvents(taskContext *taskrunner.TaskContext, objects []*unstructured.Unstructured, err error) {
 	for _, obj := range objects {
-		id := object.UnstructuredToObjMeta(obj)
+		id := object.UnstructuredToObjMetaOrDie(obj)
 		taskContext.EventChannel() <- createApplyFailedEvent(id,
 			applyerror.NewInitializeApplyOptionError(err))
 		taskContext.CaptureResourceFailure(id)

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -9,7 +9,8 @@ import (
 	"sync"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -116,7 +117,9 @@ func TestApplyTask_BasicAppliedObjects(t *testing.T) {
 
 			// The applied resources should be stored in the TaskContext
 			// for the final inventory.
-			expected := object.UnstructuredsToObjMetas(objs)
+			expected, err := object.UnstructuredsToObjMetas(objs)
+			require.NoError(t, err)
+
 			actual := taskContext.AppliedResources()
 			if !object.SetEquals(expected, actual) {
 				t.Errorf("expected (%s) inventory resources, got (%s)", expected, actual)

--- a/pkg/apply/task/inv_add_task.go
+++ b/pkg/apply/task/inv_add_task.go
@@ -31,7 +31,7 @@ func (i *InvAddTask) Action() event.ResourceAction {
 }
 
 func (i *InvAddTask) Identifiers() []object.ObjMetadata {
-	return object.UnstructuredsToObjMetas(i.Objects)
+	return object.UnstructuredsToObjMetasOrDie(i.Objects)
 }
 
 // Start updates the inventory by merging the locally applied objects
@@ -52,7 +52,7 @@ func (i *InvAddTask) Start(taskContext *taskrunner.TaskContext) {
 			}
 		}
 		klog.V(4).Infof("merging %d local objects into inventory", len(i.Objects))
-		currentObjs := object.UnstructuredsToObjMetas(i.Objects)
+		currentObjs := object.UnstructuredsToObjMetasOrDie(i.Objects)
 		_, err := i.InvClient.Merge(i.InvInfo, currentObjs)
 		taskContext.TaskChannel() <- taskrunner.TaskResult{Err: err}
 	}()

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -6,6 +6,7 @@ package task
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
@@ -68,9 +69,9 @@ var obj3 = &unstructured.Unstructured{
 const taskName = "test-inventory-task"
 
 func TestInvAddTask(t *testing.T) {
-	id1 := object.UnstructuredToObjMeta(obj1)
-	id2 := object.UnstructuredToObjMeta(obj2)
-	id3 := object.UnstructuredToObjMeta(obj3)
+	id1 := object.UnstructuredToObjMetaOrDie(obj1)
+	id2 := object.UnstructuredToObjMetaOrDie(obj2)
+	id3 := object.UnstructuredToObjMetaOrDie(obj3)
 
 	tests := map[string]struct {
 		initialObjs  []object.ObjMetadata
@@ -118,7 +119,9 @@ func TestInvAddTask(t *testing.T) {
 			if taskName != task.Name() {
 				t.Errorf("expected task name (%s), got (%s)", taskName, task.Name())
 			}
-			applyIds := object.UnstructuredsToObjMetas(tc.applyObjs)
+			applyIds, err := object.UnstructuredsToObjMetas(tc.applyObjs)
+			require.NoError(t, err)
+
 			if !object.SetEquals(applyIds, task.Identifiers()) {
 				t.Errorf("expected task ids (%s), got (%s)", applyIds, task.Identifiers())
 			}

--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestInvSetTask(t *testing.T) {
-	id1 := object.UnstructuredToObjMeta(obj1)
-	id2 := object.UnstructuredToObjMeta(obj2)
-	id3 := object.UnstructuredToObjMeta(obj3)
+	id1 := object.UnstructuredToObjMetaOrDie(obj1)
+	id2 := object.UnstructuredToObjMetaOrDie(obj2)
+	id3 := object.UnstructuredToObjMetaOrDie(obj3)
 
 	tests := map[string]struct {
 		appliedObjs   []object.ObjMetadata

--- a/pkg/apply/task/printer_adapter.go
+++ b/pkg/apply/task/printer_adapter.go
@@ -33,10 +33,14 @@ type resourcePrinterImpl struct {
 // PrintObj takes the provided object and operation and emits
 // it on the channel.
 func (r *resourcePrinterImpl) PrintObj(obj runtime.Object, _ io.Writer) error {
+	id, err := object.RuntimeToObjMeta(obj)
+	if err != nil {
+		return err
+	}
 	r.ch <- event.Event{
 		Type: event.ApplyType,
 		ApplyEvent: event.ApplyEvent{
-			Identifier: object.RuntimeToObjMeta(obj),
+			Identifier: id,
 			Operation:  r.applyOperation,
 			Resource:   obj.(*unstructured.Unstructured),
 		},

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -43,7 +43,7 @@ func (p *PruneTask) Action() event.ResourceAction {
 }
 
 func (p *PruneTask) Identifiers() []object.ObjMetadata {
-	return object.UnstructuredsToObjMetas(p.Objects)
+	return object.UnstructuredsToObjMetasOrDie(p.Objects)
 }
 
 // Start creates a new goroutine that will invoke

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -275,7 +275,7 @@ func (cic *ClusterInventoryClient) getClusterInventoryObjsByLabel(inv InventoryI
 	if localInv == nil {
 		return nil, fmt.Errorf("retrieving cluster inventory object with nil local inventory")
 	}
-	localObj := object.UnstructuredToObjMeta(localInv)
+	localObj := object.UnstructuredToObjMetaOrDie(localInv)
 	mapping, err := cic.mapper.RESTMapping(localObj.GroupKind)
 	if err != nil {
 		return nil, err

--- a/pkg/kstatus/polling/statusreaders/common.go
+++ b/pkg/kstatus/polling/statusreaders/common.go
@@ -172,11 +172,3 @@ func toSelector(resource *unstructured.Unstructured, path ...string) (labels.Sel
 	}
 	return metav1.LabelSelectorAsSelector(&s)
 }
-
-func toIdentifier(u *unstructured.Unstructured) object.ObjMetadata {
-	return object.ObjMetadata{
-		GroupKind: u.GroupVersionKind().GroupKind(),
-		Name:      u.GetName(),
-		Namespace: u.GetNamespace(),
-	}
-}

--- a/pkg/kstatus/polling/statusreaders/deployment.go
+++ b/pkg/kstatus/polling/statusreaders/deployment.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 func NewDeploymentResourceReader(reader engine.ClusterReader, mapper meta.RESTMapper, rsStatusReader resourceTypeStatusReader) engine.StatusReader {
@@ -41,7 +42,7 @@ type deploymentResourceReader struct {
 var _ resourceTypeStatusReader = &deploymentResourceReader{}
 
 func (d *deploymentResourceReader) ReadStatusForObject(ctx context.Context, deployment *unstructured.Unstructured) *event.ResourceStatus {
-	identifier := toIdentifier(deployment)
+	identifier := object.UnstructuredToObjMetaOrDie(deployment)
 
 	replicaSetStatuses, err := statusForGeneratedResources(ctx, d.mapper, d.reader, d.rsStatusReader, deployment,
 		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(), "spec", "selector")

--- a/pkg/kstatus/polling/statusreaders/generic.go
+++ b/pkg/kstatus/polling/statusreaders/generic.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper) engine.StatusReader {
@@ -41,7 +42,7 @@ type genericStatusReader struct {
 var _ resourceTypeStatusReader = &genericStatusReader{}
 
 func (g *genericStatusReader) ReadStatusForObject(_ context.Context, resource *unstructured.Unstructured) *event.ResourceStatus {
-	identifier := toIdentifier(resource)
+	identifier := object.UnstructuredToObjMetaOrDie(resource)
 
 	res, err := g.statusFunc(resource)
 	if err != nil {

--- a/pkg/kstatus/polling/statusreaders/testing.go
+++ b/pkg/kstatus/polling/statusreaders/testing.go
@@ -47,8 +47,8 @@ func (f *fakeStatusReader) ReadStatus(_ context.Context, _ object.ObjMetadata) *
 	return nil
 }
 
-func (f *fakeStatusReader) ReadStatusForObject(_ context.Context, object *unstructured.Unstructured) *event.ResourceStatus {
-	identifier := toIdentifier(object)
+func (f *fakeStatusReader) ReadStatusForObject(_ context.Context, obj *unstructured.Unstructured) *event.ResourceStatus {
+	identifier := object.UnstructuredToObjMetaOrDie(obj)
 	return &event.ResourceStatus{
 		Identifier: identifier,
 	}

--- a/pkg/object/graph/depends_test.go
+++ b/pkg/object/graph/depends_test.go
@@ -576,8 +576,8 @@ func verifyObjSets(t *testing.T, expected [][]*unstructured.Unstructured, actual
 // containsUnstructured returns true if the passed object is within the passed
 // slice of objects; false otherwise. Order is not important.
 func containsObjs(objs []*unstructured.Unstructured, obj *unstructured.Unstructured) bool {
-	ids := object.UnstructuredsToObjMetas(objs)
-	id := object.UnstructuredToObjMeta(obj)
+	ids := object.UnstructuredsToObjMetasOrDie(objs)
+	id := object.UnstructuredToObjMetaOrDie(obj)
 	for _, i := range ids {
 		if i == id {
 			return true

--- a/pkg/object/unstructured.go
+++ b/pkg/object/unstructured.go
@@ -5,8 +5,11 @@
 package object
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -18,28 +21,49 @@ var (
 	ExtensionsV1CRD = extensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition")
 )
 
-// UnstructuredsToObjMetas returns a slice of ObjMetadata translated from
-// a slice of Unstructured objects.
-func UnstructuredsToObjMetas(objs []*unstructured.Unstructured) []ObjMetadata {
+// UnstructuredsToObjMetas converts a slice of unstructureds to a slice of
+// ObjMetadata. If the values for any of the unstructured objects doesn't
+// pass validation, an error will be returned.
+func UnstructuredsToObjMetas(objs []*unstructured.Unstructured) ([]ObjMetadata, error) {
 	objMetas := make([]ObjMetadata, 0, len(objs))
 	for _, obj := range objs {
-		objMetas = append(objMetas, ObjMetadata{
-			Name:      obj.GetName(),
-			Namespace: obj.GetNamespace(),
-			GroupKind: obj.GroupVersionKind().GroupKind(),
-		})
+		objMeta, err := UnstructuredToObjMeta(obj)
+		if err != nil {
+			return nil, err
+		}
+		objMetas = append(objMetas, objMeta)
+	}
+	return objMetas, nil
+}
+
+// UnstructuredsToObjMetasOrDie converts a slice of unstructureds to a slice of
+// ObjMetadata. If the values for any of the unstructured objects doesn't
+// pass validation, the function will panic.
+func UnstructuredsToObjMetasOrDie(objs []*unstructured.Unstructured) []ObjMetadata {
+	objMetas, err := UnstructuredsToObjMetas(objs)
+	if err != nil {
+		panic(err)
 	}
 	return objMetas
 }
 
-// UnstructuredsToObjMetas returns an ObjMetadata translated from
-// an Unstructured object.
-func UnstructuredToObjMeta(obj *unstructured.Unstructured) ObjMetadata {
-	return ObjMetadata{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		GroupKind: obj.GroupVersionKind().GroupKind(),
+// UnstructuredToObjMeta extracts the identifying information from an
+// Unstructured object and returns it as Objmetadata. If the values doesn't
+// pass validation, an error will be returned.
+func UnstructuredToObjMeta(obj *unstructured.Unstructured) (ObjMetadata, error) {
+	return CreateObjMetadata(obj.GetNamespace(), obj.GetName(),
+		obj.GroupVersionKind().GroupKind())
+}
+
+// UnstructuredToObjMetaOrDie extracts the identifying information from an
+// Unstructured object and returns it as Objmetadata. If the values doesn't
+// pass validation, the function will panic.
+func UnstructuredToObjMetaOrDie(obj *unstructured.Unstructured) ObjMetadata {
+	objMeta, err := UnstructuredToObjMeta(obj)
+	if err != nil {
+		panic(err)
 	}
+	return objMeta
 }
 
 // IsKindNamespace returns true if the passed Unstructured object is
@@ -87,4 +111,62 @@ func GetCRDGroupKind(u *unstructured.Unstructured) (schema.GroupKind, bool) {
 		}
 	}
 	return emptyGroupKind, false
+}
+
+// UnknownTypeError captures information about a type for which no information
+// could be found in the cluster or among the known CRDs.
+type UnknownTypeError struct {
+	GroupKind schema.GroupKind
+}
+
+func (e *UnknownTypeError) Error() string {
+	return fmt.Sprintf("unknown resource type: %q", e.GroupKind.String())
+}
+
+// LookupResourceScope tries to look up the scope of the type of the provided
+// resource, looking at both the types known to the cluster (through the
+// RESTMapper) and the provided CRDs. If no information about the type can
+// be found, an UnknownTypeError wil be returned.
+func LookupResourceScope(u *unstructured.Unstructured, crds []*unstructured.Unstructured, mapper meta.RESTMapper) (meta.RESTScope, error) {
+	gvk := u.GroupVersionKind()
+	// First see if we can find the type (and the scope) in the cluster through
+	// the RESTMapper.
+	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	// Not finding a match is not an error here, so only error out for other
+	// error types.
+	if err != nil && !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+
+	var scope meta.RESTScope
+	if err == nil {
+		// If we find the type in the cluster, we just look up the scope there.
+		scope = mapping.Scope
+	} else {
+		// If we couldn't find the type in the cluster, check if we find a
+		// match in any of the provided CRDs.
+		for _, crd := range crds {
+			group, _, _ := unstructured.NestedString(crd.Object, "spec", "group")
+			kind, _, _ := unstructured.NestedString(crd.Object, "spec", "names", "kind")
+			if gvk.Kind == kind && gvk.Group == group {
+				scopeName, _, _ := unstructured.NestedString(crd.Object, "spec", "scope")
+				switch scopeName {
+				case "Namespaced":
+					scope = meta.RESTScopeNamespace
+				case "Cluster":
+					scope = meta.RESTScopeRoot
+				default:
+					return nil, fmt.Errorf("unknown scope %q", scopeName)
+				}
+				break
+			}
+		}
+	}
+
+	if scope == nil {
+		return nil, &UnknownTypeError{
+			GroupKind: gvk.GroupKind(),
+		}
+	}
+	return scope, nil
 }

--- a/pkg/object/validate.go
+++ b/pkg/object/validate.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-errors/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// MultiValidationError captures validation errors for multiple resources.
+type MultiValidationError struct {
+	Errors []*ValidationError
+}
+
+func (ae MultiValidationError) Error() string {
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "%d resources failed validation\n", len(ae.Errors))
+	for _, e := range ae.Errors {
+		b.WriteString(e.Error())
+	}
+	return b.String()
+}
+
+// ValidationError captures errors resulting from validation of a resources.
+type ValidationError struct {
+	GroupVersionKind schema.GroupVersionKind
+	Name             string
+	Namespace        string
+	FieldErrors      field.ErrorList
+}
+
+func (e *ValidationError) Error() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Resource: %q, Name: %q, Namespace: %q\n",
+		e.GroupVersionKind.String(), e.Name, e.Namespace))
+	b.WriteString(e.FieldErrors.ToAggregate().Error())
+	return b.String()
+}
+
+// Validator contains functionality for validating a set of resources prior
+// to being used by the Apply functionality. This imposes some constraint not
+// always required, such as namespaced resources must have the namespace set.
+type Validator struct {
+	Mapper meta.RESTMapper
+}
+
+// Validate validates the provided resources. A RESTMapper will be used
+// to fetch type information from the live cluster.
+func (v *Validator) Validate(resources []*unstructured.Unstructured) error {
+	crds := findCRDs(resources)
+	var errs []*ValidationError
+	for _, r := range resources {
+		var errList field.ErrorList
+		if err := v.validateName(r); err != nil {
+			if fieldErr, ok := isFieldError(err); ok {
+				errList = append(errList, fieldErr)
+			} else {
+				return err
+			}
+		}
+		if err := v.validateNamespace(r, crds); err != nil {
+			if fieldErr, ok := isFieldError(err); ok {
+				errList = append(errList, fieldErr)
+			} else {
+				return err
+			}
+		}
+		if len(errList) > 0 {
+			errs = append(errs, &ValidationError{
+				GroupVersionKind: r.GroupVersionKind(),
+				Name:             r.GetName(),
+				Namespace:        r.GetNamespace(),
+				FieldErrors:      errList,
+			})
+		}
+	}
+
+	if len(errs) > 0 {
+		return &MultiValidationError{
+			Errors: errs,
+		}
+	}
+	return nil
+}
+
+// isFieldError checks if an error is of type *field.Error. If so,
+// a reference to an error of that type is returned.
+func isFieldError(err error) (*field.Error, bool) {
+	var fieldErr *field.Error
+	if errors.As(err, &fieldErr) {
+		return fieldErr, true
+	}
+	return nil, false
+}
+
+// findCRDs looks through the provided resources and returns a slice with
+// the resources that are CRDs.
+func findCRDs(us []*unstructured.Unstructured) []*unstructured.Unstructured {
+	var crds []*unstructured.Unstructured
+	for _, u := range us {
+		if IsCRD(u) {
+			crds = append(crds, u)
+		}
+	}
+	return crds
+}
+
+// validateName validates the value of the name field of the resource.
+func (v *Validator) validateName(u *unstructured.Unstructured) error {
+	if u.GetName() == "" {
+		return field.Required(field.NewPath("metadata", "name"), "name is required")
+	}
+	return nil
+}
+
+// validateNamespace validates the value of the namespace field of the resource.
+func (v *Validator) validateNamespace(u *unstructured.Unstructured, crds []*unstructured.Unstructured) error {
+	scope, err := LookupResourceScope(u, crds, v.Mapper)
+	if err != nil {
+		return err
+	}
+
+	ns := u.GetNamespace()
+	if scope == meta.RESTScopeNamespace && ns == "" {
+		return field.Required(field.NewPath("metadata", "namespace"), "namespace is required")
+	}
+	if scope == meta.RESTScopeRoot && ns != "" {
+		return field.Invalid(field.NewPath("metadata", "namespace"), ns, "namespace must be empty")
+	}
+	return nil
+}

--- a/pkg/object/validate_test.go
+++ b/pkg/object/validate_test.go
@@ -1,0 +1,251 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestValidate(t *testing.T) {
+	_ = apiextv1.AddToScheme(scheme.Scheme)
+	testCases := map[string]struct {
+		resources     []*unstructured.Unstructured
+		expectedError error
+	}{
+		"errors are reported for resources": {
+			resources: []*unstructured.Unstructured{
+				testutil.Unstructured(t, `
+apiVersion: apps/v1
+kind: Deployment
+`,
+				),
+			},
+			expectedError: &object.MultiValidationError{
+				Errors: []*object.ValidationError{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						Name:      "",
+						Namespace: "",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeRequired,
+								Field:    "metadata.name",
+								BadValue: "",
+								Detail:   "name is required",
+							},
+							{
+								Type:     field.ErrorTypeRequired,
+								Field:    "metadata.namespace",
+								BadValue: "",
+								Detail:   "namespace is required",
+							},
+						},
+					},
+				},
+			},
+		},
+		"error is reported for all resources": {
+			resources: []*unstructured.Unstructured{
+				testutil.Unstructured(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+`),
+				testutil.Unstructured(t, `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: default
+`,
+				),
+			},
+			expectedError: &object.MultiValidationError{
+				Errors: []*object.ValidationError{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						Name:      "",
+						Namespace: "default",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeRequired,
+								Field:    "metadata.name",
+								BadValue: "",
+								Detail:   "name is required",
+							},
+						},
+					},
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "StatefulSet",
+						},
+						Name:      "",
+						Namespace: "default",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeRequired,
+								Field:    "metadata.name",
+								BadValue: "",
+								Detail:   "name is required",
+							},
+						},
+					},
+				},
+			},
+		},
+		"error is reported if a cluster-scoped resource has namespace set": {
+			resources: []*unstructured.Unstructured{
+				testutil.Unstructured(t, `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+  namespace: default
+`,
+				),
+			},
+			expectedError: &object.MultiValidationError{
+				Errors: []*object.ValidationError{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "",
+							Version: "v1",
+							Kind:    "Namespace",
+						},
+						Name:      "foo",
+						Namespace: "default",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeInvalid,
+								Field:    "metadata.namespace",
+								BadValue: "default",
+								Detail:   "namespace must be empty",
+							},
+						},
+					},
+				},
+			},
+		},
+		"error is reported if a namespace-scoped resource doesn't have namespace set": {
+			resources: []*unstructured.Unstructured{
+				testutil.Unstructured(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+`,
+				),
+			},
+			expectedError: &object.MultiValidationError{
+				Errors: []*object.ValidationError{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "Deployment",
+						},
+						Name:      "foo",
+						Namespace: "",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeRequired,
+								Field:    "metadata.namespace",
+								BadValue: "",
+								Detail:   "namespace is required",
+							},
+						},
+					},
+				},
+			},
+		},
+		"scope for CRs are found in CRDs if available": {
+			resources: []*unstructured.Unstructured{
+				testutil.Unstructured(t, `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: customs.custom.io
+spec:
+  group: custom.io
+  names:
+    kind: Custom
+  scope: Cluster
+`,
+				),
+				testutil.Unstructured(t, `
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: foo
+  namespace: default
+`,
+				),
+			},
+			expectedError: &object.MultiValidationError{
+				Errors: []*object.ValidationError{
+					{
+						GroupVersionKind: schema.GroupVersionKind{
+							Group:   "custom.io",
+							Version: "v1",
+							Kind:    "Custom",
+						},
+						Name:      "foo",
+						Namespace: "default",
+						FieldErrors: []*field.Error{
+							{
+								Type:     field.ErrorTypeInvalid,
+								Field:    "metadata.namespace",
+								BadValue: "default",
+								Detail:   "namespace must be empty",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+			defer tf.Cleanup()
+
+			mapper, err := tf.ToRESTMapper()
+			require.NoError(t, err)
+
+			err = (&object.Validator{
+				Mapper: mapper,
+			}).Validate(tc.resources)
+
+			if tc.expectedError == nil {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/pkg/ordering/sort.go
+++ b/pkg/ordering/sort.go
@@ -37,8 +37,8 @@ var _ sort.Interface = SortableUnstructureds{}
 func (a SortableUnstructureds) Len() int      { return len(a) }
 func (a SortableUnstructureds) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a SortableUnstructureds) Less(i, j int) bool {
-	first := object.UnstructuredToObjMeta(a[i])
-	second := object.UnstructuredToObjMeta(a[j])
+	first := object.UnstructuredToObjMetaOrDie(a[i])
+	second := object.UnstructuredToObjMetaOrDie(a[j])
 	return less(first, second)
 }
 

--- a/pkg/testutil/events.go
+++ b/pkg/testutil/events.go
@@ -68,8 +68,6 @@ func VerifyEvents(expEvents []ExpEvent, events []event.Event) error {
 	return fmt.Errorf("event %s not found", expEvents[expEventIndex].EventType)
 }
 
-var nilIdentifier = object.ObjMetadata{}
-
 // nolint:gocyclo
 // TODO(mortent): This function is pretty complex and with quite a bit of
 // duplication. We should see if there is a better way to provide a flexible
@@ -105,7 +103,7 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 		}
 		ae := e.ApplyEvent
 
-		if aee.Identifier != nilIdentifier {
+		if aee.Identifier != object.NilObjMetadata {
 			if aee.Identifier != ae.Identifier {
 				return false
 			}
@@ -147,7 +145,7 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 		}
 		pe := e.PruneEvent
 
-		if pee.Identifier != nilIdentifier {
+		if pee.Identifier != object.NilObjMetadata {
 			if pee.Identifier != pe.Identifier {
 				return false
 			}
@@ -169,7 +167,7 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 		}
 		de := e.DeleteEvent
 
-		if dee.Identifier != nilIdentifier {
+		if dee.Identifier != object.NilObjMetadata {
 			if dee.Identifier != de.Identifier {
 				return false
 			}

--- a/pkg/testutil/object.go
+++ b/pkg/testutil/object.go
@@ -39,7 +39,7 @@ type Mutator interface {
 	Mutate(u *unstructured.Unstructured)
 }
 
-// ToIdentifer translates object yaml config into ObjMetadata.
+// ToIdentifier translates object yaml config into ObjMetadata.
 func ToIdentifier(t *testing.T, manifest string) object.ObjMetadata {
 	obj := Unstructured(t, manifest)
 	return object.ObjMetadata{

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -44,7 +44,7 @@ func continueOnErrorTest(_ client.Client, invConfig InventoryConfig, inventoryNa
 		{
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
-				Identifier: object.UnstructuredToObjMeta(manifestToUnstructured(invalidCrd)),
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(invalidCrd)),
 				Error:      fmt.Errorf("failed to apply"),
 			},
 		},

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -47,14 +47,14 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
 				Operation:  event.Created,
-				Identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(crd)),
 				Error:      nil,
 			},
 		},
 		{
 			EventType: event.StatusType,
 			StatusEvent: &testutil.ExpStatusEvent{
-				Identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(crd)),
 				Status:     status.CurrentStatus,
 				Error:      nil,
 			},
@@ -97,7 +97,7 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
 				Operation:  event.Deleted,
-				Identifier: object.UnstructuredToObjMeta(manifestToUnstructured(crd)),
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(crd)),
 				Error:      nil,
 			},
 		},

--- a/test/e2e/inventory_policy_test.go
+++ b/test/e2e/inventory_policy_test.go
@@ -59,7 +59,7 @@ func inventoryPolicyMustMatchTest(c client.Client, invConfig InventoryConfig, na
 		{
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
-				Identifier: object.UnstructuredToObjMeta(deploymentManifest(namespaceName)),
+				Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
 				Error:      inventory.NewInventoryOverlapError(fmt.Errorf("test")),
 			},
 		},
@@ -109,7 +109,7 @@ func inventoryPolicyAdoptIfNoInventoryTest(c client.Client, invConfig InventoryC
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
 				Operation:  event.Configured,
-				Identifier: object.UnstructuredToObjMeta(deploymentManifest(namespaceName)),
+				Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
 				Error:      nil,
 			},
 		},
@@ -169,7 +169,7 @@ func inventoryPolicyAdoptAllTest(c client.Client, invConfig InventoryConfig, nam
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
 				Operation:  event.Configured,
-				Identifier: object.UnstructuredToObjMeta(deploymentManifest(namespaceName)),
+				Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
 				Error:      nil,
 			},
 		},


### PR DESCRIPTION
This PR adds better validation of the resources passed into the `Applier.Run` function. This primarily makes sure:
 * All resources have a name that is not an empty string.
 * All resources that are namespace-scoped have the namespace set.
 * All resources that are cluster-scoped have an empty namespace.

Since we rely on these properties for populating the inventory, it is important that we validate this prior to making any changes to inventory list. We have had a couple of issues related to this.

This also attempts to clean up the functions for converting from `*unstructured.Unstructured`/`*resource.Info`/`object.Runtime` to `object.ObjMetadata`. With this change, they will all use the `CreateObjMetadata` function which performs some validation (it does not check for namespace since it is more complicated). All the regular `ToObjMeta` functions now return an error in addition to the ObjMetadata. It adds additional functions with the naming pattern `ToObjMetaOrDie` which will panic instead of returning error. Obviously the latter should only be used when we know the resources have already been validated. The validation function described above should handle this. Open to suggestions on how we can further improve this.