### PR TITLE
Marshal with k8s.io/apimachinery/pkg/util/yaml

### DIFF
--- a/pkg/apply/mutator/apply_time_mutator_test.go
+++ b/pkg/apply/mutator/apply_time_mutator_test.go
@@ -409,7 +409,7 @@ func TestMutate(t *testing.T) {
 			mutated: false,
 			reason:  "",
 			// exact error message isn't very important. Feel free to update if the error text changes.
-			errMsg: `failed to read jsonpath field in target resource (v1/namespaces/map-namespace/ConfigMap/map3-name): ` +
+			errMsg: `failed to read annotation in resource (v1/namespaces/map-namespace/ConfigMap/map3-name): ` +
 				`failed to parse apply-time-mutation annotation: "not a valid substitution list": ` +
 				`error unmarshaling JSON: ` +
 				`while decoding JSON: ` +

--- a/pkg/jsonpath/jsonpath_test.go
+++ b/pkg/jsonpath/jsonpath_test.go
@@ -36,7 +36,7 @@ entries:
 - name: a
   value: x
 - name: b
-  value: y
+  value: "y"
 - name: c
   value: z
 `
@@ -65,7 +65,7 @@ entries:
 - name: a
   value: x
 - name: b
-  value: y
+  value: "y"
 - name: c
   value: z
 `

--- a/pkg/kstatus/polling/testutil/testing.go
+++ b/pkg/kstatus/polling/testutil/testing.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"testing"
 
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/object/strings.go
+++ b/pkg/object/strings.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/yaml"
+)
+
+var codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+// YamlStringer delays YAML marshalling for logging until String() is called.
+type YamlStringer struct {
+	O runtime.Object
+}
+
+// String marshals the wrapped object to a YAML string. If serializing errors,
+// the error string will be returned instead. This is primarily for use with
+// verbose logging.
+func (ys YamlStringer) String() string {
+	jsonBytes, err := runtime.Encode(unstructured.NewJSONFallbackEncoder(codec), ys.O)
+	if err != nil {
+		return fmt.Sprintf("<<failed to serialize as json: %s>>", err)
+	}
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return fmt.Sprintf("<<failed to convert from json to yaml: %s>>", err)
+	}
+	return string(yamlBytes)
+}

--- a/pkg/object/strings.go
+++ b/pkg/object/strings.go
@@ -7,29 +7,21 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/yaml"
 )
 
-var codec = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-
 // YamlStringer delays YAML marshalling for logging until String() is called.
 type YamlStringer struct {
-	O runtime.Object
+	O *unstructured.Unstructured
 }
 
 // String marshals the wrapped object to a YAML string. If serializing errors,
 // the error string will be returned instead. This is primarily for use with
 // verbose logging.
 func (ys YamlStringer) String() string {
-	jsonBytes, err := runtime.Encode(unstructured.NewJSONFallbackEncoder(codec), ys.O)
+	yamlBytes, err := yaml.Marshal(ys.O)
 	if err != nil {
-		return fmt.Sprintf("<<failed to serialize as json: %s>>", err)
-	}
-	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
-	if err != nil {
-		return fmt.Sprintf("<<failed to convert from json to yaml: %s>>", err)
+		return fmt.Sprintf("<<failed to serialize as yaml: %s>>", err)
 	}
 	return string(yamlBytes)
 }

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func randomString(prefix string) string {


### PR DESCRIPTION
- apimachinery yaml.Marshal fixes number type parsing by casting to int64 and float64
- Fix inaccurate error message in mutator
- Move YamlStringer to object pkg for reuse by other pkgs
- Fix jsonpath tests parsing y as a bool
- Fix kstatus example_test.go to actually be a test