### PR TITLE
Prune/Delete should use the specified propagation policy

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -249,7 +249,7 @@ func setDefaults(o *Options) {
 	if o.PollInterval == time.Duration(0) {
 		o.PollInterval = poller.DefaultPollInterval
 	}
-	if o.PrunePropagationPolicy == metav1.DeletionPropagation("") {
+	if o.PrunePropagationPolicy == "" {
 		o.PrunePropagationPolicy = metav1.DeletePropagationBackground
 	}
 }

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -132,7 +132,9 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 				taskContext.CapturePruneFailure(pruneID)
 				continue
 			}
-			err = namespacedClient.Delete(context.TODO(), pruneID.Name, metav1.DeleteOptions{})
+			err = namespacedClient.Delete(context.TODO(), pruneID.Name, metav1.DeleteOptions{
+				PropagationPolicy: &o.PropagationPolicy,
+			})
 			if err != nil {
 				if klog.V(4).Enabled() {
 					klog.Errorf("prune failed for %s (%s)", pruneID, err)


### PR DESCRIPTION
PruneOptions doesn't properly propagate the provided PropagationPolicy to the namespacedClient, which means that providing a PropagationPolicy doesn't have any effect. This addresses this issue and adds a test.