### PR TITLE
Add more robust event list testing in e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/cli-utils
 go 1.16
 
 require (
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.2.0
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/pkg/testutil/matcher.go
+++ b/pkg/testutil/matcher.go
@@ -1,0 +1,109 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package testutil
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/gomega/format"
+)
+
+// Equal returns a matcher for use with Gomega that uses go-cmp's cmp.Equal to
+// compare and cmp.Diff to show the difference, if there is one.
+//
+// Example Usage:
+// Expect(receivedEvents).To(testutil.Equal(expectedEvents))
+func Equal(expected interface{}) *cmpMatcher {
+	return &cmpMatcher{expected: expected}
+}
+
+type cmpMatcher struct {
+	expected    interface{}
+	explanation error
+}
+
+func (cm *cmpMatcher) Match(actual interface{}) (bool, error) {
+	match := cmp.Equal(actual, cm.expected, cmpopts.EquateErrors())
+	if !match {
+		cm.explanation = errors.New(cmp.Diff(actual, cm.expected, cmpopts.EquateErrors()))
+	}
+	return match, nil
+}
+
+func (cm *cmpMatcher) FailureMessage(actual interface{}) string {
+	return format.Message(actual, "to deeply equal", cm.expected) +
+		"\nDiff:\n" + indent(cm.explanation.Error(), 1)
+}
+
+func (cm *cmpMatcher) NegatedFailureMessage(actual interface{}) string {
+	return format.Message(actual, "not to deeply equal", cm.expected) +
+		"\nDiff:\n" + indent(cm.explanation.Error(), 1)
+}
+
+func indent(in string, indentation uint) string {
+	indent := strings.Repeat(format.Indent, int(indentation))
+	lines := strings.Split(in, "\n")
+	return indent + strings.Join(lines, fmt.Sprintf("\n%s", indent))
+}
+
+// EqualErrorType returns an error with an Is(error)bool function that matches
+// any error with the same type as the supplied error.
+//
+// Use with testutil.Equal to handle error comparisons.
+func EqualErrorType(err error) equalErrorType {
+	return equalErrorType{
+		err: err,
+	}
+}
+
+type equalErrorType struct {
+	err error
+}
+
+func (e equalErrorType) Error() string {
+	return "EqualErrorType"
+}
+
+func (e equalErrorType) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	return reflect.TypeOf(e.err) == reflect.TypeOf(err)
+}
+
+func (e equalErrorType) Unwrap() error {
+	return e.err
+}
+
+// EqualErrorString returns an error with an Is(error)bool function that matches
+// any error with the same Error() as the supplied string value.
+//
+// Use with testutil.Equal to handle error comparisons.
+func EqualErrorString(err string) equalErrorString {
+	return equalErrorString{
+		err: err,
+	}
+}
+
+// equalError is an error that matches any non-nil error of the specified type.
+type equalErrorString struct {
+	err string
+}
+
+func (e equalErrorString) Error() string {
+	return e.err
+}
+
+func (e equalErrorString) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	return e.err == err.Error()
+}

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,15 +41,133 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 		Expect(e.Type).NotTo(Equal(event.ErrorType))
 		applierEvents = append(applierEvents, e)
 	}
-	err := testutil.VerifyEvents([]testutil.ExpEvent{
+
+	expEvents := []testutil.ExpEvent{
 		{
+			// InitTask
 			EventType: event.InitType,
+			InitEvent: &testutil.ExpInitEvent{},
 		},
 		{
-			EventType: event.ApplyType,
+			// InvAddTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "inventory-add-0",
+				Type:   event.Started,
+			},
 		},
-	}, applierEvents)
-	Expect(err).ToNot(HaveOccurred())
+		{
+			// InvAddTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "inventory-add-0",
+				Type:   event.Finished,
+			},
+		},
+		{
+			// ApplyTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.ApplyAction,
+				Name:   "apply-0",
+				Type:   event.Started,
+			},
+		},
+		{
+			// Create deployment
+			EventType: event.ApplyType,
+			ApplyEvent: &testutil.ExpApplyEvent{
+				Operation:  event.Created,
+				Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
+				Error:      nil,
+			},
+		},
+		{
+			// ApplyTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.ApplyAction,
+				Name:   "apply-0",
+				Type:   event.Finished,
+			},
+		},
+		{
+			// WaitTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.WaitAction,
+				Name:   "wait-0",
+				Type:   event.Started,
+			},
+		},
+		{
+			// WaitTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.WaitAction,
+				Name:   "wait-0",
+				Type:   event.Finished,
+			},
+		},
+		{
+			// InvSetTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "inventory-set-0",
+				Type:   event.Started,
+			},
+		},
+		{
+			// InvSetTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "inventory-set-0",
+				Type:   event.Finished,
+			},
+		},
+	}
+	received := testutil.EventsToExpEvents(applierEvents)
+
+	// handle required async NotFound StatusEvents
+	expected := testutil.ExpEvent{
+		EventType: event.StatusType,
+		StatusEvent: &testutil.ExpStatusEvent{
+			Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
+			Status:     status.NotFoundStatus,
+			Error:      nil,
+		},
+	}
+	received, matches := testutil.RemoveEqualEvents(received, expected)
+	Expect(matches).To(BeNumerically(">=", 1), "unexpected number of %q status events", status.NotFoundStatus)
+
+	// handle optional async InProgress StatusEvents
+	expected = testutil.ExpEvent{
+		EventType: event.StatusType,
+		StatusEvent: &testutil.ExpStatusEvent{
+			Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
+			Status:     status.InProgressStatus,
+			Error:      nil,
+		},
+	}
+	received, _ = testutil.RemoveEqualEvents(received, expected)
+
+	// handle required async Current StatusEvents
+	expected = testutil.ExpEvent{
+		EventType: event.StatusType,
+		StatusEvent: &testutil.ExpStatusEvent{
+			Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
+			Status:     status.CurrentStatus,
+			Error:      nil,
+		},
+	}
+	received, matches = testutil.RemoveEqualEvents(received, expected)
+	Expect(matches).To(BeNumerically(">=", 1), "unexpected number of %q status events", status.CurrentStatus)
+
+	Expect(received).To(testutil.Equal(expEvents))
 
 	By("Verify inventory")
 	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 1)
@@ -58,12 +178,80 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	destroyInv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
 	destroyerEvents := runCollectNoErr(destroyer.Run(destroyInv, options))
-	err = testutil.VerifyEvents([]testutil.ExpEvent{
+
+	expEvents = []testutil.ExpEvent{
 		{
-			EventType: event.DeleteType,
+			// InitTask
+			EventType: event.InitType,
+			InitEvent: &testutil.ExpInitEvent{},
 		},
-	}, destroyerEvents)
-	Expect(err).ToNot(HaveOccurred())
+		{
+			// PruneTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.DeleteAction,
+				Name:   "prune-0",
+				Type:   event.Started,
+			},
+		},
+		{
+			// Delete deployment
+			EventType: event.DeleteType,
+			DeleteEvent: &testutil.ExpDeleteEvent{
+				Operation:  event.Deleted,
+				Identifier: object.UnstructuredToObjMetaOrDie(deploymentManifest(namespaceName)),
+				Error:      nil,
+			},
+		},
+		{
+			// PruneTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.DeleteAction,
+				Name:   "prune-0",
+				Type:   event.Finished,
+			},
+		},
+		// TODO: Why is waiting skipped on destroy?
+		// {
+		// 	// WaitTask start
+		// 	EventType: event.ActionGroupType,
+		// 	ActionGroupEvent: &testutil.ExpActionGroupEvent{
+		// 		Action: event.WaitAction,
+		// 		Name:   "wait-0",
+		// 		Type:   event.Started,
+		// 	},
+		// },
+		// {
+		// 	// WaitTask finished
+		// 	EventType: event.ActionGroupType,
+		// 	ActionGroupEvent: &testutil.ExpActionGroupEvent{
+		// 		Action: event.WaitAction,
+		// 		Name:   "wait-0",
+		// 		Type:   event.Finished,
+		// 	},
+		// },
+		{
+			// DeleteInvTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "delete-inventory-0",
+				Type:   event.Started,
+			},
+		},
+		{
+			// DeleteInvTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action: event.InventoryAction,
+				Name:   "delete-inventory-0",
+				Type:   event.Finished,
+			},
+		},
+	}
+
+	Expect(testutil.EventsToExpEvents(destroyerEvents)).To(testutil.Equal(expEvents))
 }
 
 func createInventoryInfo(invConfig InventoryConfig, inventoryName, namespaceName, inventoryID string) inventory.InventoryInfo {

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -25,13 +25,13 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	applier := invConfig.ApplierFactoryFunc()
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	applyInv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryInfo := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 
 	resources := []*unstructured.Unstructured{
 		deploymentManifest(namespaceName),
 	}
 
-	applyCh := applier.Run(context.TODO(), applyInv, resources, apply.Options{
+	applyCh := applier.Run(context.TODO(), inventoryInfo, resources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 	})
@@ -175,9 +175,8 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	By("Destroy resources")
 	destroyer := invConfig.DestroyerFactoryFunc()
 
-	destroyInv := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(destroyInv, options))
+	destroyerEvents := runCollectNoErr(destroyer.Run(inventoryInfo, options))
 
 	expEvents = []testutil.ExpEvent{
 		{


### PR DESCRIPTION
- Add testutil.Equal to show comparisons with cmp.Diff output
- Add github.com/google/go-cmp for cmp.Equal and cmp.Diff
  These comparison tools make debugging easier and properly handle
  error comparisons, using cmpopts.EquateErrors()
- Added EventsToExpEvents, EventToExpEvent, and RemoveEqualEvents
  to testutil to help with comparing event lists
- Add InitEvent to ExpEvent, to enable validating it exists
- e2e tests have all been upgraded to validate a full list of
  events, rather than just a partial list with partial contents.
  This should increase confidence that new changes don't break things.
- Add test cleanup in AfterSuite and AfterEach to allow re-using a kind
  cluster between multiple test runs without test failures.