### PR TITLE
e2e test cleanup

### DIFF
--- a/pkg/object/mutation/types.go
+++ b/pkg/object/mutation/types.go
@@ -114,13 +114,26 @@ func (r ResourceReference) GroupVersionKind() schema.GroupVersionKind {
 	return schema.FromAPIVersionAndKind(r.APIVersion, r.Kind)
 }
 
-// ObjMetadata returns the name, namespace, group, and kind of the ResourceReference
+// ObjMetadata returns the name, namespace, group, and kind of the
+// ResourceReference, wrapped in a new ObjMetadata object.
 func (r ResourceReference) ObjMetadata() object.ObjMetadata {
 	return object.ObjMetadata{
 		Name:      r.Name,
 		Namespace: r.Namespace,
 		GroupKind: r.GroupVersionKind().GroupKind(),
 	}
+}
+
+// Unstructured returns the name, namespace, group, version, and kind of the
+// ResourceReference, wrapped in a new Unstructured object.
+// This is useful for performing operations with
+// sigs.k8s.io/controller-runtime/pkg/client's unstructured Client.
+func (r ResourceReference) Unstructured() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetName(r.Name)
+	obj.SetNamespace(r.Namespace)
+	obj.SetGroupVersionKind(r.GroupVersionKind())
+	return obj
 }
 
 // String returns the format GROUP[/VERSION][/namespaces/NAMESPACE]/KIND/NAME

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"strings"
+)
+
+var deployment1 = []byte(strings.TrimSpace(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.19.6
+        ports:
+        - containerPort: 80
+`))
+
+var apiservice1 = []byte(strings.TrimSpace(`
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  insecureSkipTLSVerify: true
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  versionPriority: 100
+  service:
+    name: custom-metrics-stackdriver-adapter
+    namespace: custom-metrics
+  version: v1beta1
+`))
+
+var invalidCrd = []byte(strings.TrimSpace(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: invalidexamples.cli-utils.example.io
+spec:
+  conversion:
+    strategy: None
+  group: cli-utils.example.io
+  names:
+    kind: InvalidExample
+    listKind: InvalidExampleList
+    plural: invalidexamples
+    singular: invalidexample
+  scope: Cluster
+`))
+
+var pod1 = []byte(strings.TrimSpace(`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+`))
+
+var pod2 = []byte(strings.TrimSpace(`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod2
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+`))
+
+var pod3 = []byte(strings.TrimSpace(`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod3
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+`))
+
+var podA = []byte(strings.TrimSpace(`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod-a
+  namespace: test
+  annotations:
+    config.kubernetes.io/apply-time-mutation: |
+      - sourceRef:
+          kind: Pod
+          name: pod-b
+        sourcePath: $.status.podIP
+        targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
+        token: ${pob-b-ip}
+      - sourceRef:
+          kind: Pod
+          name: pod-b
+        sourcePath: $.spec.containers[?(@.name=="nginx")].ports[?(@.name=="tcp")].containerPort
+        targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
+        token: ${pob-b-port}
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.21
+    ports:
+    - name: tcp
+      containerPort: 80
+    env:
+    - name: SERVICE_HOST
+      value: "${pob-b-ip}:${pob-b-port}"
+`))
+
+var podB = []byte(strings.TrimSpace(`
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pod-b
+  namespace: test
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.21
+    ports:
+    - name: tcp
+      containerPort: 80
+`))

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -4,19 +4,148 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object/dependson"
+	"sigs.k8s.io/cli-utils/pkg/object/mutation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func withReplicas(obj *unstructured.Unstructured, replicas int) *unstructured.Unstructured {
+	err := unstructured.SetNestedField(obj.Object, int64(replicas), "spec", "replicas")
+	Expect(err).NotTo(HaveOccurred())
+	return obj
+}
+
+func withNamespace(obj *unstructured.Unstructured, namespace string) *unstructured.Unstructured {
+	obj.SetNamespace(namespace)
+	return obj
+}
+
+func withDependsOn(obj *unstructured.Unstructured, dep string) *unstructured.Unstructured {
+	a := obj.GetAnnotations()
+	if a == nil {
+		a = make(map[string]string, 1)
+	}
+	a[dependson.Annotation] = dep
+	obj.SetAnnotations(a)
+	return obj
+}
+
+func deleteUnstructuredAndWait(c client.Client, obj *unstructured.Unstructured) {
+	ref := mutation.NewResourceReference(obj)
+
+	err := c.Delete(context.TODO(), obj,
+		client.PropagationPolicy(metav1.DeletePropagationForeground))
+	Expect(err).NotTo(HaveOccurred(),
+		"expected DELETE to not error (%s): %s", ref, err)
+
+	waitForDeletion(c, obj)
+}
+
+func waitForDeletion(c client.Client, obj *unstructured.Unstructured) {
+	ref := mutation.NewResourceReference(obj)
+	resultObj := ref.Unstructured()
+
+	timeout := 30 * time.Second
+	retry := 2 * time.Second
+
+	t := time.NewTimer(timeout)
+	s := time.NewTimer(0)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			Fail("timed out waiting for resource to be fully deleted")
+			return
+		case <-s.C:
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      obj.GetName(),
+			}, resultObj)
+			if err != nil {
+				Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound),
+					"expected GET to error with NotFound (%s): %s", ref, err)
+				return
+			}
+			s = time.NewTimer(retry)
+		}
+	}
+}
+
+func waitForCreation(c client.Client, obj *unstructured.Unstructured) {
+	ref := mutation.NewResourceReference(obj)
+	resultObj := ref.Unstructured()
+
+	timeout := 30 * time.Second
+	retry := 2 * time.Second
+
+	t := time.NewTimer(timeout)
+	s := time.NewTimer(0)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			Fail("timed out waiting for resource to be fully created")
+			return
+		case <-s.C:
+			err := c.Get(context.TODO(), types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      obj.GetName(),
+			}, resultObj)
+			if err == nil {
+				return
+			}
+			Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound),
+				"expected GET to error with NotFound (%s): %s", ref, err)
+			// if NotFound, sleep and retry
+			s = time.NewTimer(retry)
+		}
+	}
+}
+
+func assertUnstructuredExists(c client.Client, obj *unstructured.Unstructured) *unstructured.Unstructured {
+	ref := mutation.NewResourceReference(obj)
+	resultObj := ref.Unstructured()
+
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}, resultObj)
+	Expect(err).NotTo(HaveOccurred(),
+		"expected GET not to error (%s): %s", ref, err)
+	return resultObj
+}
+
+func assertUnstructuredDoesNotExist(c client.Client, obj *unstructured.Unstructured) {
+	ref := mutation.NewResourceReference(obj)
+	resultObj := ref.Unstructured()
+
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}, resultObj)
+	Expect(err).To(HaveOccurred(),
+		"expected GET to error (%s)", ref)
+	Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound),
+		"expected GET to error with NotFound (%s): %s", ref, err)
+}
 
 func randomString(prefix string) string {
 	randomSuffix := common.RandomStr()
@@ -91,73 +220,6 @@ metadata:
 	return u
 }
 
-func deploymentManifest(namespace string) *unstructured.Unstructured {
-	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: appsv1.SchemeGroupVersion.String(),
-			Kind:       "Deployment",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx-deployment",
-			Namespace: namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: func() *int32 { r := int32(4); return &r }(),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "nginx",
-				},
-			},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": "nginx",
-					},
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  "nginx",
-							Image: "nginx:1.19.6",
-						},
-					},
-				},
-			},
-		},
-	}
-	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(dep)
-	if err != nil {
-		panic(err)
-	}
-	return &unstructured.Unstructured{
-		Object: u,
-	}
-}
-
-func apiserviceManifest() *unstructured.Unstructured {
-	apiservice := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "apiregistration.k8s.io/v1",
-			"kind":       "APIService",
-			"metadata": map[string]interface{}{
-				"name": "v1beta1.custom.metrics.k8s.io",
-			},
-			"spec": map[string]interface{}{
-				"insecureSkipTLSVerify": true,
-				"group":                 "custom.metrics.k8s.io",
-				"groupPriorityMinimum":  100,
-				"versionPriority":       100,
-				"service": map[string]interface{}{
-					"name":      "custom-metrics-stackdriver-adapter",
-					"namespace": "custome-metrics",
-				},
-				"version": "v1beta1",
-			},
-		},
-	}
-	return apiservice
-}
-
 func manifestToUnstructured(manifest []byte) *unstructured.Unstructured {
 	u := make(map[string]interface{})
 	err := yaml.Unmarshal(manifest, &u)
@@ -167,12 +229,4 @@ func manifestToUnstructured(manifest []byte) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: u,
 	}
-}
-
-func updateReplicas(u *unstructured.Unstructured, replicas int) *unstructured.Unstructured {
-	err := unstructured.SetNestedField(u.Object, int64(replicas), "spec", "replicas")
-	if err != nil {
-		panic(err)
-	}
-	return u
 }

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -37,7 +37,6 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 
 	var applierEvents []event.Event
 	for e := range ch {
-		Expect(e.Type).NotTo(Equal(event.ErrorType))
 		applierEvents = append(applierEvents, e)
 	}
 
@@ -179,7 +178,7 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 	By("destroy the resources, including the crd")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/mutation_test.go
+++ b/test/e2e/mutation_test.go
@@ -6,15 +6,10 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
@@ -49,17 +44,12 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 		withNamespace(manifestToUnstructured(podB), namespaceName),
 	}
 
-	for _, obj := range resources {
-		obj.SetNamespace(namespaceName)
-	}
-
 	ch := applier.Run(context.TODO(), inv, resources, apply.Options{
 		EmitStatusEvents: false,
 	})
 
 	var applierEvents []event.Event
 	for e := range ch {
-		Expect(e.Type).NotTo(Equal(event.ErrorType))
 		applierEvents = append(applierEvents, e)
 	}
 	expEvents := []testutil.ExpEvent{
@@ -197,29 +187,38 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 	}
 	Expect(testutil.EventsToExpEvents(applierEvents)).To(testutil.Equal(expEvents))
 
-	By("verify resource was mutated")
-	var podBObj v1.Pod
-	err := c.Get(context.TODO(), types.NamespacedName{
-		Namespace: namespaceName,
-		Name:      manifestToUnstructured(podB).GetName(),
-	}, &podBObj)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(podBObj.Status.PodIP).NotTo(BeEmpty())
-	Expect(podBObj.Spec.Containers[0].Ports[0].ContainerPort).To(Equal(int32(80)))
-	host := fmt.Sprintf("%s:%d", podBObj.Status.PodIP, podBObj.Spec.Containers[0].Ports[0].ContainerPort)
+	By("verify podB is created and ready")
+	result := assertUnstructuredExists(c, withNamespace(manifestToUnstructured(podB), namespaceName))
 
-	var podAObj v1.Pod
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Namespace: namespaceName,
-		Name:      manifestToUnstructured(podA).GetName(),
-	}, &podAObj)
+	podIP, found, err := testutil.NestedField(result.Object, "status", "podIP")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(podAObj.Spec.Containers[0].Env[0].Value).To(Equal(host))
+	Expect(found).To(BeTrue())
+	Expect(podIP).NotTo(BeEmpty()) // use podIP as proxy for readiness
+
+	containerPort, found, err := testutil.NestedField(result.Object, "spec", "containers", 0, "ports", 0, "containerPort")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(containerPort).To(Equal(int64(80)))
+
+	host := fmt.Sprintf("%s:%d", podIP, containerPort)
+
+	By("verify podA is mutated, created, and ready")
+	result = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(podA), namespaceName))
+
+	podIP, found, err = testutil.NestedField(result.Object, "status", "podIP")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(podIP).NotTo(BeEmpty()) // use podIP as proxy for readiness
+
+	envValue, found, err := testutil.NestedField(result.Object, "spec", "containers", 0, "env", 0, "value")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(envValue).To(Equal(host))
 
 	By("destroy resources in opposite order")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollectNoErr(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{
@@ -339,70 +338,9 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 
 	Expect(testutil.EventsToExpEvents(destroyerEvents)).To(testutil.Equal(expEvents))
 
-	By("verify resources deleted")
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Namespace: namespaceName,
-		Name:      manifestToUnstructured(podB).GetName(),
-	}, &podBObj)
-	Expect(err).To(HaveOccurred())
-	Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound))
+	By("verify podB deleted")
+	assertUnstructuredDoesNotExist(c, withNamespace(manifestToUnstructured(podB), namespaceName))
 
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Namespace: namespaceName,
-		Name:      manifestToUnstructured(podA).GetName(),
-	}, &podAObj)
-	Expect(err).To(HaveOccurred())
-	Expect(apierrors.ReasonForError(err)).To(Equal(metav1.StatusReasonNotFound))
+	By("verify podA deleted")
+	assertUnstructuredDoesNotExist(c, withNamespace(manifestToUnstructured(podA), namespaceName))
 }
-
-func withNamespace(obj *unstructured.Unstructured, namespace string) *unstructured.Unstructured {
-	obj.SetNamespace(namespace)
-	return obj
-}
-
-var podA = []byte(strings.TrimSpace(`
-kind: Pod
-apiVersion: v1
-metadata:
-  name: pod-a
-  namespace: test
-  annotations:
-    config.kubernetes.io/apply-time-mutation: |
-      - sourceRef:
-          kind: Pod
-          name: pod-b
-        sourcePath: $.status.podIP
-        targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
-        token: ${pob-b-ip}
-      - sourceRef:
-          kind: Pod
-          name: pod-b
-        sourcePath: $.spec.containers[?(@.name=="nginx")].ports[?(@.name=="tcp")].containerPort
-        targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
-        token: ${pob-b-port}
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.21
-    ports:
-    - name: tcp
-      containerPort: 80
-    env:
-    - name: SERVICE_HOST
-      value: "${pob-b-ip}:${pob-b-port}"
-`))
-
-var podB = []byte(strings.TrimSpace(`
-kind: Pod
-apiVersion: v1
-metadata:
-  name: pod-b
-  namespace: test
-spec:
-  containers:
-  - name: nginx
-    image: nginx:1.21
-    ports:
-    - name: tcp
-      containerPort: 80
-`))

--- a/test/e2e/name_inv_strategy_test.go
+++ b/test/e2e/name_inv_strategy_test.go
@@ -23,7 +23,7 @@ func applyWithExistingInvTest(c client.Client, invConfig InventoryConfig, invent
 	orgApplyInv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, orgInventoryID))
 
 	resources := []*unstructured.Unstructured{
-		deploymentManifest(namespaceName),
+		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
 
 	runWithNoErr(applier.Run(context.TODO(), orgApplyInv, resources, apply.Options{


### PR DESCRIPTION
- Unstructured() added to ResourceReference to aid test operations
- Test artifacts moved into artifacts_test.go
- deploymentManifest and apiserviceManifest replaced with
  yaml->unstructured, for consistency with other test artifacts
- Added withReplicas, withNamespace, and withDependsOn for easier inline
  mutation of test artifacts
- Added deleteUnstructuredAndWait, assertUnstructuredExists, and
  assertUnstructuredDoesNotExist to validate actual cluster state,
  not just events. Also reduced flakiness by waiting for delete.
- Removed error check before event validation. The event diff
  provides much more context for debugging.
- Replaced typed resources with unstructured and used
  testutil.NestedField to extract values.
- Updated prune error test to use full event list comparison and
  validate server state.
- Add 2nd resource to continue on error test
- Don't fail early on error from event list
- Fix flakey prune error test
  Add wait for pod2 after creation
  Add wait for pod2 after deletion
  Re-use inventory to ensure prune of pod2 not skipped
- Add optional klog support for e2e tests