### PR TITLE
Pass the RESTMapper explicitly into infoHelper

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -34,12 +34,16 @@ func NewApplier(factory cmdutil.Factory, invClient inventory.InventoryClient, st
 	if err != nil {
 		return nil, err
 	}
+	mapper, err := factory.ToRESTMapper()
+	if err != nil {
+		return nil, err
+	}
 	return &Applier{
 		pruneOptions: pruneOpts,
 		statusPoller: statusPoller,
 		factory:      factory,
 		invClient:    invClient,
-		infoHelper:   info.NewInfoHelper(factory),
+		infoHelper:   info.NewInfoHelper(mapper, factory),
 	}, nil
 }
 

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -4,6 +4,7 @@
 package info
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -22,23 +23,21 @@ type InfoHelper interface {
 	BuildInfo(obj *unstructured.Unstructured) (*resource.Info, error)
 }
 
-func NewInfoHelper(factory util.Factory) *infoHelper {
+func NewInfoHelper(mapper meta.RESTMapper, factory util.Factory) *infoHelper {
 	return &infoHelper{
+		mapper:  mapper,
 		factory: factory,
 	}
 }
 
 type infoHelper struct {
+	mapper  meta.RESTMapper
 	factory util.Factory
 }
 
 func (ih *infoHelper) UpdateInfo(info *resource.Info) error {
-	mapper, err := ih.factory.ToRESTMapper()
-	if err != nil {
-		return err
-	}
 	gvk := info.Object.GetObjectKind().GroupVersionKind()
-	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	mapping, err := ih.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return err
 	}

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -88,7 +88,7 @@ func NewInventoryClient(factory cmdutil.Factory,
 		dryRunStrategy:        common.DryRunNone,
 		InventoryFactoryFunc:  invFunc,
 		invToUnstructuredFunc: invToUnstructuredFunc,
-		InfoHelper:            info.NewInfoHelper(factory),
+		InfoHelper:            info.NewInfoHelper(mapper, factory),
 	}
 	return &clusterInventoryClient, nil
 }


### PR DESCRIPTION
This allows for better control, for example allowing us to invalidate
the discovery cache before proceeding.
