### PR TITLE
Move inventory annotation addition

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -75,6 +75,10 @@ func (a *Applier) prepareObjects(localInv inventory.InventoryInfo, localObjs []*
 	if err := inventory.ValidateNoInventory(localObjs); err != nil {
 		return nil, nil, err
 	}
+	// Add the inventory annotation to the resources being applied.
+	for _, localObj := range localObjs {
+		inventory.AddInventoryIDAnnotation(localObj, localInv)
+	}
 	// If the inventory uses the Name strategy and an inventory ID is provided,
 	// verify that the existing inventory object (if there is one) has an ID
 	// label that matches.

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -140,8 +140,6 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 				taskContext.CaptureResourceFailure(id)
 				continue
 			}
-			// add the inventory annotation to the resource being applied.
-			inventory.AddInventoryIDAnnotation(obj, a.InvInfo)
 			ao.SetObjects([]*resource.Info{info})
 			klog.V(5).Infof("applying %s/%s...", info.Namespace, info.Name)
 			err = ao.Run()


### PR DESCRIPTION
* Moves inventory annotation out of the apply task. This is part of the effort to separate the inventory from the apply, since the two operations are orthogonal.