### PR TITLE
[DEMO] Updates TaskContext to store entire object

### DIFF
--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -117,7 +117,7 @@ func TestInvSetTask(t *testing.T) {
 				PrevInventory: prevInventory,
 			}
 			for _, applyObj := range tc.appliedObjs {
-				context.ResourceApplied(applyObj, "unusued-uid", int64(0))
+				context.ResourceApplied(applyObj, nil)
 			}
 			for _, applyFailure := range tc.applyFailures {
 				context.CaptureResourceFailure(applyFailure)


### PR DESCRIPTION
/hold

* Example-only code to demonstrate `TaskContext` as an object cache
* Updates `applyInfo` to `*unstructured.Unstructured` within `TaskContext`

Example Output

```
$ kapply apply ~/go/src/github.com/GoogleContainerTools/kpt/e2e/live/testdata/depends-on-ordering/
namespace/depends-on-namespace unchanged
pod/pod-c unchanged
I0912 22:44:00.425225  465283 apply_task.go:182] mutate depends-on-namespace/pod-a field here: source depends-on object: default/pod-c
pod/pod-a unchanged
I0912 22:44:00.428305  465283 apply_task.go:182] mutate depends-on-namespace/pod-b field here: source depends-on object: depends-on-namespace/pod-a
pod/pod-b unchanged
4 resource(s) applied. 0 created, 4 unchanged, 0 configured, 0 failed
```

/assign @karlkfi 
