### PR TITLE
Fix flaky continue on error test

### DIFF
--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -111,6 +111,7 @@ const (
 )
 
 type ApplyEvent struct {
+	GroupName  string
 	Identifier object.ObjMetadata
 	Operation  ApplyEventOperation
 	Resource   *unstructured.Unstructured
@@ -134,6 +135,7 @@ const (
 )
 
 type PruneEvent struct {
+	GroupName  string
 	Identifier object.ObjMetadata
 	Operation  PruneEventOperation
 	Object     *unstructured.Unstructured
@@ -152,6 +154,7 @@ const (
 )
 
 type DeleteEvent struct {
+	GroupName  string
 	Identifier object.ObjMetadata
 	Operation  DeleteEventOperation
 	Object     *unstructured.Unstructured

--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -20,21 +20,28 @@ type EventFactory interface {
 
 // CreateEventFactory returns the correct concrete version of
 // an EventFactory based on the passed boolean.
-func CreateEventFactory(isDelete bool) EventFactory {
+func CreateEventFactory(isDelete bool, groupName string) EventFactory {
 	if isDelete {
-		return DeleteEventFactory{}
+		return DeleteEventFactory{
+			groupName: groupName,
+		}
 	}
-	return PruneEventFactory{}
+	return PruneEventFactory{
+		groupName: groupName,
+	}
 }
 
 // PruneEventFactory implements EventFactory interface as a concrete
 // representation of for prune events.
-type PruneEventFactory struct{}
+type PruneEventFactory struct {
+	groupName string
+}
 
 func (pef PruneEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) event.Event {
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
+			GroupName:  pef.groupName,
 			Operation:  event.Pruned,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMetaOrDie(obj),
@@ -46,6 +53,7 @@ func (pef PruneEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured, 
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
+			GroupName:  pef.groupName,
 			Operation:  event.PruneSkipped,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMetaOrDie(obj),
@@ -58,6 +66,7 @@ func (pef PruneEventFactory) CreateFailedEvent(id object.ObjMetadata, err error)
 	return event.Event{
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
+			GroupName:  pef.groupName,
 			Identifier: id,
 			Error:      err,
 		},
@@ -66,12 +75,15 @@ func (pef PruneEventFactory) CreateFailedEvent(id object.ObjMetadata, err error)
 
 // DeleteEventFactory implements EventFactory interface as a concrete
 // representation of for delete events.
-type DeleteEventFactory struct{}
+type DeleteEventFactory struct {
+	groupName string
+}
 
 func (def DeleteEventFactory) CreateSuccessEvent(obj *unstructured.Unstructured) event.Event {
 	return event.Event{
 		Type: event.DeleteType,
 		DeleteEvent: event.DeleteEvent{
+			GroupName:  def.groupName,
 			Operation:  event.Deleted,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMetaOrDie(obj),
@@ -83,6 +95,7 @@ func (def DeleteEventFactory) CreateSkippedEvent(obj *unstructured.Unstructured,
 	return event.Event{
 		Type: event.DeleteType,
 		DeleteEvent: event.DeleteEvent{
+			GroupName:  def.groupName,
 			Operation:  event.DeleteSkipped,
 			Object:     obj,
 			Identifier: object.UnstructuredToObjMetaOrDie(obj),
@@ -95,6 +108,7 @@ func (def DeleteEventFactory) CreateFailedEvent(id object.ObjMetadata, err error
 	return event.Event{
 		Type: event.DeleteType,
 		DeleteEvent: event.DeleteEvent{
+			GroupName:  def.groupName,
 			Identifier: id,
 			Error:      err,
 		},

--- a/pkg/apply/prune/event-factory_test.go
+++ b/pkg/apply/prune/event-factory_test.go
@@ -34,7 +34,7 @@ func TestEventFactory(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			id, err := object.UnstructuredToObjMeta(tc.obj)
 			require.NoError(t, err)
-			eventFactory := CreateEventFactory(tc.destroy)
+			eventFactory := CreateEventFactory(tc.destroy, "task-0")
 			// Validate the "success" event"
 			actualEvent := eventFactory.CreateSuccessEvent(tc.obj)
 			if tc.expectedType != actualEvent.Type {

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -85,12 +85,15 @@ type Options struct {
 //   pruneObjs - objects to prune (delete)
 //   pruneFilters - list of filters for deletion permission
 //   taskContext - task for apply/prune
+//   taskName - name of the parent task group, for events
 //   o - options for dry-run
 func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 	pruneFilters []filter.ValidationFilter,
 	taskContext *taskrunner.TaskContext,
-	o Options) error {
-	eventFactory := CreateEventFactory(o.Destroy)
+	taskName string,
+	o Options,
+) error {
+	eventFactory := CreateEventFactory(o.Destroy, taskName)
 	// Iterate through objects to prune (delete). If an object is not pruned
 	// and we need to keep it in the inventory, we must capture the prune failure.
 	for _, pruneObj := range pruneObjs {

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -401,7 +401,7 @@ func TestPrune(t *testing.T) {
 			err = func() error {
 				defer close(eventChannel)
 				// Run the prune and validate.
-				return po.Prune(tc.pruneObjs, tc.pruneFilters, taskContext, tc.options)
+				return po.Prune(tc.pruneObjs, tc.pruneFilters, taskContext, "test-0", tc.options)
 			}()
 
 			if err != nil {
@@ -498,7 +498,7 @@ func TestPruneWithErrors(t *testing.T) {
 					opts = defaultOptions
 				}
 				// Run the prune and validate.
-				return po.Prune(tc.pruneObjs, []filter.ValidationFilter{}, taskContext, opts)
+				return po.Prune(tc.pruneObjs, []filter.ValidationFilter{}, taskContext, "test-0", opts)
 			}()
 			if err != nil {
 				t.Fatalf("Unexpected error during Prune(): %#v", err)
@@ -626,7 +626,7 @@ func TestPrune_PropagationPolicy(t *testing.T) {
 			eventChannel := make(chan event.Event, 1)
 			resourceCache := cache.NewResourceCacheMap()
 			taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
-			err := po.Prune([]*unstructured.Unstructured{pdb}, []filter.ValidationFilter{}, taskContext, Options{
+			err := po.Prune([]*unstructured.Unstructured{pdb}, []filter.ValidationFilter{}, taskContext, "test-0", Options{
 				PropagationPolicy: tc.propagationPolicy,
 			})
 			assert.NoError(t, err)

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -86,7 +86,7 @@ func TestApplyTask_BasicAppliedObjects(t *testing.T) {
 			objs := toUnstructureds(tc.applied)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return &fakeApplyOptions{}, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -172,7 +172,7 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 			objs := toUnstructureds(tc.rss)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return &fakeApplyOptions{}, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -293,7 +293,7 @@ func TestApplyTask_DryRun(t *testing.T) {
 
 				ao := &fakeApplyOptions{}
 				oldAO := applyOptionsFactoryFunc
-				applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+				applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 					return ao, nil
 				}
 				defer func() { applyOptionsFactoryFunc = oldAO }()
@@ -428,7 +428,7 @@ func TestApplyTaskWithError(t *testing.T) {
 
 			ao := &fakeApplyOptions{}
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
+			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
 				return ao, nil
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()

--- a/pkg/apply/task/printer_adapter_test.go
+++ b/pkg/apply/task/printer_adapter_test.go
@@ -19,7 +19,8 @@ func TestKubectlPrinterAdapter(t *testing.T) {
 	operation := "serverside-applied"
 
 	adapter := KubectlPrinterAdapter{
-		ch: ch,
+		ch:        ch,
+		groupName: "test-0",
 	}
 
 	toPrinterFunc := adapter.toPrinterFunc()

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -53,19 +53,24 @@ func (p *PruneTask) Identifiers() []object.ObjMetadata {
 // to signal to the taskrunner that the task has completed (or failed).
 func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		klog.V(2).Infof("prune task starting (%d objects)", len(p.Objects))
+		klog.V(2).Infof("prune task starting (objects: %d, name: %q)", len(p.Objects), p.Name())
 		// Create filter to prevent deletion of currently applied
 		// objects. Must be done here to wait for applied UIDs.
 		uidFilter := filter.CurrentUIDFilter{
 			CurrentUIDs: taskContext.AppliedResourceUIDs(),
 		}
 		p.Filters = append(p.Filters, uidFilter)
-		err := p.PruneOptions.Prune(p.Objects,
-			p.Filters, taskContext, prune.Options{
+		err := p.PruneOptions.Prune(
+			p.Objects,
+			p.Filters,
+			taskContext,
+			p.Name(),
+			prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,
 				PropagationPolicy: p.PropagationPolicy,
 				Destroy:           p.Destroy,
-			})
+			},
+		)
 		taskContext.TaskChannel() <- taskrunner.TaskResult{
 			Err: err,
 		}

--- a/pkg/testutil/events.go
+++ b/pkg/testutil/events.go
@@ -30,12 +30,13 @@ type ExpInitEvent struct {
 }
 
 type ExpActionGroupEvent struct {
-	Name   string
-	Action event.ResourceAction
-	Type   event.ActionGroupEventType
+	GroupName string
+	Action    event.ResourceAction
+	Type      event.ActionGroupEventType
 }
 
 type ExpApplyEvent struct {
+	GroupName  string
 	Operation  event.ApplyEventOperation
 	Identifier object.ObjMetadata
 	Error      error
@@ -48,12 +49,14 @@ type ExpStatusEvent struct {
 }
 
 type ExpPruneEvent struct {
+	GroupName  string
 	Operation  event.PruneEventOperation
 	Identifier object.ObjMetadata
 	Error      error
 }
 
 type ExpDeleteEvent struct {
+	GroupName  string
 	Operation  event.DeleteEventOperation
 	Identifier object.ObjMetadata
 	Error      error
@@ -97,7 +100,7 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 
 		age := e.ActionGroupEvent
 
-		if agee.Name != age.GroupName {
+		if agee.GroupName != age.GroupName {
 			return false
 		}
 
@@ -118,6 +121,12 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 
 		if aee.Identifier != object.NilObjMetadata {
 			if aee.Identifier != ae.Identifier {
+				return false
+			}
+		}
+
+		if aee.GroupName != "" {
+			if aee.GroupName != ae.GroupName {
 				return false
 			}
 		}
@@ -164,6 +173,12 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 			}
 		}
 
+		if pee.GroupName != "" {
+			if pee.GroupName != pe.GroupName {
+				return false
+			}
+		}
+
 		if pee.Operation != pe.Operation {
 			return false
 		}
@@ -182,6 +197,12 @@ func isMatch(ee ExpEvent, e event.Event) bool {
 
 		if dee.Identifier != object.NilObjMetadata {
 			if dee.Identifier != de.Identifier {
+				return false
+			}
+		}
+
+		if dee.GroupName != "" {
+			if dee.GroupName != de.GroupName {
 				return false
 			}
 		}
@@ -221,9 +242,9 @@ func EventToExpEvent(e event.Event) ExpEvent {
 		return ExpEvent{
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &ExpActionGroupEvent{
-				Name:   e.ActionGroupEvent.GroupName,
-				Action: e.ActionGroupEvent.Action,
-				Type:   e.ActionGroupEvent.Type,
+				GroupName: e.ActionGroupEvent.GroupName,
+				Action:    e.ActionGroupEvent.Action,
+				Type:      e.ActionGroupEvent.Type,
 			},
 		}
 
@@ -231,6 +252,7 @@ func EventToExpEvent(e event.Event) ExpEvent {
 		return ExpEvent{
 			EventType: event.ApplyType,
 			ApplyEvent: &ExpApplyEvent{
+				GroupName:  e.ApplyEvent.GroupName,
 				Identifier: e.ApplyEvent.Identifier,
 				Operation:  e.ApplyEvent.Operation,
 				Error:      e.ApplyEvent.Error,
@@ -251,6 +273,7 @@ func EventToExpEvent(e event.Event) ExpEvent {
 		return ExpEvent{
 			EventType: event.PruneType,
 			PruneEvent: &ExpPruneEvent{
+				GroupName:  e.PruneEvent.GroupName,
 				Identifier: e.PruneEvent.Identifier,
 				Operation:  e.PruneEvent.Operation,
 				Error:      e.PruneEvent.Error,
@@ -261,6 +284,7 @@ func EventToExpEvent(e event.Event) ExpEvent {
 		return ExpEvent{
 			EventType: event.DeleteType,
 			DeleteEvent: &ExpDeleteEvent{
+				GroupName:  e.DeleteEvent.GroupName,
 				Identifier: e.DeleteEvent.Identifier,
 				Operation:  e.DeleteEvent.Operation,
 				Error:      e.DeleteEvent.Error,

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -46,33 +46,34 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Create deployment
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(deployment1), namespaceName)),
 				Error:      nil,
@@ -82,45 +83,45 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -185,15 +186,16 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete deployment
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-0",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(deployment1), namespaceName)),
 				Error:      nil,
@@ -203,9 +205,9 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Finished,
 			},
 		},
 		// TODO: Why is waiting skipped on destroy?
@@ -231,18 +233,18 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// DeleteInvTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -41,33 +41,34 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply invalidCrd fails
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(invalidCrd)),
 				Error: testutil.EqualErrorType(
 					applyerror.NewApplyRunError(errors.New("failed to apply")),
@@ -78,6 +79,7 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// Create pod1
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod1), namespaceName)),
 				Error:      nil,
@@ -87,9 +89,9 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		// Note: No WaitTask when apply fails
@@ -116,18 +118,18 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"errors"
+	"sort"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -133,7 +134,10 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 			},
 		},
 	}
-	Expect(testutil.EventsToExpEvents(applierEvents)).To(testutil.Equal(expEvents))
+	receivedEvents := testutil.EventsToExpEvents(applierEvents)
+	// sort to allow comparison of multiple ApplyTasks in the same task group
+	sort.Sort(testutil.GroupedEventsByID(receivedEvents))
+	Expect(receivedEvents).To(testutil.Equal(expEvents))
 
 	By("Verify pod1 created")
 	assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod1), namespaceName))

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -45,33 +45,34 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply CRD before custom resource
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(crd)),
 				Error:      nil,
@@ -81,42 +82,43 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply CRD before custom resource
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-1",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(cr)),
 				Error:      nil,
@@ -126,45 +128,45 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -185,15 +187,16 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete custom resource first
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-0",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(cr)),
 				Error:      nil,
@@ -203,42 +206,43 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete CRD after custom resource
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-1",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(manifestToUnstructured(crd)),
 				Error:      nil,
@@ -248,45 +252,45 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// DeleteInvTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -46,33 +46,34 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply Pod2 first
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod2), namespaceName)),
 				Error:      nil,
@@ -82,42 +83,43 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply pod3 second
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-1",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod3), namespaceName)),
 				Error:      nil,
@@ -127,42 +129,43 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-2",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-2",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply pod1 third
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-2",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod1), namespaceName)),
 				Error:      nil,
@@ -172,45 +175,45 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-2",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-2",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-2",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-2",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-2",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-2",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -252,15 +255,16 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete pod1 first
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-0",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod1), namespaceName)),
 				Error:      nil,
@@ -270,42 +274,43 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete pod3 second
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-1",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod3), namespaceName)),
 				Error:      nil,
@@ -315,42 +320,43 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-2",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-2",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete pod2 third
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-2",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod2), namespaceName)),
 				Error:      nil,
@@ -360,45 +366,45 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-2",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-2",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-2",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-2",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-2",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-2",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// DeleteInvTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/inventory_policy_test.go
+++ b/test/e2e/inventory_policy_test.go
@@ -59,33 +59,34 @@ func inventoryPolicyMustMatchTest(c client.Client, invConfig InventoryConfig, na
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// ApplyTask error: resource managed by another inventory
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(deployment1), namespaceName)),
 				Error: testutil.EqualErrorType(
 					inventory.NewInventoryOverlapError(errors.New("test")),
@@ -96,45 +97,45 @@ func inventoryPolicyMustMatchTest(c client.Client, invConfig InventoryConfig, na
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -206,33 +207,34 @@ func inventoryPolicyAdoptIfNoInventoryTest(c client.Client, invConfig InventoryC
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply deployment
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Configured,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(deployment1), namespaceName)),
 				Error:      nil,
@@ -242,45 +244,45 @@ func inventoryPolicyAdoptIfNoInventoryTest(c client.Client, invConfig InventoryC
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -367,33 +369,34 @@ func inventoryPolicyAdoptAllTest(c client.Client, invConfig InventoryConfig, nam
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply deployment
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Configured,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(deployment1), namespaceName)),
 				Error:      nil,
@@ -403,45 +406,45 @@ func inventoryPolicyAdoptAllTest(c client.Client, invConfig InventoryConfig, nam
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/mutation_test.go
+++ b/test/e2e/mutation_test.go
@@ -58,33 +58,34 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply PodB first
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(podB), namespaceName)),
 				Error:      nil,
@@ -94,42 +95,43 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Apply pod3 second
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-1",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(podA), namespaceName)),
 				Error:      nil,
@@ -139,45 +141,45 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-1",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -226,15 +228,16 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete podA first
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-0",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(podA), namespaceName)),
 				Error:      nil,
@@ -244,42 +247,43 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-0",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete pod3 second
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
+				GroupName:  "prune-1",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(podB), namespaceName)),
 				Error:      nil,
@@ -289,45 +293,45 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-1",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// WaitTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Started,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Started,
 			},
 		},
 		{
 			// WaitTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.WaitAction,
-				Name:   "wait-1",
-				Type:   event.Finished,
+				Action:    event.WaitAction,
+				GroupName: "wait-1",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// DeleteInvTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Finished,
 			},
 		},
 	}

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -44,33 +44,34 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Create deployment
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod1), namespaceName)),
 				Error:      nil,
@@ -80,9 +81,9 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		// TODO: Why no waiting???
@@ -108,18 +109,18 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -155,33 +156,34 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// InvAddTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvAddTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-add-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
 			},
 		},
 		{
 			// ApplyTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Started,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Create pod2
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
 				Operation:  event.Created,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod2), namespaceName)),
 				Error:      nil,
@@ -191,9 +193,9 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// ApplyTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.ApplyAction,
-				Name:   "apply-0",
-				Type:   event.Finished,
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
 			},
 		},
 		// Don't prune pod1, it should already be deleted.
@@ -220,18 +222,18 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// InvSetTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// InvSetTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "inventory-set-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
 			},
 		},
 	}
@@ -264,16 +266,16 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// PruneTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Started,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// Delete pod2
 			EventType: event.DeleteType,
 			DeleteEvent: &testutil.ExpDeleteEvent{
-				// TODO: this delete is flakey (sometimes skipped), because there's no WaitTask after creation
+				GroupName:  "prune-0",
 				Operation:  event.Deleted,
 				Identifier: object.UnstructuredToObjMetaOrDie(withNamespace(manifestToUnstructured(pod2), namespaceName)),
 				Error:      nil,
@@ -283,9 +285,9 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// PruneTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.DeleteAction,
-				Name:   "prune-0",
-				Type:   event.Finished,
+				Action:    event.DeleteAction,
+				GroupName: "prune-0",
+				Type:      event.Finished,
 			},
 		},
 		// TODO: Why is waiting skipped on destroy?
@@ -311,18 +313,18 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Started,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Started,
 			},
 		},
 		{
 			// DeleteInvTask finished
 			EventType: event.ActionGroupType,
 			ActionGroupEvent: &testutil.ExpActionGroupEvent{
-				Action: event.InventoryAction,
-				Name:   "delete-inventory-0",
-				Type:   event.Finished,
+				Action:    event.InventoryAction,
+				GroupName: "delete-inventory-0",
+				Type:      event.Finished,
 			},
 		},
 	}


### PR DESCRIPTION
1. Add GroupName to Apply, Prune, and Delete events
    - GroupName can be used to identify which ActionGroupEvent the
      Apply/Prune/Delete belongs to. This is useful for tracking progress
      during a long apply/destroy.
2. Fix flaky continue on error test
    - Add GroupedEventsByID to impliment a custom sort algorithm fo use by
      tests, to simplify the comparison of otherwise unsorted
      apply/prune/delete events in an action group.
