### PR TITLE
Skip InventoryPolicyApplyFilter for the `AdoptAll` inventory policy to improve the performance

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -173,14 +173,16 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 			InventoryPolicy:        options.InventoryPolicy,
 		}
 		// Build list of apply validation filters.
-		applyFilters := []filter.ValidationFilter{
-			filter.InventoryPolicyApplyFilter{
+		applyFilters := []filter.ValidationFilter{}
+		if options.InventoryPolicy != inventory.AdoptAll {
+			applyFilters = append(applyFilters, filter.InventoryPolicyApplyFilter{
 				Client:    client,
 				Mapper:    mapper,
 				Inv:       invInfo,
 				InvPolicy: options.InventoryPolicy,
-			},
+			})
 		}
+
 		// Build list of prune validation filters.
 		pruneFilters := []filter.ValidationFilter{
 			filter.PreventRemoveFilter{},


### PR DESCRIPTION
Running InventoryPolicyApplyFilter involves getting every object in the
current inventory from the live cluster, which can be expensive if the
inventory includes lots of objects.

If the inventory policy is `AdoptAll`, the current inventory can take
ownership of any objects. Therefore, it is not necessary to run
InventoryPolicyApplyFilter.