### PR TITLE
Adds object sorting for apply, prune, and delete

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -97,13 +97,13 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Only emit status events if we are waiting for status.
+	// Only print status events if we are waiting for status.
 	//TODO: This is not the right way to do this. There are situations where
 	// we do need status events event if we are not waiting for status. The
 	// printers should be updated to handle this.
-	var emitStatusEvents bool
+	var printStatusEvents bool
 	if r.reconcileTimeout != time.Duration(0) || r.pruneTimeout != time.Duration(0) {
-		emitStatusEvents = true
+		printStatusEvents = true
 	}
 
 	// TODO: Fix DemandOneDirectory to no longer return FileNameFlags
@@ -153,7 +153,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		ReconcileTimeout:  r.reconcileTimeout,
 		// If we are not waiting for status, tell the applier to not
 		// emit the events.
-		EmitStatusEvents:       emitStatusEvents,
+		EmitStatusEvents:       printStatusEvents,
 		NoPrune:                r.noPrune,
 		DryRunStrategy:         common.DryRunNone,
 		PrunePropagationPolicy: prunePropPolicy,
@@ -164,5 +164,5 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, common.DryRunNone)
+	return printer.Print(ch, common.DryRunNone, printStatusEvents)
 }

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -116,15 +116,16 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
+	printStatusEvents := r.deleteTimeout != time.Duration(0)
 	ch := d.Run(inv, apply.DestroyerOptions{
 		DeleteTimeout:           r.deleteTimeout,
 		DeletePropagationPolicy: deletePropPolicy,
 		InventoryPolicy:         inventoryPolicy,
-		EmitStatusEvents:        r.deleteTimeout != time.Duration(0),
+		EmitStatusEvents:        printStatusEvents,
 	})
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, common.DryRunNone)
+	return printer.Print(ch, common.DryRunNone, printStatusEvents)
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -165,5 +165,5 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, drs)
+	return printer.Print(ch, drs, false) // Do not print status
 }

--- a/cmd/printers/events/formatter.go
+++ b/cmd/printers/events/formatter.go
@@ -88,7 +88,9 @@ func (ef *formatter) FormatErrorEvent(_ event.ErrorEvent) error {
 
 func (ef *formatter) FormatActionGroupEvent(age event.ActionGroupEvent, ags []event.ActionGroup,
 	as *list.ApplyStats, ps *list.PruneStats, ds *list.DeleteStats, c list.Collector) error {
-	if age.Action == event.ApplyAction && age.Type == event.Finished {
+	if age.Action == event.ApplyAction &&
+		age.Type == event.Finished &&
+		list.IsLastActionGroup(age, ags) {
 		output := fmt.Sprintf("%d resource(s) applied. %d created, %d unchanged, %d configured, %d failed",
 			as.Sum(), as.Created, as.Unchanged, as.Configured, as.Failed)
 		// Only print information about serverside apply if some of the
@@ -99,11 +101,15 @@ func (ef *formatter) FormatActionGroupEvent(age event.ActionGroupEvent, ags []ev
 		ef.print(output)
 	}
 
-	if age.Action == event.PruneAction && age.Type == event.Finished {
+	if age.Action == event.PruneAction &&
+		age.Type == event.Finished &&
+		list.IsLastActionGroup(age, ags) {
 		ef.print("%d resource(s) pruned, %d skipped, %d failed", ps.Pruned, ps.Skipped, ps.Failed)
 	}
 
-	if age.Action == event.DeleteAction && age.Type == event.Finished {
+	if age.Action == event.DeleteAction &&
+		age.Type == event.Finished &&
+		list.IsLastActionGroup(age, ags) {
 		ef.print("%d resource(s) deleted, %d skipped", ds.Deleted, ds.Skipped)
 	}
 

--- a/cmd/printers/printer/printer.go
+++ b/cmd/printers/printer/printer.go
@@ -9,5 +9,5 @@ import (
 )
 
 type Printer interface {
-	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy) error
+	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy, printStatus bool) error
 }

--- a/cmd/printers/table/printer.go
+++ b/cmd/printers/table/printer.go
@@ -18,7 +18,7 @@ type Printer struct {
 	IOStreams genericclioptions.IOStreams
 }
 
-func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy) error {
+func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy, printStatus bool) error {
 	// Wait for the init event that will give us the set of
 	// resources.
 	var initEvent event.InitEvent

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -209,10 +209,6 @@ rm $BASE/configMap.yaml
 
 kapply apply $BASE --reconcile-timeout=120s > $OUTPUT/status;
 
-expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
-
-expectedOutputLine "service/the-service is Current: Service is ready"
-
 expectedOutputLine "configmap/the-map2 is Current: Resource is always ready"
 
 expectedOutputLine "configmap/the-map1 pruned"

--- a/examples/alphaTestExamples/inventoryNamespace.md
+++ b/examples/alphaTestExamples/inventoryNamespace.md
@@ -89,7 +89,6 @@ kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
 expectedOutputLine "namespace/test-namespace unchanged"
 expectedOutputLine "configmap/cm-a created"
 expectedOutputLine "2 resource(s) applied. 1 created, 1 unchanged, 0 configured"
-expectedOutputLine "0 resource(s) pruned, 0 skipped"
 
 # There should be only one inventory object
 kubectl get cm -n test-namespace --selector='cli-utils.sigs.k8s.io/inventory-id' --no-headers | wc -l > $OUTPUT/status

--- a/examples/alphaTestExamples/pruneBasic.md
+++ b/examples/alphaTestExamples/pruneBasic.md
@@ -98,7 +98,6 @@ kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
 expectedOutputLine "configmap/cm-a created"
 expectedOutputLine "configmap/cm-b created"
 expectedOutputLine "configmap/cm-c created"
-expectedOutputLine "0 resource(s) pruned, 0 skipped"
 
 # There should be only one inventory object
 kubectl get cm --selector='cli-utils.sigs.k8s.io/inventory-id' --no-headers | wc -l > $OUTPUT/status

--- a/examples/alphaTestExamples/pruneNamespace.md
+++ b/examples/alphaTestExamples/pruneNamespace.md
@@ -114,7 +114,6 @@ expectedOutputLine "configmap/cm-a created"
 expectedOutputLine "configmap/cm-b created"
 expectedOutputLine "configmap/cm-c created"
 expectedOutputLine "4 resource(s) applied. 4 created, 0 unchanged, 0 configured"
-expectedOutputLine "0 resource(s) pruned, 0 skipped"
 
 # There should be only one inventory object
 kubectl get cm --selector='cli-utils.sigs.k8s.io/inventory-id' --no-headers | wc -l > $OUTPUT/status

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -315,42 +315,41 @@ func TestApplier(t *testing.T) {
 				testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
 				testutil.Unstructured(t, resources["secret"], testutil.AddOwningInv(t, "test")),
 			},
-			reconcileTimeout: time.Minute,
-			prune:            true,
-			inventoryPolicy:  inventory.InventoryPolicyMustMatch,
-			statusEvents:     []pollevent.Event{},
+			prune:           true,
+			inventoryPolicy: inventory.InventoryPolicyMustMatch,
+			statusEvents:    []pollevent.Event{},
 			expectedEvents: []testutil.ExpEvent{
 				{
 					EventType: event.InitType,
 				},
 				{
+					// Inventory task starting
 					EventType: event.ActionGroupType,
 				},
 				{
+					// Inventory task finished
 					EventType: event.ActionGroupType,
 				},
 				{
+					// Prune task starting
 					EventType: event.ActionGroupType,
 				},
 				{
-					EventType: event.ActionGroupType,
-				},
-				{
-					EventType: event.ActionGroupType,
-				},
-				{
+					// Prune object
 					EventType: event.PruneType,
 					PruneEvent: &testutil.ExpPruneEvent{
 						Operation: event.Pruned,
 					},
 				},
 				{
+					// Prune object
 					EventType: event.PruneType,
 					PruneEvent: &testutil.ExpPruneEvent{
 						Operation: event.Pruned,
 					},
 				},
 				{
+					// Prune task finished
 					EventType: event.ActionGroupType,
 				},
 			},
@@ -576,7 +575,7 @@ func TestApplier(t *testing.T) {
 			})
 
 			var events []event.Event
-			timer := time.NewTimer(30 * time.Second)
+			timer := time.NewTimer(10 * time.Second)
 
 		loop:
 			for {
@@ -586,9 +585,12 @@ func TestApplier(t *testing.T) {
 						break loop
 					}
 					if e.Type == event.ActionGroupType &&
-						e.ActionGroupEvent.Action == event.ApplyAction &&
 						e.ActionGroupEvent.Type == event.Finished {
-						close(poller.start)
+						if e.ActionGroupEvent.Action == event.ApplyAction ||
+							e.ActionGroupEvent.Action == event.PruneAction ||
+							e.ActionGroupEvent.Action == event.DeleteAction {
+							close(poller.start)
+						}
 					}
 					events = append(events, e)
 				case <-timer.C:

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -586,9 +586,10 @@ func TestApplier(t *testing.T) {
 					}
 					if e.Type == event.ActionGroupType &&
 						e.ActionGroupEvent.Type == event.Finished {
+						// If we do not also check for PruneAction, then the tests
+						// hang, timeout, and fail.
 						if e.ActionGroupEvent.Action == event.ApplyAction ||
-							e.ActionGroupEvent.Action == event.PruneAction ||
-							e.ActionGroupEvent.Action == event.DeleteAction {
+							e.ActionGroupEvent.Action == event.PruneAction {
 							close(poller.start)
 						}
 					}

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/object/graph"
 )
 
 const defaultWaitTimeout = 1 * time.Minute
@@ -100,7 +101,7 @@ func (t *TaskQueueBuilder) Build() *TaskQueue {
 // AppendInvAddTask appends an inventory add task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding inventory add task")
+	klog.V(2).Infoln("adding inventory add task")
 	t.tasks = append(t.tasks, &task.InvAddTask{
 		TaskName:  fmt.Sprintf("inventory-add-%d", t.invAddCounter),
 		InvClient: t.InvClient,
@@ -114,7 +115,7 @@ func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyOb
 // AppendInvAddTask appends an inventory set task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding inventory set task")
+	klog.V(2).Infoln("adding inventory set task")
 	t.tasks = append(t.tasks, &task.InvSetTask{
 		TaskName:  fmt.Sprintf("inventory-set-%d", t.invSetCounter),
 		InvClient: t.InvClient,
@@ -127,7 +128,7 @@ func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo) *TaskQu
 // AppendInvAddTask appends to the task queue a task to delete the inventory object.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding delete inventory task")
+	klog.V(2).Infoln("adding delete inventory task")
 	t.tasks = append(t.tasks, &task.DeleteInvTask{
 		TaskName:  fmt.Sprintf("delete-inventory-%d", t.deleteInvCounter),
 		InvClient: t.InvClient,
@@ -139,9 +140,9 @@ func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo) *Tas
 
 // AppendInvAddTask appends a task to the task queue to apply the passed objects
 // to the cluster. Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendApplyTask(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured,
-	crdSplitRes crdSplitResult, o Options) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding apply task")
+func (t *TaskQueueBuilder) AppendApplyTask(inv inventory.InventoryInfo,
+	applyObjs []*unstructured.Unstructured, o Options) *TaskQueueBuilder {
+	klog.V(2).Infof("adding apply task (%d objects)", len(applyObjs))
 	prevInvIds, _ := t.InvClient.GetClusterObjs(inv)
 	prevInventory := make(map[object.ObjMetadata]bool, len(prevInvIds))
 	for _, prevInvID := range prevInvIds {
@@ -150,7 +151,6 @@ func (t *TaskQueueBuilder) AppendApplyTask(inv inventory.InventoryInfo, applyObj
 	t.tasks = append(t.tasks, &task.ApplyTask{
 		TaskName:          fmt.Sprintf("apply-%d", t.applyCounter),
 		Objects:           applyObjs,
-		CRDs:              crdSplitRes.crds,
 		PrevInventory:     prevInventory,
 		ServerSideOptions: o.ServerSideOptions,
 		DryRunStrategy:    o.DryRunStrategy,
@@ -166,13 +166,14 @@ func (t *TaskQueueBuilder) AppendApplyTask(inv inventory.InventoryInfo, applyObj
 
 // AppendInvAddTask appends a task to wait on the passed objects to the task queue.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendWaitTask(waitIds []object.ObjMetadata) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding wait task")
+func (t *TaskQueueBuilder) AppendWaitTask(waitIds []object.ObjMetadata, condition taskrunner.Condition,
+	waitTimeout time.Duration) *TaskQueueBuilder {
+	klog.V(2).Infoln("adding wait task")
 	t.tasks = append(t.tasks, taskrunner.NewWaitTask(
 		fmt.Sprintf("wait-%d", t.waitCounter),
 		waitIds,
-		taskrunner.AllCurrent,
-		defaultWaitTimeout,
+		condition,
+		waitTimeout,
 		t.Mapper),
 	)
 	t.waitCounter += 1
@@ -183,7 +184,7 @@ func (t *TaskQueueBuilder) AppendWaitTask(waitIds []object.ObjMetadata) *TaskQue
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs []*unstructured.Unstructured,
 	pruneFilters []filter.ValidationFilter, o Options) *TaskQueueBuilder {
-	klog.V(5).Infoln("adding prune task")
+	klog.V(2).Infof("adding prune task (%d objects)", len(pruneObjs))
 	t.tasks = append(t.tasks,
 		&task.PruneTask{
 			TaskName:          fmt.Sprintf("prune-%d", t.pruneCounter),
@@ -202,20 +203,19 @@ func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs []*unstructured.Unstructure
 // AppendApplyWaitTasks adds apply and wait tasks to the task queue,
 // depending on build variables (like dry-run) and resource types
 // (like CRD's). Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendApplyWaitTasks(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured, o Options) *TaskQueueBuilder {
-	crdSplitRes, hasCRDs := splitAfterCRDs(applyObjs)
-	if hasCRDs {
-		t.AppendApplyTask(inv, append(crdSplitRes.before, crdSplitRes.crds...), crdSplitRes, o)
-		if !o.DryRunStrategy.ClientOrServerDryRun() {
-			waitIds := object.UnstructuredsToObjMetasOrDie(crdSplitRes.crds)
-			t.AppendWaitTask(waitIds)
+func (t *TaskQueueBuilder) AppendApplyWaitTasks(inv inventory.InventoryInfo,
+	applyObjs []*unstructured.Unstructured, o Options) *TaskQueueBuilder {
+	// Use the "depends-on" annotation to create a graph, ands sort the
+	// objects to apply into sets using a topological sort.
+	applySets := graph.SortObjs(applyObjs)
+	addWaitTask, waitTimeout := waitTaskTimeout(o.DryRunStrategy.ClientOrServerDryRun(),
+		len(applySets), o.ReconcileTimeout)
+	for _, applySet := range applySets {
+		t.AppendApplyTask(inv, applySet, o)
+		if addWaitTask {
+			applyIds := object.UnstructuredsToObjMetas(applySet)
+			t.AppendWaitTask(applyIds, taskrunner.AllCurrent, waitTimeout)
 		}
-		applyObjs = crdSplitRes.after
-	}
-	t.AppendApplyTask(inv, applyObjs, crdSplitRes, o)
-	if !o.DryRunStrategy.ClientOrServerDryRun() && o.ReconcileTimeout != time.Duration(0) {
-		waitIds := object.UnstructuredsToObjMetasOrDie(applyObjs)
-		t.AppendWaitTask(waitIds)
 	}
 	return t
 }
@@ -226,47 +226,34 @@ func (t *TaskQueueBuilder) AppendApplyWaitTasks(inv inventory.InventoryInfo, app
 func (t *TaskQueueBuilder) AppendPruneWaitTasks(pruneObjs []*unstructured.Unstructured,
 	pruneFilters []filter.ValidationFilter, o Options) *TaskQueueBuilder {
 	if o.Prune {
-		t.AppendPruneTask(pruneObjs, pruneFilters, o)
-		if !o.DryRunStrategy.ClientOrServerDryRun() && o.PruneTimeout != time.Duration(0) {
-			pruneIds := object.UnstructuredsToObjMetasOrDie(pruneObjs)
-			t.AppendWaitTask(pruneIds)
+		// Use the "depends-on" annotation to create a graph, ands sort the
+		// objects to prune into sets using a (reverse) topological sort.
+		pruneSets := graph.ReverseSortObjs(pruneObjs)
+		addWaitTask, waitTimeout := waitTaskTimeout(o.DryRunStrategy.ClientOrServerDryRun(),
+			len(pruneSets), o.ReconcileTimeout)
+		for _, pruneSet := range pruneSets {
+			t.AppendPruneTask(pruneSet, pruneFilters, o)
+			if addWaitTask {
+				pruneIds := object.UnstructuredsToObjMetas(pruneSet)
+				t.AppendWaitTask(pruneIds, taskrunner.AllNotFound, waitTimeout)
+			}
 		}
 	}
 	return t
 }
 
-type crdSplitResult struct {
-	before []*unstructured.Unstructured
-	after  []*unstructured.Unstructured
-	crds   []*unstructured.Unstructured
-}
-
-// splitAfterCRDs takes a sorted slice of infos and splits it into
-// three parts; resources before CRDs, the CRDs themselves, and finally
-// all the resources after the CRDs.
-// The function returns the three different sets of resources and
-// a boolean that tells whether there were any CRDs in the set of
-// resources.
-func splitAfterCRDs(objs []*unstructured.Unstructured) (crdSplitResult, bool) {
-	var before []*unstructured.Unstructured
-	var after []*unstructured.Unstructured
-
-	var crds []*unstructured.Unstructured
-	for _, obj := range objs {
-		if object.IsCRD(obj) {
-			crds = append(crds, obj)
-			continue
-		}
-
-		if len(crds) > 0 {
-			after = append(after, obj)
-		} else {
-			before = append(before, obj)
-		}
+// waitTaskTimeout returns true if the wait task should be added to the task queue;
+// false otherwise. If true, also returns the duration within wait task before timeout.
+func waitTaskTimeout(dryRun bool, numObjSets int, reconcileTimeout time.Duration) (bool, time.Duration) {
+	var zeroTimeout = time.Duration(0)
+	if dryRun {
+		return false, zeroTimeout
 	}
-	return crdSplitResult{
-		before: before,
-		after:  after,
-		crds:   crds,
-	}, len(crds) > 0
+	if reconcileTimeout != zeroTimeout {
+		return true, reconcileTimeout
+	}
+	if numObjSets > 1 {
+		return true, defaultWaitTimeout
+	}
+	return false, zeroTimeout
 }

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -213,7 +213,7 @@ func (t *TaskQueueBuilder) AppendApplyWaitTasks(inv inventory.InventoryInfo,
 	for _, applySet := range applySets {
 		t.AppendApplyTask(inv, applySet, o)
 		if addWaitTask {
-			applyIds := object.UnstructuredsToObjMetas(applySet)
+			applyIds := object.UnstructuredsToObjMetasOrDie(applySet)
 			t.AppendWaitTask(applyIds, taskrunner.AllCurrent, waitTimeout)
 		}
 	}
@@ -234,7 +234,7 @@ func (t *TaskQueueBuilder) AppendPruneWaitTasks(pruneObjs []*unstructured.Unstru
 		for _, pruneSet := range pruneSets {
 			t.AppendPruneTask(pruneSet, pruneFilters, o)
 			if addWaitTask {
-				pruneIds := object.UnstructuredsToObjMetas(pruneSet)
+				pruneIds := object.UnstructuredsToObjMetasOrDie(pruneSet)
 				t.AppendWaitTask(pruneIds, taskrunner.AllNotFound, waitTimeout)
 			}
 		}

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -344,7 +344,7 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			applyIds := object.UnstructuredsToObjMetas(tc.applyObjs)
+			applyIds := object.UnstructuredsToObjMetasOrDie(tc.applyObjs)
 			fakeInvClient := inventory.NewFakeInventoryClient(applyIds)
 			tqb := TaskQueueBuilder{
 				PruneOptions: pruneOptions,
@@ -587,7 +587,7 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			pruneIds := object.UnstructuredsToObjMetas(tc.pruneObjs)
+			pruneIds := object.UnstructuredsToObjMetasOrDie(tc.pruneObjs)
 			fakeInvClient := inventory.NewFakeInventoryClient(pruneIds)
 			tqb := TaskQueueBuilder{
 				PruneOptions: pruneOptions,
@@ -638,8 +638,8 @@ func verifyObjSets(t *testing.T, expected []*unstructured.Unstructured, actual [
 // containsObj returns true if the passed object is within the passed
 // slice of objects; false otherwise.
 func containsObj(objs []*unstructured.Unstructured, obj *unstructured.Unstructured) bool {
-	ids := object.UnstructuredsToObjMetas(objs)
-	id := object.UnstructuredToObjMeta(obj)
+	ids := object.UnstructuredsToObjMetasOrDie(objs)
+	id := object.UnstructuredToObjMetaOrDie(obj)
 	for _, i := range ids {
 		if i == id {
 			return true

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/apply"
 	cmddelete "k8s.io/kubectl/pkg/cmd/delete"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/slice"
 	applyerror "sigs.k8s.io/cli-utils/pkg/apply/error"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
@@ -52,7 +51,6 @@ type ApplyTask struct {
 	InfoHelper info.InfoHelper
 	Mapper     meta.RESTMapper
 	Objects    []*unstructured.Unstructured
-	CRDs       []*unstructured.Unstructured
 	// Used for determining inventory during errors
 	PrevInventory     map[object.ObjMetadata]bool
 	DryRunStrategy    common.DryRunStrategy
@@ -91,43 +89,7 @@ func (a *ApplyTask) Identifiers() []object.ObjMetadata {
 func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		objects := a.Objects
-		klog.V(4).Infof("apply task starting; attempting to apply %d objects", len(objects))
-
-		// If this is a dry run, we need to handle situations where
-		// we have a CRD and a CR in the same resource set, but the CRD
-		// will not actually have been applied when we reach the CR.
-		if a.DryRunStrategy.ClientOrServerDryRun() {
-			klog.V(4).Infof("dry-run filtering custom resources...")
-			// Find all resources in the set that doesn't exist in the
-			// RESTMapper, but where we do have the CRD for the type in
-			// the resource set.
-			objs, objsWithCRD, err := a.filterCRsWithCRDInSet(objects)
-			if err != nil {
-				sendBatchApplyEvents(taskContext, objs, err)
-				a.sendTaskResult(taskContext)
-				return
-			}
-
-			// Just send the apply event here. We know it must be a
-			// Created event since the type didn't already exist in the
-			// cluster.
-			for _, obj := range objsWithCRD {
-				taskContext.EventChannel() <- createApplyEvent(object.UnstructuredToObjMetaOrDie(obj), event.Created, nil)
-			}
-			// Update the resource set to no longer include the CRs.
-			klog.V(4).Infof("after dry-run filtering custom resources, %d objects left", len(objs))
-			objects = objs
-		}
-
-		// ApplyOptions doesn't allow an empty set of resources, so check
-		// for that here. It could happen if this is dry-run and we removed
-		// all resources in the previous step.
-		if len(objects) == 0 {
-			klog.V(4).Infoln("no objects to apply after dry-run filtering--returning")
-			a.sendTaskResult(taskContext)
-			return
-		}
-
+		klog.V(2).Infof("apply task starting (%d objects)", len(objects))
 		// Create a new instance of the applyOptions interface and use it
 		// to apply the objects.
 		ao, dynamic, err := applyOptionsFactoryFunc(taskContext.EventChannel(),
@@ -291,40 +253,6 @@ func (a *ApplyTask) sendTaskResult(taskContext *taskrunner.TaskContext) {
 	taskContext.TaskChannel() <- taskrunner.TaskResult{}
 }
 
-// filterCRsWithCRDInSet loops through all the resources and filters out the
-// resources that doesn't exist in the RESTMapper, but where we do have a CRD
-// in the resource set that defines the needed type. It returns two slices,
-// the seconds contains the resources that meets the above criteria while the
-// first slice contains the remaining resources.
-func (a *ApplyTask) filterCRsWithCRDInSet(objects []*unstructured.Unstructured) ([]*unstructured.Unstructured, []*unstructured.Unstructured, error) {
-	var objs []*unstructured.Unstructured
-	var objsWithCRD []*unstructured.Unstructured
-
-	crdsInfo := buildCRDsInfo(a.CRDs)
-	for _, obj := range objects {
-		gvk := obj.GroupVersionKind()
-
-		// First check if we find the type in the RESTMapper.
-		//TODO: Maybe we do care if there is a new version of the CRD?
-		_, err := a.Mapper.RESTMapping(gvk.GroupKind())
-		if err != nil && !meta.IsNoMatchError(err) {
-			return objs, objsWithCRD, err
-		}
-
-		// If we can't find the type in the RESTMapper, but we do have the
-		// CRD in the set of resources, filter out the object.
-		if meta.IsNoMatchError(err) && crdsInfo.includesCRDForCR(obj) {
-			objsWithCRD = append(objsWithCRD, obj)
-			continue
-		}
-
-		// If the resource is in the RESTMapper, or it is not there but we
-		// also don't have the CRD, just keep the resource.
-		objs = append(objs, obj)
-	}
-	return objs, objsWithCRD, nil
-}
-
 // objInCluster returns true if the passed object is in the slice of
 // previous inventory, because an object in the previous inventory
 // exists in the cluster.
@@ -333,54 +261,6 @@ func (a *ApplyTask) objInCluster(obj object.ObjMetadata) bool {
 		return true
 	}
 	return false
-}
-
-type crdsInfo struct {
-	crds []crdInfo
-}
-
-// includesCRDForCR checks if we have information about a CRD that defines
-// the types needed for the provided CR.
-func (c *crdsInfo) includesCRDForCR(cr *unstructured.Unstructured) bool {
-	gvk := cr.GroupVersionKind()
-	for _, crd := range c.crds {
-		if gvk.Group == crd.group &&
-			gvk.Kind == crd.kind &&
-			slice.ContainsString(crd.versions, gvk.Version, nil) {
-			return true
-		}
-	}
-	return false
-}
-
-type crdInfo struct {
-	group    string
-	kind     string
-	versions []string
-}
-
-func buildCRDsInfo(crds []*unstructured.Unstructured) *crdsInfo {
-	var crdsInf []crdInfo
-	for _, crd := range crds {
-		group, _, _ := unstructured.NestedString(crd.Object, "spec", "group")
-		kind, _, _ := unstructured.NestedString(crd.Object, "spec", "names", "kind")
-
-		var versions []string
-		crdVersions, _, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
-		for _, ver := range crdVersions {
-			verObj := ver.(map[string]interface{})
-			version, _, _ := unstructured.NestedString(verObj, "name")
-			versions = append(versions, version)
-		}
-		crdsInf = append(crdsInf, crdInfo{
-			kind:     kind,
-			group:    group,
-			versions: versions,
-		})
-	}
-	return &crdsInfo{
-		crds: crdsInf,
-	}
 }
 
 // ClearTimeout is not supported by the ApplyTask.

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -6,6 +6,7 @@ package task
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/filter"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
@@ -52,6 +53,7 @@ func (p *PruneTask) Identifiers() []object.ObjMetadata {
 // to signal to the taskrunner that the task has completed (or failed).
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
+		klog.V(2).Infof("prune task starting (%d objects)", len(p.Objects))
 		// Create filter to prevent deletion of currently applied
 		// objects. Must be done here to wait for applied UIDs.
 		uidFilter := filter.CurrentUIDFilter{

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -120,6 +120,13 @@ func (tc *TaskContext) PruneFailures() []object.ObjMetadata {
 	return failures
 }
 
+// PruneFailed returns true if the passed object identifier
+// has been stored as a prune failure; false otherwise.
+func (tc *TaskContext) PruneFailed(id object.ObjMetadata) bool {
+	_, found := tc.pruneFailures[id]
+	return found
+}
+
 // applyInfo captures information about resources that have been
 // applied. This is captured in the TaskContext so other tasks
 // running later might use this information.

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -142,7 +142,11 @@ func (w *WaitTask) checkCondition(taskContext *TaskContext, coll *resourceStatus
 func (w *WaitTask) computeResourceWaitData(taskContext *TaskContext) []resourceWaitData {
 	var rwd []resourceWaitData
 	for _, id := range w.Ids {
-		if taskContext.ResourceFailed(id) {
+		// Skip checking condition for resources which have failed
+		// to apply or failed to prune/delete (depending on wait condition).
+		// This includes resources which are skipped because of filtering.
+		if (w.Condition == AllCurrent && taskContext.ResourceFailed(id)) ||
+			(w.Condition == AllNotFound && taskContext.PruneFailed(id)) {
 			continue
 		}
 		gen, _ := taskContext.ResourceGeneration(id)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -121,6 +121,9 @@ var _ = Describe("Applier", func() {
 				It("Server-Side Apply", func() {
 					serversideApplyTest(c, invConfig, inventoryName, namespace.GetName())
 				})
+				It("Implements depends-on apply ordering", func() {
+					dependsOnTest(c, invConfig, inventoryName, namespace.GetName())
+				})
 			})
 
 			Context("Inventory policy", func() {


### PR DESCRIPTION
* Adds object sorting functionality for apply, prune, and delete. Extends the current task queue paradigm to dynamically create possibly multiple apply and prune tasks interspersed with possible wait tasks. These wait tasks delay execution of subsequent tasks until the proper object status in the cluster is met. The exact tasks in the task queue are determined by the topological sort of an object dependency graph. An explicit dependency is be created with a `depends-on` annotation within a resource config, while implicit dependencies are created for namespaces and CRD's. Without these dependencies, the task queue is not materially different than the current task queue.
* Removes hard-coded CRD ordering code, since this is now handled by the dependency graph and task queue.
* Removes hard-coded namespace ordering code, since this is now handled by the dependency graph and task queue.
* Do not print empty prune/delete stats (no more `0 resource(s) pruned, ...`), since we can now skip a prune task if there are no resources to prune.
* Updates the `Print` interface to add a `PrintStatus` boolean (which means we can now remove the `EmitStatus` plumbing by alway emitting status events; but maybe not print them). Because of the current size of this PR, we will clean up this `EmitStatus` plumbing and tests in a future PR.
* Adds `depends-on` e2e test.
