### PR TITLE
Expose cyclic dependency error

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -173,12 +173,15 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 			},
 		}
 		// Build the task queue by appending tasks in the proper order.
-		taskQueue := taskBuilder.
+		taskQueue, err := taskBuilder.
 			AppendInvAddTask(invInfo, applyObjs, options.DryRunStrategy).
 			AppendApplyWaitTasks(invInfo, applyObjs, opts).
 			AppendPruneWaitTasks(pruneObjs, pruneFilters, opts).
 			AppendInvSetTask(invInfo, options.DryRunStrategy).
 			Build()
+		if err != nil {
+			handleError(eventChannel, err)
+		}
 		// Send event to inform the caller about the resources that
 		// will be applied/pruned.
 		eventChannel <- event.Event{

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -131,10 +131,13 @@ func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <
 			},
 		}
 		// Build the ordered set of tasks to execute.
-		taskQueue := taskBuilder.
+		taskQueue, err := taskBuilder.
 			AppendPruneWaitTasks(deleteObjs, deleteFilters, opts).
 			AppendDeleteInvTask(inv, options.DryRunStrategy).
 			Build()
+		if err != nil {
+			handleError(eventChannel, err)
+		}
 		// Send event to inform the caller about the resources that
 		// will be pruned.
 		eventChannel <- event.Event{

--- a/pkg/object/graph/depends.go
+++ b/pkg/object/graph/depends.go
@@ -16,9 +16,9 @@ import (
 // Each of the objects in an apply set is applied together. The order of
 // the returned applied sets is a topological ordering of the sets to apply.
 // Returns an single empty apply set if there are no objects to apply.
-func SortObjs(objs []*unstructured.Unstructured) [][]*unstructured.Unstructured {
+func SortObjs(objs []*unstructured.Unstructured) ([][]*unstructured.Unstructured, error) {
 	if len(objs) == 0 {
-		return [][]*unstructured.Unstructured{}
+		return [][]*unstructured.Unstructured{}, nil
 	}
 	// Create the graph, and build a map of object metadata to the object (Unstructured).
 	g := New()
@@ -35,7 +35,7 @@ func SortObjs(objs []*unstructured.Unstructured) [][]*unstructured.Unstructured 
 	objSets := [][]*unstructured.Unstructured{}
 	sortedObjSets, err := g.Sort()
 	if err != nil {
-		return objSets
+		return [][]*unstructured.Unstructured{}, err
 	}
 	// Map the object metadata back to the sorted sets of unstructured objects.
 	for _, objSet := range sortedObjSets {
@@ -49,18 +49,21 @@ func SortObjs(objs []*unstructured.Unstructured) [][]*unstructured.Unstructured 
 		}
 		objSets = append(objSets, currentSet)
 	}
-	return objSets
+	return objSets, nil
 }
 
 // ReverseSortObjs is the same as SortObjs but using reverse ordering.
-func ReverseSortObjs(objs []*unstructured.Unstructured) [][]*unstructured.Unstructured {
+func ReverseSortObjs(objs []*unstructured.Unstructured) ([][]*unstructured.Unstructured, error) {
 	// Sorted objects using normal ordering.
-	s := SortObjs(objs)
+	s, err := SortObjs(objs)
+	if err != nil {
+		return [][]*unstructured.Unstructured{}, err
+	}
 	// Reverse the ordering of the object sets using swaps.
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
-	return s
+	return s, nil
 }
 
 // addExplicitEdges updates the graph with edges from objects


### PR DESCRIPTION
* Expose fatal cyclic dependency error during "depends-on" calculation.

Error looks like
```
error: cyclic dependency
        {test-cyclic-error-ns pod-a Pod} -> {test-cyclic-error-ns pod-b Pod}
        {test-cyclic-error-ns pod-b Pod} -> {test-cyclic-error-ns pod-c Pod}
        {test-cyclic-error-ns pod-c Pod} -> {test-cyclic-error-ns pod-a Pod}
```