### PR TITLE
Avoid dryRun as state in inventory client

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -98,7 +98,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 
 	// Based on the inventory template manifest we look up the inventory
 	// from the live state using the inventory client.
-	identifiers, err := invClient.GetClusterObjs(inv)
+	identifiers, err := invClient.GetClusterObjs(inv, common.DryRunNone)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -741,7 +741,7 @@ func TestReadAndPrepareObjects(t *testing.T) {
 				},
 				invClient: fakeInvClient,
 			}
-			applyObjs, pruneObjs, err := applier.prepareObjects(tc.inventory, tc.localObjs)
+			applyObjs, pruneObjs, err := applier.prepareObjects(tc.inventory, tc.localObjs, Options{})
 			if tc.isError {
 				assert.Error(t, err)
 				return

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -152,9 +152,9 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 // objects minus the set of currently applied objects. Returns an error
 // if one occurs.
 func (po *PruneOptions) GetPruneObjs(inv inventory.InventoryInfo,
-	localObjs []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	localObjs []*unstructured.Unstructured, o Options) ([]*unstructured.Unstructured, error) {
 	localIds := object.UnstructuredsToObjMetasOrDie(localObjs)
-	prevInvIds, err := po.InvClient.GetClusterObjs(inv)
+	prevInvIds, err := po.InvClient.GetClusterObjs(inv, o.DryRunStrategy)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -559,7 +559,7 @@ func TestGetPruneObjs(t *testing.T) {
 					scheme.Scheme.PrioritizedVersionsAllGroups()...),
 			}
 			currentInventory := createInventoryInfo(tc.prevInventory...)
-			actualObjs, err := po.GetPruneObjs(currentInventory, tc.localObjs)
+			actualObjs, err := po.GetPruneObjs(currentInventory, tc.localObjs, Options{})
 			if err != nil {
 				t.Fatalf("unexpected error %s returned", err)
 			}

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -100,13 +100,15 @@ func (t *TaskQueueBuilder) Build() *TaskQueue {
 
 // AppendInvAddTask appends an inventory add task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured) *TaskQueueBuilder {
+func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured,
+	dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding inventory add task")
 	t.tasks = append(t.tasks, &task.InvAddTask{
 		TaskName:  fmt.Sprintf("inventory-add-%d", t.invAddCounter),
 		InvClient: t.InvClient,
 		InvInfo:   inv,
 		Objects:   applyObjs,
+		DryRun:    dryRun,
 	})
 	t.invAddCounter += 1
 	return t
@@ -114,12 +116,13 @@ func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyOb
 
 // AppendInvAddTask appends an inventory set task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo) *TaskQueueBuilder {
+func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo, dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding inventory set task")
 	t.tasks = append(t.tasks, &task.InvSetTask{
 		TaskName:  fmt.Sprintf("inventory-set-%d", t.invSetCounter),
 		InvClient: t.InvClient,
 		InvInfo:   inv,
+		DryRun:    dryRun,
 	})
 	t.invSetCounter += 1
 	return t
@@ -127,12 +130,13 @@ func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo) *TaskQu
 
 // AppendInvAddTask appends to the task queue a task to delete the inventory object.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo) *TaskQueueBuilder {
+func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo, dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding delete inventory task")
 	t.tasks = append(t.tasks, &task.DeleteInvTask{
 		TaskName:  fmt.Sprintf("delete-inventory-%d", t.deleteInvCounter),
 		InvClient: t.InvClient,
 		InvInfo:   inv,
+		DryRun:    dryRun,
 	})
 	t.deleteInvCounter += 1
 	return t
@@ -143,7 +147,7 @@ func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo) *Tas
 func (t *TaskQueueBuilder) AppendApplyTask(inv inventory.InventoryInfo,
 	applyObjs []*unstructured.Unstructured, o Options) *TaskQueueBuilder {
 	klog.V(2).Infof("adding apply task (%d objects)", len(applyObjs))
-	prevInvIds, _ := t.InvClient.GetClusterObjs(inv)
+	prevInvIds, _ := t.InvClient.GetClusterObjs(inv, o.DryRunStrategy)
 	prevInventory := make(map[object.ObjMetadata]bool, len(prevInvIds))
 	for _, prevInvID := range prevInvIds {
 		prevInventory[prevInvID] = true

--- a/pkg/apply/task/delete_inv_task.go
+++ b/pkg/apply/task/delete_inv_task.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -20,6 +21,7 @@ type DeleteInvTask struct {
 	TaskName  string
 	InvClient inventory.InventoryClient
 	InvInfo   inventory.InventoryInfo
+	DryRun    common.DryRunStrategy
 }
 
 func (i *DeleteInvTask) Name() string {
@@ -38,7 +40,7 @@ func (i *DeleteInvTask) Identifiers() []object.ObjMetadata {
 func (i *DeleteInvTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
 		klog.V(2).Infoln("starting delete inventory task")
-		err := i.InvClient.DeleteInventoryObj(i.InvInfo)
+		err := i.InvClient.DeleteInventoryObj(i.InvInfo, i.DryRun)
 		// Not found is not error, since this means it was already deleted.
 		if apierrors.IsNotFound(err) {
 			err = nil

--- a/pkg/apply/task/delete_inv_task_test.go
+++ b/pkg/apply/task/delete_inv_task_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -43,6 +44,7 @@ func TestDeleteInvTask(t *testing.T) {
 				TaskName:  taskName,
 				InvClient: client,
 				InvInfo:   localInv,
+				DryRun:    common.DryRunNone,
 			}
 			if taskName != task.Name() {
 				t.Errorf("expected task name (%s), got (%s)", taskName, task.Name())

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -130,7 +130,7 @@ func TestInvAddTask(t *testing.T) {
 			if result.Err != nil {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
-			actual, _ := client.GetClusterObjs(nil)
+			actual, _ := client.GetClusterObjs(nil, common.DryRunNone)
 			if !object.SetEquals(tc.expectedObjs, actual) {
 				t.Errorf("expected merged inventory (%s), got (%s)", tc.expectedObjs, actual)
 			}

--- a/pkg/apply/task/inv_set_task.go
+++ b/pkg/apply/task/inv_set_task.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -17,6 +18,7 @@ type InvSetTask struct {
 	TaskName  string
 	InvClient inventory.InventoryClient
 	InvInfo   inventory.InventoryInfo
+	DryRun    common.DryRunStrategy
 }
 
 func (i *InvSetTask) Name() string {
@@ -43,7 +45,7 @@ func (i *InvSetTask) Start(taskContext *taskrunner.TaskContext) {
 		klog.V(4).Infof("set inventory %d prune failures", len(pruneFailures))
 		invObjs := object.Union(appliedObjs, pruneFailures)
 		klog.V(4).Infof("set inventory %d total objects", len(invObjs))
-		err := i.InvClient.Replace(i.InvInfo, invObjs)
+		err := i.InvClient.Replace(i.InvInfo, invObjs, i.DryRun)
 		taskContext.TaskChannel() <- taskrunner.TaskResult{Err: err}
 	}()
 }

--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -8,6 +8,7 @@ import (
 
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -73,7 +74,7 @@ func TestInvSetTask(t *testing.T) {
 			if result.Err != nil {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
-			actual, _ := client.GetClusterObjs(nil)
+			actual, _ := client.GetClusterObjs(nil, common.DryRunNone)
 			if !object.SetEquals(tc.expectedObjs, actual) {
 				t.Errorf("expected merged inventory (%s), got (%s)", tc.expectedObjs, actual)
 			}

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -36,7 +36,7 @@ func NewFakeInventoryClient(initObjs []object.ObjMetadata) *FakeInventoryClient 
 }
 
 // GetClusterObjs returns currently stored set of objects.
-func (fic *FakeInventoryClient) GetClusterObjs(inv InventoryInfo) ([]object.ObjMetadata, error) {
+func (fic *FakeInventoryClient) GetClusterObjs(InventoryInfo, common.DryRunStrategy) ([]object.ObjMetadata, error) {
 	if fic.Err != nil {
 		return []object.ObjMetadata{}, fic.Err
 	}
@@ -46,7 +46,7 @@ func (fic *FakeInventoryClient) GetClusterObjs(inv InventoryInfo) ([]object.ObjM
 // Merge stores the passed objects with the current stored cluster inventory
 // objects. Returns the set difference of the current set of objects minus
 // the passed set of objects, or an error if one is set up.
-func (fic *FakeInventoryClient) Merge(inv InventoryInfo, objs []object.ObjMetadata) ([]object.ObjMetadata, error) {
+func (fic *FakeInventoryClient) Merge(_ InventoryInfo, objs []object.ObjMetadata, _ common.DryRunStrategy) ([]object.ObjMetadata, error) {
 	if fic.Err != nil {
 		return []object.ObjMetadata{}, fic.Err
 	}
@@ -57,7 +57,8 @@ func (fic *FakeInventoryClient) Merge(inv InventoryInfo, objs []object.ObjMetada
 
 // Replace the stored cluster inventory objs with the passed obj, or an
 // error if one is set up.
-func (fic *FakeInventoryClient) Replace(inv InventoryInfo, objs []object.ObjMetadata) error {
+
+func (fic *FakeInventoryClient) Replace(_ InventoryInfo, objs []object.ObjMetadata, _ common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
 	}
@@ -66,16 +67,14 @@ func (fic *FakeInventoryClient) Replace(inv InventoryInfo, objs []object.ObjMeta
 }
 
 // DeleteInventoryObj returns an error if one is forced; does nothing otherwise.
-func (fic *FakeInventoryClient) DeleteInventoryObj(inv InventoryInfo) error {
+func (fic *FakeInventoryClient) DeleteInventoryObj(InventoryInfo, common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
 	}
 	return nil
 }
 
-func (fic *FakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
-
-func (fic *FakeInventoryClient) ApplyInventoryNamespace(inv *unstructured.Unstructured) error {
+func (fic *FakeInventoryClient) ApplyInventoryNamespace(*unstructured.Unstructured, common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
 	}
@@ -92,14 +91,10 @@ func (fic *FakeInventoryClient) ClearError() {
 	fic.Err = nil
 }
 
-func (fic *FakeInventoryClient) GetClusterInventoryInfo(inv InventoryInfo) (*unstructured.Unstructured, error) {
+func (fic *FakeInventoryClient) GetClusterInventoryInfo(InventoryInfo, common.DryRunStrategy) (*unstructured.Unstructured, error) {
 	return nil, nil
 }
 
-func (fic *FakeInventoryClient) UpdateLabels(inv InventoryInfo, labels map[string]string) error {
-	return nil
-}
-
-func (fic *FakeInventoryClient) GetClusterInventoryObjs(inv InventoryInfo) ([]*unstructured.Unstructured, error) {
+func (fic *FakeInventoryClient) GetClusterInventoryObjs(_ InventoryInfo) ([]*unstructured.Unstructured, error) {
 	return []*unstructured.Unstructured{}, nil
 }


### PR DESCRIPTION
This updates the inventory client interface to accept `DryRunStrategy` as a parameter to the functions instead of relying it to be set state on the implementation. This means an additional parameter that must be passed around, but I prefer that to keeping it as state. I think we can further simplify part of the `InventoryClient` by pulling out functionality that doesn't depend on the type of the inventory object.

This also removes the `UpdateLabels` function from the interface. As far as I can tell, it is not in use.