### PR TITLE
[WIP] Add context and timeouts

### DIFF
--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -236,12 +236,15 @@ deployment.apps/foo is InProgress: inProgress
 				timeout:   tc.timeout,
 			}
 
-			cmd := &cobra.Command{}
+			cmd := &cobra.Command{
+				RunE: runner.runE,
+			}
 			cmd.SetIn(strings.NewReader(tc.input))
 			var buf bytes.Buffer
 			cmd.SetOut(&buf)
 
-			err := runner.runE(cmd, []string{})
+			// execute with cobra to handle setting the default context
+			err := cmd.Execute()
 
 			if tc.expectedErrMsg != "" {
 				if !assert.Error(t, err) {

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -733,7 +733,7 @@ func TestReadAndPrepareObjects(t *testing.T) {
 			}
 			// Create applier with fake inventory client, and call prepareObjects
 			applier := Applier{
-				pruneOptions: &prune.PruneOptions{
+				pruner: &prune.Pruner{
 					InvClient: fakeInvClient,
 					Client:    dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objs...),
 					Mapper: testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme,
@@ -741,7 +741,12 @@ func TestReadAndPrepareObjects(t *testing.T) {
 				},
 				invClient: fakeInvClient,
 			}
-			applyObjs, pruneObjs, err := applier.prepareObjects(tc.inventory, tc.localObjs, Options{})
+			applyObjs, pruneObjs, err := applier.prepareObjects(
+				context.TODO(),
+				tc.inventory,
+				tc.localObjs,
+				Options{},
+			)
 			if tc.isError {
 				assert.Error(t, err)
 				return

--- a/pkg/apply/filter/current-uids-filter.go
+++ b/pkg/apply/filter/current-uids-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +27,7 @@ func (cuf CurrentUIDFilter) Name() string {
 // because the it is a namespace that objects still reside in; otherwise
 // returns false. This filter should not be added to the list of filters
 // for "destroying", since every object is being deletet. Never returns an error.
-func (cuf CurrentUIDFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
+func (cuf CurrentUIDFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error) {
 	uid := string(obj.GetUID())
 	if cuf.CurrentUIDs.Has(uid) {
 		reason := fmt.Sprintf("object removal prevented; UID just applied: %s", uid)

--- a/pkg/apply/filter/current-uids-filter_test.go
+++ b/pkg/apply/filter/current-uids-filter_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +51,8 @@ func TestCurrentUIDFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetUID(types.UID(tc.objUID))
-			actual, reason, err := filter.Filter(obj)
+			ctx := context.TODO()
+			actual, reason, err := filter.Filter(ctx, obj)
 			if err != nil {
 				t.Fatalf("CurrentUIDFilter unexpected error (%s)", err)
 			}

--- a/pkg/apply/filter/filter.go
+++ b/pkg/apply/filter/filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -17,5 +19,5 @@ type ValidationFilter interface {
 	// Filter returns true if validation fails. If true a
 	// reason string is included in the return. If an error happens
 	// during filtering it is returned.
-	Filter(obj *unstructured.Unstructured) (bool, string, error)
+	Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error)
 }

--- a/pkg/apply/filter/inventory-policy-apply-filter.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter.go
@@ -34,12 +34,12 @@ func (ipaf InventoryPolicyApplyFilter) Name() string {
 // Filter returns true if the passed object should be filtered (NOT applied) and
 // a filter reason string; false otherwise. Returns an error if one occurred
 // during the filter calculation
-func (ipaf InventoryPolicyApplyFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
+func (ipaf InventoryPolicyApplyFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error) {
 	if obj == nil {
 		return true, "missing object", nil
 	}
 	// Object must be retrieved from the cluster to get the inventory id.
-	clusterObj, err := ipaf.getObject(object.UnstructuredToObjMetaOrDie(obj))
+	clusterObj, err := ipaf.getObject(ctx, object.UnstructuredToObjMetaOrDie(obj))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// This simply means the object hasn't been created yet.
@@ -60,7 +60,7 @@ func (ipaf InventoryPolicyApplyFilter) Filter(obj *unstructured.Unstructured) (b
 }
 
 // getObject retrieves the passed object from the cluster, or an error if one occurred.
-func (ipaf InventoryPolicyApplyFilter) getObject(id object.ObjMetadata) (*unstructured.Unstructured, error) {
+func (ipaf InventoryPolicyApplyFilter) getObject(ctx context.Context, id object.ObjMetadata) (*unstructured.Unstructured, error) {
 	mapping, err := ipaf.Mapper.RESTMapping(id.GroupKind)
 	if err != nil {
 		return nil, err
@@ -69,5 +69,5 @@ func (ipaf InventoryPolicyApplyFilter) getObject(id object.ObjMetadata) (*unstru
 	if err != nil {
 		return nil, err
 	}
-	return namespacedClient.Get(context.TODO(), id.Name, metav1.GetOptions{})
+	return namespacedClient.Get(ctx, id.Name, metav1.GetOptions{})
 }

--- a/pkg/apply/filter/inventory-policy-apply-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
@@ -103,7 +104,8 @@ func TestInventoryPolicyApplyFilter(t *testing.T) {
 				Inv:       inventory.WrapInventoryInfoObj(invObj),
 				InvPolicy: tc.policy,
 			}
-			actual, reason, err := filter.Filter(obj)
+			ctx := context.TODO()
+			actual, reason, err := filter.Filter(ctx, obj)
 			if tc.isError != (err != nil) {
 				t.Fatalf("Expected InventoryPolicyFilter error (%v), got (%v)", tc.isError, (err != nil))
 			}

--- a/pkg/apply/filter/inventory-policy-filter.go
+++ b/pkg/apply/filter/inventory-policy-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,7 +27,7 @@ func (ipf InventoryPolicyFilter) Name() string {
 // Filter returns true if the passed object should NOT be pruned (deleted)
 // because the "prevent remove" annotation is present; otherwise returns
 // false. Never returns an error.
-func (ipf InventoryPolicyFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
+func (ipf InventoryPolicyFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error) {
 	// Check the inventory id "match" and the adopt policy to determine
 	// if an object should be pruned (deleted).
 	if !inventory.CanPrune(ipf.Inv, obj, ipf.InvPolicy) {

--- a/pkg/apply/filter/inventory-policy-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-filter_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -89,7 +90,8 @@ func TestInventoryPolicyFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(objIDAnnotation)
-			actual, reason, err := filter.Filter(obj)
+			ctx := context.TODO()
+			actual, reason, err := filter.Filter(ctx, obj)
 			if err != nil {
 				t.Fatalf("InventoryPolicyFilter unexpected error (%s)", err)
 			}

--- a/pkg/apply/filter/local-namespaces-filter.go
+++ b/pkg/apply/filter/local-namespaces-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,7 +28,7 @@ func (lnf LocalNamespacesFilter) Name() string {
 // because the it is a namespace that objects still reside in; otherwise
 // returns false. This filter should not be added to the list of filters
 // for "destroying", since every object is being delete. Never returns an error.
-func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
+func (lnf LocalNamespacesFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error) {
 	id := object.UnstructuredToObjMetaOrDie(obj)
 	if id.GroupKind == object.CoreV1Namespace.GroupKind() &&
 		lnf.LocalNamespaces.Has(id.Name) {

--- a/pkg/apply/filter/local-namespaces-filter_test.go
+++ b/pkg/apply/filter/local-namespaces-filter_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,7 +51,8 @@ func TestLocalNamespacesFilter(t *testing.T) {
 			}
 			namespace := testNamespace.DeepCopy()
 			namespace.SetName(tc.namespace)
-			actual, reason, err := filter.Filter(namespace)
+			ctx := context.TODO()
+			actual, reason, err := filter.Filter(ctx, namespace)
 			if err != nil {
 				t.Fatalf("LocalNamespacesFilter unexpected error (%s)", err)
 			}

--- a/pkg/apply/filter/prevent-remove-filter.go
+++ b/pkg/apply/filter/prevent-remove-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -24,7 +25,7 @@ func (prf PreventRemoveFilter) Name() string {
 // Filter returns true if the passed object should NOT be pruned (deleted)
 // because the "prevent remove" annotation is present; otherwise returns
 // false. Never returns an error.
-func (prf PreventRemoveFilter) Filter(obj *unstructured.Unstructured) (bool, string, error) {
+func (prf PreventRemoveFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) (bool, string, error) {
 	for annotation, value := range obj.GetAnnotations() {
 		if common.NoDeletion(annotation, value) {
 			reason := fmt.Sprintf("object removal prevented; delete annotation: %s/%s", annotation, value)

--- a/pkg/apply/filter/prevent-remove-filter_test.go
+++ b/pkg/apply/filter/prevent-remove-filter_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -71,7 +72,8 @@ func TestPreventDeleteAnnotation(t *testing.T) {
 			filter := PreventRemoveFilter{}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(tc.annotations)
-			actual, reason, err := filter.Filter(obj)
+			ctx := context.TODO()
+			actual, reason, err := filter.Filter(ctx, obj)
 			if err != nil {
 				t.Fatalf("PreventRemoveFilter unexpected error (%s)", err)
 			}

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -79,12 +80,12 @@ func TestApplyTask_BasicAppliedObjects(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			defer close(eventChannel)
-			taskContext := taskrunner.NewTaskContext(eventChannel)
+			taskContext := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 
 			objs := toUnstructureds(tc.applied)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return &fakeApplyOptions{}, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -164,12 +165,12 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			defer close(eventChannel)
-			taskContext := taskrunner.NewTaskContext(eventChannel)
+			taskContext := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 
 			objs := toUnstructureds(tc.rss)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return &fakeApplyOptions{}, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -275,7 +276,7 @@ func TestApplyTask_DryRun(t *testing.T) {
 			drs := common.Strategies[i]
 			t.Run(tn, func(t *testing.T) {
 				eventChannel := make(chan event.Event)
-				taskContext := taskrunner.NewTaskContext(eventChannel)
+				taskContext := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 
 				restMapper := testutil.NewFakeRESTMapper(schema.GroupVersionKind{
 					Group:   "apps",
@@ -289,7 +290,7 @@ func TestApplyTask_DryRun(t *testing.T) {
 
 				ao := &fakeApplyOptions{}
 				oldAO := applyOptionsFactoryFunc
-				applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+				applyOptionsFactoryFunc = func(chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 					return ao, nil
 				}
 				defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -409,7 +410,7 @@ func TestApplyTaskWithError(t *testing.T) {
 		drs := common.DryRunNone
 		t.Run(tn, func(t *testing.T) {
 			eventChannel := make(chan event.Event)
-			taskContext := taskrunner.NewTaskContext(eventChannel)
+			taskContext := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 
 			restMapper := testutil.NewFakeRESTMapper(schema.GroupVersionKind{
 				Group:   "apps",
@@ -423,7 +424,7 @@ func TestApplyTaskWithError(t *testing.T) {
 
 			ao := &fakeApplyOptions{}
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return ao, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()

--- a/pkg/apply/task/delete_inv_task.go
+++ b/pkg/apply/task/delete_inv_task.go
@@ -49,5 +49,5 @@ func (i *DeleteInvTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-// ClearTimeout is not supported by the DeleteInvTask.
-func (i *DeleteInvTask) ClearTimeout() {}
+// OnStatusEvent is not supported by DeleteInvTask.
+func (i *DeleteInvTask) OnStatusEvent(taskContext *taskrunner.TaskContext, e event.StatusEvent) {}

--- a/pkg/apply/task/delete_inv_task_test.go
+++ b/pkg/apply/task/delete_inv_task_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,7 +40,7 @@ func TestDeleteInvTask(t *testing.T) {
 			client := inventory.NewFakeInventoryClient([]object.ObjMetadata{})
 			client.Err = tc.err
 			eventChannel := make(chan event.Event)
-			context := taskrunner.NewTaskContext(eventChannel)
+			context := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 			task := DeleteInvTask{
 				TaskName:  taskName,
 				InvClient: client,

--- a/pkg/apply/task/inv_add_task.go
+++ b/pkg/apply/task/inv_add_task.go
@@ -60,8 +60,8 @@ func (i *InvAddTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-// ClearTimeout is not supported by the InvAddTask.
-func (i *InvAddTask) ClearTimeout() {}
+// OnStatusEvent is not supported by InvAddTask.
+func (i *InvAddTask) OnStatusEvent(taskContext *taskrunner.TaskContext, e event.StatusEvent) {}
 
 // inventoryNamespaceInSet returns the the namespace the passed inventory
 // object will be applied to, or nil if this namespace object does not exist

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -109,7 +110,7 @@ func TestInvAddTask(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client := inventory.NewFakeInventoryClient(tc.initialObjs)
 			eventChannel := make(chan event.Event)
-			context := taskrunner.NewTaskContext(eventChannel)
+			context := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 			task := InvAddTask{
 				TaskName:  taskName,
 				InvClient: client,

--- a/pkg/apply/task/inv_set_task.go
+++ b/pkg/apply/task/inv_set_task.go
@@ -63,5 +63,5 @@ func (i *InvSetTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-// ClearTimeout is not supported by the InvSetTask.
-func (i *InvSetTask) ClearTimeout() {}
+// OnStatusEvent is not supported by InvSetTask.
+func (i *InvSetTask) OnStatusEvent(taskContext *taskrunner.TaskContext, e event.StatusEvent) {}

--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -105,7 +106,7 @@ func TestInvSetTask(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			client := inventory.NewFakeInventoryClient([]object.ObjMetadata{})
 			eventChannel := make(chan event.Event)
-			context := taskrunner.NewTaskContext(eventChannel)
+			context := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 			prevInventory := make(map[object.ObjMetadata]bool, len(tc.prevInventory))
 			for _, prevInvID := range tc.prevInventory {
 				prevInventory[prevInvID] = true

--- a/pkg/apply/task/resetmapper_task.go
+++ b/pkg/apply/task/resetmapper_task.go
@@ -51,11 +51,5 @@ func extractDeferredDiscoveryRESTMapper(mapper meta.RESTMapper) (*restmapper.Def
 }
 
 func (r *ResetRESTMapperTask) sendTaskResult(taskContext *taskrunner.TaskContext, err error) {
-	taskContext.TaskChannel() <- taskrunner.TaskResult{
-		Err: err,
-	}
+	taskContext.TaskChannel() <- taskrunner.TaskResult{Err: err}
 }
-
-// ClearTimeout doesn't do anything as ResetRESTMapperTask doesn't support
-// timeouts.
-func (r *ResetRESTMapperTask) ClearTimeout() {}

--- a/pkg/apply/task/resetmapper_task_test.go
+++ b/pkg/apply/task/resetmapper_task_test.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func TestResetRESTMapperTask(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			defer close(eventChannel)
-			taskContext := taskrunner.NewTaskContext(eventChannel)
+			taskContext := taskrunner.NewTaskContext(context.TODO(), eventChannel)
 
 			mapper, discoveryClient := tc.toRESTMapper()
 

--- a/pkg/apply/task/send_event_task.go
+++ b/pkg/apply/task/send_event_task.go
@@ -25,6 +25,5 @@ func (s *SendEventTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-// ClearTimeout doesn't do anything as SendEventTask doesn't support
-// timeouts.
-func (s *SendEventTask) ClearTimeout() {}
+// OnStatusEvent is not supported by SendEventTask.
+func (s *SendEventTask) OnStatusEvent(taskContext *taskrunner.TaskContext, e event.StatusEvent) {}

--- a/pkg/apply/taskrunner/collector.go
+++ b/pkg/apply/taskrunner/collector.go
@@ -4,51 +4,85 @@
 package taskrunner
 
 import (
+	"sync"
+
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
-// newResourceStatusCollector returns a new resourceStatusCollector
-// that will keep track of the status of the provided resources.
-func newResourceStatusCollector(identifiers []object.ObjMetadata) *resourceStatusCollector {
-	rm := make(map[object.ObjMetadata]resourceStatus)
+// Condition is a type that defines the types of conditions
+// which a WaitTask can use.
+type Condition string
 
-	for _, obj := range identifiers {
-		rm[obj] = resourceStatus{
-			Identifier:    obj,
-			CurrentStatus: status.UnknownStatus,
-		}
-	}
-	return &resourceStatusCollector{
-		resourceMap: rm,
+const (
+	// AllCurrent Condition means all the provided resources
+	// has reached (and remains in) the Current status.
+	AllCurrent Condition = "AllCurrent"
+
+	// AllNotFound Condition means all the provided resources
+	// has reached the NotFound status, i.e. they are all deleted
+	// from the cluster.
+	AllNotFound Condition = "AllNotFound"
+)
+
+// Meets returns true if the provided status meets the condition and
+// false if it does not.
+func (c Condition) Meets(s status.Status) bool {
+	switch c {
+	case AllCurrent:
+		return s == status.CurrentStatus
+	case AllNotFound:
+		return s == status.NotFoundStatus
+	default:
+		return false
 	}
 }
 
-// resourceStatusCollector keeps track of the latest seen status for all the
+type ResourceGeneration struct {
+	Identifier object.ObjMetadata
+	Generation int64
+}
+
+// NewResourceStatusCollector returns a new resourceStatusCollector
+// that will keep track of the status of the provided resources.
+func NewResourceStatusCollector() *ResourceStatusCollector {
+	return &ResourceStatusCollector{
+		resourceMap: make(map[object.ObjMetadata]ResourceStatus),
+	}
+}
+
+// ResourceStatusCollector keeps track of the latest seen status for all the
 // resources that is of interest during the operation.
-type resourceStatusCollector struct {
-	resourceMap map[object.ObjMetadata]resourceStatus
+type ResourceStatusCollector struct {
+	resourceMap map[object.ObjMetadata]ResourceStatus
+	// mu protects concurrent map access
+	mu sync.Mutex
 }
 
 // resoureStatus contains the latest status for a given
 // resource as identified by the Identifier.
-type resourceStatus struct {
-	Identifier    object.ObjMetadata
+type ResourceStatus struct {
 	CurrentStatus status.Status
 	Message       string
 	Generation    int64
 }
 
-// resourceStatus updates the collector with the latest
-// seen status for the given resource.
-func (a *resourceStatusCollector) resourceStatus(r *event.ResourceStatus) {
-	if ri, found := a.resourceMap[r.Identifier]; found {
-		ri.CurrentStatus = r.Status
-		ri.Message = r.Message
-		ri.Generation = getGeneration(r)
-		a.resourceMap[r.Identifier] = ri
-	}
+// Put updates the collector with the specified status
+func (a *ResourceStatusCollector) Put(id object.ObjMetadata, rs ResourceStatus) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.resourceMap[id] = rs
+}
+
+// PutEventStatus updates the collector with the latest status from an
+// ResourceStatus event.
+func (a *ResourceStatusCollector) PutEventStatus(rs *event.ResourceStatus) {
+	a.Put(rs.Identifier, ResourceStatus{
+		CurrentStatus: rs.Status,
+		Message:       rs.Message,
+		Generation:    getGeneration(rs),
+	})
 }
 
 // getGeneration looks up the value of the generation field in the
@@ -61,9 +95,9 @@ func getGeneration(r *event.ResourceStatus) int64 {
 	return r.Resource.GetGeneration()
 }
 
-// conditionMet tests whether the provided Condition holds true for
+// ConditionMet tests whether the provided Condition holds true for
 // all resources given by the list of Ids.
-func (a *resourceStatusCollector) conditionMet(rwd []resourceWaitData, c Condition) bool {
+func (a *ResourceStatusCollector) ConditionMet(rwd []ResourceGeneration, c Condition) bool {
 	switch c {
 	case AllCurrent:
 		return a.allMatchStatus(rwd, status.CurrentStatus)
@@ -74,15 +108,26 @@ func (a *resourceStatusCollector) conditionMet(rwd []resourceWaitData, c Conditi
 	}
 }
 
+// matchStatus returns the status of any resources with the specified
+// identifiers that match the supplied status.
+func (a *ResourceStatusCollector) Get(id object.ObjMetadata) ResourceStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	rs, found := a.resourceMap[id]
+	if !found {
+		return ResourceStatus{
+			CurrentStatus: status.UnknownStatus,
+		}
+	}
+	return rs
+}
+
 // allMatchStatus checks whether all resources given by the
 // Ids parameter has the provided status.
-func (a *resourceStatusCollector) allMatchStatus(rwd []resourceWaitData, s status.Status) bool {
+func (a *ResourceStatusCollector) allMatchStatus(rwd []ResourceGeneration, s status.Status) bool {
 	for _, wd := range rwd {
-		ri, found := a.resourceMap[wd.identifier]
-		if !found {
-			return false
-		}
-		if ri.Generation < wd.generation || ri.CurrentStatus != s {
+		rs := a.Get(wd.Identifier)
+		if rs.Generation < wd.Generation || rs.CurrentStatus != s {
 			return false
 		}
 	}
@@ -91,13 +136,10 @@ func (a *resourceStatusCollector) allMatchStatus(rwd []resourceWaitData, s statu
 
 // noneMatchStatus checks whether none of the resources given
 // by the Ids parameters has the provided status.
-func (a *resourceStatusCollector) noneMatchStatus(rwd []resourceWaitData, s status.Status) bool {
+func (a *ResourceStatusCollector) noneMatchStatus(rwd []ResourceGeneration, s status.Status) bool {
 	for _, wd := range rwd {
-		ri, found := a.resourceMap[wd.identifier]
-		if !found {
-			return false
-		}
-		if ri.Generation < wd.generation || ri.CurrentStatus == s {
+		rs := a.Get(wd.Identifier)
+		if rs.Generation < wd.Generation || rs.CurrentStatus == s {
 			return false
 		}
 	}

--- a/pkg/apply/taskrunner/collector_test.go
+++ b/pkg/apply/taskrunner/collector_test.go
@@ -32,92 +32,86 @@ func TestCollector_ConditionMet(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		collectorState map[object.ObjMetadata]resourceStatus
-		waitTaskData   []resourceWaitData
+		collectorState map[object.ObjMetadata]ResourceStatus
+		waitTaskData   []ResourceGeneration
 		condition      Condition
 		expectedResult bool
 	}{
 		"single resource with current status": {
-			collectorState: map[object.ObjMetadata]resourceStatus{
+			collectorState: map[object.ObjMetadata]ResourceStatus{
 				identifiers["dep"]: {
-					Identifier:    identifiers["dep"],
 					CurrentStatus: status.CurrentStatus,
 					Generation:    int64(42),
 				},
 			},
-			waitTaskData: []resourceWaitData{
+			waitTaskData: []ResourceGeneration{
 				{
-					identifier: identifiers["dep"],
-					generation: int64(42),
+					Identifier: identifiers["dep"],
+					Generation: int64(42),
 				},
 			},
 			condition:      AllCurrent,
 			expectedResult: true,
 		},
 		"single resource with current status and old generation": {
-			collectorState: map[object.ObjMetadata]resourceStatus{
+			collectorState: map[object.ObjMetadata]ResourceStatus{
 				identifiers["dep"]: {
-					Identifier:    identifiers["dep"],
 					CurrentStatus: status.CurrentStatus,
 					Generation:    int64(41),
 				},
 			},
-			waitTaskData: []resourceWaitData{
+			waitTaskData: []ResourceGeneration{
 				{
-					identifier: identifiers["dep"],
-					generation: int64(42),
+					Identifier: identifiers["dep"],
+					Generation: int64(42),
 				},
 			},
 			condition:      AllCurrent,
 			expectedResult: false,
 		},
 		"multiple resources not all current": {
-			collectorState: map[object.ObjMetadata]resourceStatus{
+			collectorState: map[object.ObjMetadata]ResourceStatus{
 				identifiers["dep"]: {
-					Identifier:    identifiers["dep"],
 					CurrentStatus: status.CurrentStatus,
 					Generation:    int64(41),
 				},
 				identifiers["custom"]: {
-					Identifier:    identifiers["custom"],
 					CurrentStatus: status.InProgressStatus,
 					Generation:    int64(0),
 				},
 			},
-			waitTaskData: []resourceWaitData{
+			waitTaskData: []ResourceGeneration{
 				{
-					identifier: identifiers["dep"],
-					generation: int64(42),
+					Identifier: identifiers["dep"],
+					Generation: int64(42),
 				},
 				{
-					identifier: identifiers["custom"],
-					generation: int64(0),
+					Identifier: identifiers["custom"],
+					Generation: int64(0),
 				},
 			},
 			condition:      AllCurrent,
 			expectedResult: false,
 		},
 		"multiple resources single with old generation": {
-			collectorState: map[object.ObjMetadata]resourceStatus{
+			collectorState: map[object.ObjMetadata]ResourceStatus{
 				identifiers["dep"]: {
-					Identifier:    identifiers["dep"],
 					CurrentStatus: status.CurrentStatus,
 					Generation:    int64(42),
 				},
 				identifiers["custom"]: {
-					Identifier:    identifiers["custom"],
 					CurrentStatus: status.CurrentStatus,
 					Generation:    int64(4),
 				},
 			},
-			waitTaskData: []resourceWaitData{
+			waitTaskData: []ResourceGeneration{
 				{
-					identifier: identifiers["dep"],
-					generation: int64(42),
+					Identifier: identifiers["dep"],
+					Generation: int64(42),
 				},
 				{
-					identifier: identifiers["custom"],
-					generation: int64(5),
+					Identifier: identifiers["custom"],
+					Generation: int64(5),
 				},
 			},
 			condition:      AllCurrent,
@@ -127,10 +121,10 @@ func TestCollector_ConditionMet(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			rsc := newResourceStatusCollector([]object.ObjMetadata{})
+			rsc := NewResourceStatusCollector()
 			rsc.resourceMap = tc.collectorState
 
-			res := rsc.conditionMet(tc.waitTaskData, tc.condition)
+			res := rsc.ConditionMet(tc.waitTaskData, tc.condition)
 
 			assert.Equal(t, tc.expectedResult, res)
 		})

--- a/pkg/apply/taskrunner/main_test.go
+++ b/pkg/apply/taskrunner/main_test.go
@@ -1,0 +1,19 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package taskrunner
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package.
+// Adds support for parsing logging flags. Example:
+// go test sigs.k8s.io/cli-utils/pkg/apply/taskrunner -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -4,21 +4,31 @@
 package taskrunner
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
-func TestWaitTask_TimeoutTriggered(t *testing.T) {
-	task := NewWaitTask("wait", []object.ObjMetadata{}, AllCurrent,
-		2*time.Second, testutil.NewFakeRESTMapper())
+func TestWaitTask_TaskTimeout(t *testing.T) {
+	// ensure conditions are not met, or task with exit early
+	task := NewWaitTask(
+		"wait",
+		[]object.ObjMetadata{depID},
+		AllCurrent,
+		2*time.Second,
+		testutil.NewFakeRESTMapper(),
+	)
 
 	eventChannel := make(chan event.Event)
-	taskContext := NewTaskContext(eventChannel)
+	taskContext := NewTaskContext(context.TODO(), eventChannel)
 	defer close(eventChannel)
 
 	task.Start(taskContext)
@@ -30,53 +40,165 @@ func TestWaitTask_TimeoutTriggered(t *testing.T) {
 		if _, ok := IsTimeoutError(res.Err); !ok {
 			t.Errorf("expected timeout error, but got %v", res.Err)
 		}
-		return
+		expected := &TimeoutError{
+			Identifiers: []object.ObjMetadata{depID},
+			Timeout:     2 * time.Second,
+			Condition:   AllCurrent,
+		}
+		require.Equal(t, res.Err.Error(), expected.Error())
 	case <-timer.C:
 		t.Errorf("expected timeout to trigger, but it didn't")
 	}
 }
 
-func TestWaitTask_TimeoutCancelled(t *testing.T) {
-	task := NewWaitTask("wait", []object.ObjMetadata{}, AllCurrent,
-		2*time.Second, testutil.NewFakeRESTMapper())
+func TestWaitTask_ContextCancelled(t *testing.T) {
+	// ensure conditions are not met, or task with exit early
+	task := NewWaitTask(
+		"wait",
+		[]object.ObjMetadata{depID},
+		AllCurrent,
+		2*time.Second,
+		testutil.NewFakeRESTMapper(),
+	)
 
+	ctx, cancel := context.WithCancel(context.Background())
 	eventChannel := make(chan event.Event)
-	taskContext := NewTaskContext(eventChannel)
+	taskContext := NewTaskContext(ctx, eventChannel)
 	defer close(eventChannel)
+	defer cancel()
 
 	task.Start(taskContext)
-	task.ClearTimeout()
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		cancel()
+	}()
+
 	timer := time.NewTimer(3 * time.Second)
 
 	select {
 	case res := <-taskContext.TaskChannel():
-		t.Errorf("didn't expect timeout error, but got %v", res.Err)
+		require.ErrorIs(t, res.Err, context.Canceled)
 	case <-timer.C:
-		return
+		t.Errorf("unexpected timeout")
 	}
 }
 
-func TestWaitTask_SingleTaskResult(t *testing.T) {
-	task := NewWaitTask("wait", []object.ObjMetadata{}, AllCurrent,
-		2*time.Second, testutil.NewFakeRESTMapper())
+func TestWaitTask_ContextTimeout(t *testing.T) {
+	// ensure conditions are not met, or task with exit early
+	task := NewWaitTask(
+		"wait",
+		[]object.ObjMetadata{depID},
+		AllCurrent,
+		2*time.Second,
+		testutil.NewFakeRESTMapper(),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	eventChannel := make(chan event.Event)
+	taskContext := NewTaskContext(ctx, eventChannel)
+	defer close(eventChannel)
+	defer cancel()
+
+	task.Start(taskContext)
+
+	timer := time.NewTimer(3 * time.Second)
+
+	select {
+	case res := <-taskContext.TaskChannel():
+		require.ErrorIs(t, res.Err, context.DeadlineExceeded)
+	case <-timer.C:
+		t.Errorf("unexpected timeout")
+	}
+}
+
+// TestWaitTask_OnStatusEvent tests that OnStatusEvent with the right status in
+// the ResourceStatusCollector triggers a TaskResult on the TaskChannel.
+func TestWaitTask_OnStatusEvent(t *testing.T) {
+	// ensure conditions are not met, or task with exit early.
+	task := NewWaitTask(
+		"wait",
+		[]object.ObjMetadata{depID},
+		AllCurrent,
+		0*time.Second,
+		testutil.NewFakeRESTMapper(),
+	)
 
 	eventChannel := make(chan event.Event)
-	taskContext := NewTaskContext(eventChannel)
+	taskContext := NewTaskContext(context.TODO(), eventChannel)
 	taskContext.taskChannel = make(chan TaskResult, 10)
 	defer close(eventChannel)
 
-	var completeWg sync.WaitGroup
+	task.Start(taskContext)
 
-	for i := 0; i < 10; i++ {
-		completeWg.Add(1)
-		go func() {
-			defer completeWg.Done()
-			task.complete(taskContext)
-		}()
+	go func() {
+		klog.V(5).Infof("status event %d", 1)
+		taskContext.ResourceStatusCollector().Put(depID, ResourceStatus{
+			CurrentStatus: kstatus.CurrentStatus,
+			Generation:    1,
+		})
+		task.OnStatusEvent(taskContext, event.StatusEvent{})
+		klog.V(5).Infof("status event %d handled", 1)
+	}()
+
+	timer := time.NewTimer(4 * time.Second)
+
+	select {
+	case res := <-taskContext.TaskChannel():
+		require.NoError(t, res.Err)
+	case <-timer.C:
+		t.Errorf("unexpected timeout")
 	}
-	completeWg.Wait()
+}
 
-	<-taskContext.TaskChannel()
+// TestWaitTask_SingleTaskResult tests that WaitTask can handle more than one
+// call to OnStatusEvent and still only send one result on the TaskChannel.
+func TestWaitTask_SingleTaskResult(t *testing.T) {
+	// ensure conditions are not met, or task with exit early.
+	task := NewWaitTask(
+		"wait",
+		[]object.ObjMetadata{depID},
+		AllCurrent,
+		0*time.Second,
+		testutil.NewFakeRESTMapper(),
+	)
+
+	eventChannel := make(chan event.Event)
+	taskContext := NewTaskContext(context.TODO(), eventChannel)
+	taskContext.taskChannel = make(chan TaskResult, 10)
+	defer close(eventChannel)
+
+	task.Start(taskContext)
+
+	var completeWg sync.WaitGroup
+	completeWg.Add(1)
+	go func() {
+		defer completeWg.Done()
+		klog.V(5).Info("waiting for task result")
+		res := <-taskContext.TaskChannel()
+		klog.V(5).Infof("received task result: %v", res.Err)
+		require.NoError(t, res.Err)
+	}()
+	completeWg.Add(4)
+	go func() {
+		for i := 0; i < 4; i++ {
+			index := i
+			go func() {
+				defer completeWg.Done()
+				time.Sleep(time.Duration(index) * time.Second)
+				klog.V(5).Infof("status event %d", index)
+				if index > 2 {
+					taskContext.ResourceStatusCollector().Put(depID, ResourceStatus{
+						CurrentStatus: kstatus.CurrentStatus,
+						Generation:    1,
+					})
+				}
+				task.OnStatusEvent(taskContext, event.StatusEvent{})
+				klog.V(5).Infof("status event %d handled", index)
+			}()
+		}
+	}()
+	completeWg.Wait()
 
 	timer := time.NewTimer(4 * time.Second)
 

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -55,9 +55,11 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	By("Destroy resources")
 	destroyer := invConfig.DestroyerFactoryFunc()
 
+	// TODO: test timeout/cancel behavior
+	ctx := context.TODO()
 	destroyInv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(destroyInv, options))
+	destroyerEvents := runCollectNoErr(destroyer.Run(ctx, destroyInv, options))
 	err = testutil.VerifyEvents([]testutil.ExpEvent{
 		{
 			EventType: event.DeleteType,

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -87,9 +87,11 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 	Expect(err).ToNot(HaveOccurred())
 
 	By("destroy the resources, including the crd")
+	// TODO: test timeout/cancel behavior
+	ctx := context.TODO()
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(inv, options))
+	destroyerEvents := runCollectNoErr(destroyer.Run(ctx, inv, options))
 	err = testutil.VerifyEvents([]testutil.ExpEvent{
 		{
 			// Initial event

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -109,9 +109,11 @@ func dependsOnTest(_ client.Client, invConfig InventoryConfig, inventoryName, na
 	Expect(err).ToNot(HaveOccurred())
 
 	By("destroy resources in opposite order")
+	// TODO: test timeout/cancel behavior
+	ctx := context.TODO()
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(inv, options))
+	destroyerEvents := runCollectNoErr(destroyer.Run(ctx, inv, options))
 	err = testutil.VerifyEvents([]testutil.ExpEvent{
 		{
 			// Initial event


### PR DESCRIPTION
- Add timeout flag to apply, destory, and preview cmds
- Default to no timeout
- Add context to TaskContext
- Pass context through to all functions that use it
- Rename prune-timeout flag to delete-timeout and add actual impl
- Rename PruneOptions to Pruner (there's already prune.Options)
- Rename PropagationPolicy to DeletionPropagationPolicy consistently
- Wrap func calls and defs for readability
- Remove Prune bool from solver.Options to simplify
  AppendPruneWaitTasks to always prune.
  Change Applier to only call AppendPruneWaitTasks if NoPrune.
  Change Destroyer to always call AppendPruneWaitTasks.
- Replace task.ClearTimeout with context.Cancel
- Add task.OnStatusEvent to fix WaitTask leaky abstraction.
  baseRunner was calling private funcs from WaitTask.
- Move ResourceStatusCollector into TaskContext. It doesn't need to
  persist between runs. Moving it simplifies baseRunner.
  This required making some of the collector funcs public.
- Remove Identifier from collector.ResourceStatus. Redundant with id.
- Add collector.Get/Put funcs for encapsulation and thread-safety
- Add locking to ResourceStatusCollector because a test was complaining
  about a race condition when updating status from another goroutine,
  like the poller does.
- Add logging to taskrunner tests for easier debugging concurrency
- Update task tests for cancel and timeout
- Rename options vars to "opts" for consistency
- Rewrite WaitTask context/timeout handling.
  TaskChannel is now only written to from one place, gated by an
  internal error channel and sync.Once.
  WaitTask now distinguishes between wait task timeout and parent
  context timeout.
- Update task tests to reflect new behavior with context cancel/timeout

**Note:** This PR is probably too big. I started cleaning things up and kept finding things to fix. Let me know what I should leave out or punt to another PR.