### PR TITLE
Printers for status returns error

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -157,8 +157,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		UseCache:     true,
 	})
 
-	printer.Print(eventChannel, identifiers, cancelFunc)
-	return nil
+	return printer.Print(eventChannel, identifiers, cancelFunc)
 }
 
 // desiredStatusNotifierFunc returns an Observer function for the

--- a/cmd/status/printers/printer/printer.go
+++ b/cmd/status/printers/printer/printer.go
@@ -21,5 +21,5 @@ type Printer interface {
 	// needs to, and that it has completed shutting down. The latter is important
 	// to make sure the printer has a chance to output all data before the
 	// program terminates.
-	Print(ch <-chan event.Event, identifiers []object.ObjMetadata, cancelFunc collector.ObserverFunc)
+	Print(ch <-chan event.Event, identifiers []object.ObjMetadata, cancelFunc collector.ObserverFunc) error
 }


### PR DESCRIPTION
This updates the `Collector` in the polling package to return any fatal errors and not only update them in the collector state. It also updates the `Printer` interface used by the `status` command to also return the error rather than delegating handling of the error completely to the printer. This allows for centralized error handling regardless of output format, for example by setting the return code based on type of error.