### PR TITLE
Ignore prune object "not found" error

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -124,6 +124,9 @@ var _ = Describe("Applier", func() {
 				It("Implements depends-on apply ordering", func() {
 					dependsOnTest(c, invConfig, inventoryName, namespace.GetName())
 				})
+				It("Prune retrieval error correctly handled", func() {
+					pruneRetrieveErrorTest(c, invConfig, inventoryName, namespace.GetName())
+				})
 			})
 
 			Context("Inventory policy", func() {
@@ -302,4 +305,10 @@ func newDestroyerFromInvFactory(invFactory inventory.InventoryClientFactory) *ap
 	d, err := apply.NewDestroyer(f, invClient, statusPoller)
 	Expect(err).NotTo(HaveOccurred())
 	return d
+}
+
+// Delete the passed object from the cluster using the passed client.
+func deleteObj(c client.Client, obj *unstructured.Unstructured) {
+	err := c.Delete(context.TODO(), obj)
+	Expect(err).NotTo(HaveOccurred())
 }

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -1,0 +1,114 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
+	By("apply a single resource, which is referenced in the inventory")
+	applier := invConfig.ApplierFactoryFunc()
+
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+
+	inv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+
+	resource1 := []*unstructured.Unstructured{
+		manifestToUnstructured(pod1),
+	}
+
+	ch := applier.Run(context.TODO(), inv, resource1, apply.Options{
+		EmitStatusEvents: false,
+	})
+
+	var applierEvents []event.Event
+	for e := range ch {
+		Expect(e.Type).NotTo(Equal(event.ErrorType))
+		applierEvents = append(applierEvents, e)
+	}
+	err := testutil.VerifyEvents([]testutil.ExpEvent{
+		{
+			// Pod1 is applied
+			EventType: event.ApplyType,
+			ApplyEvent: &testutil.ExpApplyEvent{
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(pod1)),
+				Operation:  event.Created,
+				Error:      nil,
+			},
+		},
+		{
+			// ApplyTask finished
+			EventType: event.ActionGroupType,
+		},
+	}, applierEvents)
+	Expect(err).ToNot(HaveOccurred())
+
+	// Delete the previously applied resource, which is referenced in the inventory.
+	By("delete resource, which is referenced in the inventory")
+	deleteObj(c, resource1[0])
+
+	By("Verify inventory")
+	// The inventory should still have the previously deleted item.
+	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 1)
+
+	By("apply a different resource, and validate the inventory accurately reflects only this object")
+	resource2 := []*unstructured.Unstructured{
+		manifestToUnstructured(pod2),
+	}
+
+	ch = applier.Run(context.TODO(), inv, resource2, apply.Options{
+		EmitStatusEvents: false,
+	})
+
+	var applierEvents2 []event.Event
+	for e := range ch {
+		Expect(e.Type).NotTo(Equal(event.ErrorType))
+		applierEvents2 = append(applierEvents2, e)
+	}
+	err = testutil.VerifyEvents([]testutil.ExpEvent{
+		{
+			// Pod2 is applied
+			EventType: event.ApplyType,
+			ApplyEvent: &testutil.ExpApplyEvent{
+				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(pod2)),
+				Operation:  event.Created,
+				Error:      nil,
+			},
+		},
+		{
+			// ApplyTask finished
+			EventType: event.ActionGroupType,
+		},
+	}, applierEvents2)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Verify inventory")
+	// The inventory should only have the currently applied item.
+	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 1)
+
+	By("Destroy resources")
+	destroyer := invConfig.DestroyerFactoryFunc()
+
+	destroyInv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
+	destroyerEvents := runCollectNoErr(destroyer.Run(destroyInv, options))
+	err = testutil.VerifyEvents([]testutil.ExpEvent{
+		{
+			EventType: event.DeleteType,
+		},
+	}, destroyerEvents)
+	Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
* Fixes bug where apply fatally errors if a prune object is not in cluster. Skips prune objects which are already deleted from cluster (as determined by "Not Found" error).
* Adds end-to-end test to validate the fix.
