### PR TITLE
Drop github.com/go-errors/errors and github.com/pkg/errors dependencies

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -123,7 +122,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		ErrOut: cmd.ErrOrStderr(),
 	})
 	if err != nil {
-		return errors.WrapPrefix(err, "error creating printer", 1)
+		return fmt.Errorf("error creating printer: %w", err)
 	}
 
 	// If the user has specified a timeout, we create a context with timeout,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module sigs.k8s.io/cli-utils
 go 1.16
 
 require (
-	github.com/go-errors/errors v1.4.0
 	github.com/google/uuid v1.2.0
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/go.sum
+++ b/go.sum
@@ -156,9 +156,8 @@ github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui72
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
-github.com/go-errors/errors v1.4.0 h1:2OA7MFw38+e9na72T1xgkomPb6GzZzzxvJ5U630FoRM=
-github.com/go-errors/errors v1.4.0/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -5,9 +5,9 @@ package apply
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/go-errors/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
@@ -32,7 +32,7 @@ import (
 func NewDestroyer(factory cmdutil.Factory, invClient inventory.InventoryClient, statusPoller poller.Poller) (*Destroyer, error) {
 	pruneOpts, err := prune.NewPruneOptions(factory, invClient)
 	if err != nil {
-		return nil, errors.WrapPrefix(err, "error setting up PruneOptions", 1)
+		return nil, fmt.Errorf("error setting up PruneOptions: %w", err)
 	}
 	return &Destroyer{
 		pruneOptions: pruneOpts,

--- a/pkg/kstatus/polling/engine/engine.go
+++ b/pkg/kstatus/polling/engine/engine.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-errors/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
@@ -57,8 +56,7 @@ func (s *PollerEngine) Poll(ctx context.Context, identifiers []object.ObjMetadat
 
 		clusterReader, err := options.ClusterReaderFactoryFunc(s.Reader, s.Mapper, identifiers)
 		if err != nil {
-			handleError(eventChannel,
-				errors.WrapPrefix(err, "error creating new ClusterReader", 1))
+			handleError(eventChannel, fmt.Errorf("error creating new ClusterReader: %w", err))
 			return
 		}
 		statusReaders, defaultStatusReader := options.StatusReadersFactoryFunc(clusterReader, s.Mapper)

--- a/pkg/kstatus/status/generic.go
+++ b/pkg/kstatus/status/generic.go
@@ -6,7 +6,6 @@ package status
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -26,7 +25,7 @@ func checkGenericProperties(u *unstructured.Unstructured) (*Result, error) {
 	// Check if the resource is scheduled for deletion
 	deletionTimestamp, found, err := unstructured.NestedString(obj, "metadata", "deletionTimestamp")
 	if err != nil {
-		return nil, errors.Wrap(err, "looking up metadata.deletionTimestamp from resource")
+		return nil, fmt.Errorf("looking up metadata.deletionTimestamp from resource: %w", err)
 	}
 	if found && deletionTimestamp != "" {
 		return &Result{
@@ -75,14 +74,14 @@ func checkGeneration(u *unstructured.Unstructured) (*Result, error) {
 	// ensure that the meta generation is observed
 	generation, found, err := unstructured.NestedInt64(u.Object, "metadata", "generation")
 	if err != nil {
-		return nil, errors.Wrap(err, "looking up metadata.generation from resource")
+		return nil, fmt.Errorf("looking up metadata.generation from resource: %w", err)
 	}
 	if !found {
 		return nil, nil
 	}
 	observedGeneration, found, err := unstructured.NestedInt64(u.Object, "status", "observedGeneration")
 	if err != nil {
-		return nil, errors.Wrap(err, "looking up status.observedGeneration from resource")
+		return nil, fmt.Errorf("looking up status.observedGeneration from resource: %w", err)
 	}
 	if found {
 		// Resource does not have this field, so we can't do this check.

--- a/pkg/kstatus/status/status.go
+++ b/pkg/kstatus/status/status.go
@@ -4,10 +4,10 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/pkg/object/validate.go
+++ b/pkg/object/validate.go
@@ -4,10 +4,10 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/go-errors/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/util/factory/statuspoller.go
+++ b/pkg/util/factory/statuspoller.go
@@ -4,7 +4,8 @@
 package factory
 
 import (
-	"github.com/go-errors/errors"
+	"fmt"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
@@ -16,17 +17,17 @@ import (
 func NewStatusPoller(f cmdutil.Factory) (*polling.StatusPoller, error) {
 	config, err := f.ToRESTConfig()
 	if err != nil {
-		return nil, errors.WrapPrefix(err, "error getting RESTConfig", 1)
+		return nil, fmt.Errorf("error getting RESTConfig: %w", err)
 	}
 
 	mapper, err := f.ToRESTMapper()
 	if err != nil {
-		return nil, errors.WrapPrefix(err, "error getting RESTMapper", 1)
+		return nil, fmt.Errorf("error getting RESTMapper: %w", err)
 	}
 
 	c, err := client.New(config, client.Options{Scheme: scheme.Scheme, Mapper: mapper})
 	if err != nil {
-		return nil, errors.WrapPrefix(err, "error creating client", 1)
+		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
 	return polling.NewStatusPoller(c, mapper), nil


### PR DESCRIPTION
Kubernetes is getting rid of the second one too https://github.com/kubernetes/kubernetes/issues/103043. The first one is still a transitive dep, only coming from Kustomize. Can probably be removed there too.

Should probably drop `gotest.tools` too and leave only `github.com/stretchr/testify` for assertions.