### PR TITLE
Add option for custom status readers

### DIFF
--- a/pkg/kstatus/polling/polling.go
+++ b/pkg/kstatus/polling/polling.go
@@ -68,6 +68,10 @@ type Options struct {
 	// then each resource will be fetched when needed with GET calls.
 	UseCache bool
 
+	// CustomStatusReadersFactoryFunc, when called, provides the StatusPoller with a map of custom
+	// StatusReaders for the given GroupKinds. These will be used along with the StatusReaders shipped with this
+	// library. However, it can also be used to override these with custom StatusReaders if the returned map
+	// has a key for the given GroupKinds, e.g. apps/deployments.
 	CustomStatusReadersFactoryFunc func(engine.ClusterReader, meta.RESTMapper) map[schema.GroupKind]engine.StatusReader
 }
 

--- a/pkg/kstatus/polling/statusreaders/generic.go
+++ b/pkg/kstatus/polling/statusreaders/generic.go
@@ -14,14 +14,16 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
-func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper) engine.StatusReader {
+type StatusFunc func(u *unstructured.Unstructured) (*status.Result, error)
+
+func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper, statusFunc StatusFunc) engine.StatusReader {
 	return &baseStatusReader{
 		reader: reader,
 		mapper: mapper,
 		resourceStatusReader: &genericStatusReader{
 			reader:     reader,
 			mapper:     mapper,
-			statusFunc: status.Compute,
+			statusFunc: statusFunc,
 		},
 	}
 }
@@ -36,7 +38,7 @@ type genericStatusReader struct {
 	reader engine.ClusterReader
 	mapper meta.RESTMapper
 
-	statusFunc func(u *unstructured.Unstructured) (*status.Result, error)
+	statusFunc StatusFunc
 }
 
 var _ resourceTypeStatusReader = &genericStatusReader{}

--- a/pkg/kstatus/polling/statusreaders/generic.go
+++ b/pkg/kstatus/polling/statusreaders/generic.go
@@ -14,6 +14,9 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
+// StatusFunc returns the status of the given object. This func is passed into
+// NewGenericStatusReader so that the returned StatusReader can be used for custom types.
+// An example of a StatusFunc is status.Compute.
 type StatusFunc func(u *unstructured.Unstructured) (*status.Result, error)
 
 func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper, statusFunc StatusFunc) engine.StatusReader {


### PR DESCRIPTION
This commit adds the `CustomStatusReadersFactoryFunc` option to the
StatusPoller's `Poll` method options so that consumers can provide
custom status readers for certain GroupKinds (esp. CRDs).

It also changes the `NewGenericStatusReader` func so that it accepts a
statusFunc parameter so that consumers only have to implement that
single func and use the genericStatusReader for all the boilerplate
stuff (like fetching an object from the API).

refs #382