### PR TITLE
Add global destroyer timeouts

### DIFF
--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -4,6 +4,7 @@
 package destroy
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -117,7 +118,7 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
 	printStatusEvents := r.deleteTimeout != time.Duration(0)
-	ch := d.Run(inv, apply.DestroyerOptions{
+	ch := d.Run(context.Background(), inv, apply.DestroyerOptions{
 		DeleteTimeout:           r.deleteTimeout,
 		DeletePropagationPolicy: deletePropPolicy,
 		InventoryPolicy:         inventoryPolicy,

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -139,12 +139,9 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// Create a context
-		ctx := context.Background()
-
 		// Run the applier. It will return a channel where we can receive updates
 		// to keep track of progress and any issues.
-		ch = a.Run(ctx, inv, objs, apply.Options{
+		ch = a.Run(context.Background(), inv, objs, apply.Options{
 			EmitStatusEvents:  false,
 			NoPrune:           noPrune,
 			DryRunStrategy:    drs,
@@ -156,7 +153,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		ch = d.Run(inv, apply.DestroyerOptions{
+		ch = d.Run(context.Background(), inv, apply.DestroyerOptions{
 			InventoryPolicy: inventoryPolicy,
 			DryRunStrategy:  drs,
 		})

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -89,7 +89,7 @@ func setDestroyerDefaults(o *DestroyerOptions) {
 // Run performs the destroy step. Passes the inventory object. This
 // happens asynchronously on progress and any errors are reported
 // back on the event channel.
-func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <-chan event.Event {
+func (d *Destroyer) Run(ctx context.Context, inv inventory.InventoryInfo, options DestroyerOptions) <-chan event.Event {
 	eventChannel := make(chan event.Event)
 	setDestroyerDefaults(&options)
 	go func() {
@@ -153,7 +153,7 @@ func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <
 		runner := taskrunner.NewTaskStatusRunner(deleteIds, d.statusPoller, resourceCache)
 		klog.V(4).Infoln("destroyer running TaskStatusRunner...")
 		// TODO(seans): Make the poll interval configurable like the applier.
-		err = runner.Run(context.Background(), taskQueue.ToChannel(), eventChannel, taskrunner.Options{
+		err = runner.Run(ctx, taskQueue.ToChannel(), eventChannel, taskrunner.Options{
 			UseCache:         true,
 			PollInterval:     options.PollInterval,
 			EmitStatusEvents: options.EmitStatusEvents,

--- a/pkg/apply/destroyer_test.go
+++ b/pkg/apply/destroyer_test.go
@@ -1,0 +1,348 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestDestroyerCancel(t *testing.T) {
+	testCases := map[string]struct {
+		// inventory input to destroyer
+		invInfo inventoryInfo
+		// objects in the cluster
+		clusterObjs object.UnstructuredSet
+		// options input to destroyer.Run
+		options DestroyerOptions
+		// timeout for destroyer.Run
+		runTimeout time.Duration
+		// timeout for the test
+		testTimeout time.Duration
+		// fake input events from the status poller
+		statusEvents []pollevent.Event
+		// expected output status events (async)
+		expectedStatusEvents []testutil.ExpEvent
+		// expected output events
+		expectedEvents []testutil.ExpEvent
+		// true if runTimeout is expected to have caused cancellation
+		expectRunTimeout bool
+	}{
+		"cancelled by caller while waiting for deletion": {
+			expectRunTimeout: true,
+			runTimeout:       2 * time.Second,
+			testTimeout:      30 * time.Second,
+			invInfo: inventoryInfo{
+				name:      "abc-123",
+				namespace: "test",
+				id:        "test",
+				set: object.ObjMetadataSet{
+					testutil.ToIdentifier(t, resources["deployment"]),
+				},
+			},
+			clusterObjs: object.UnstructuredSet{
+				testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
+			},
+			options: DestroyerOptions{
+				EmitStatusEvents: true,
+				// DeleteTimeout needs to block long enough to cancel the run,
+				// otherwise the WaitTask is skipped.
+				DeleteTimeout: 1 * time.Minute,
+			},
+			statusEvents: []pollevent.Event{
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.InProgressStatus,
+						Resource:   testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
+					},
+				},
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.InProgressStatus,
+						Resource:   testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
+					},
+				},
+				// Resource never becomes NotFound, blocking destroyer.Run from exiting
+			},
+			expectedStatusEvents: []testutil.ExpEvent{
+				{
+					EventType: event.StatusType,
+					StatusEvent: &testutil.ExpStatusEvent{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.InProgressStatus,
+					},
+				},
+			},
+			expectedEvents: []testutil.ExpEvent{
+				{
+					// InitTask
+					EventType: event.InitType,
+					InitEvent: &testutil.ExpInitEvent{},
+				},
+				{
+					// PruneTask start
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.DeleteAction,
+						GroupName: "prune-0",
+						Type:      event.Started,
+					},
+				},
+				{
+					// Delete Deployment
+					EventType: event.DeleteType,
+					DeleteEvent: &testutil.ExpDeleteEvent{
+						GroupName:  "prune-0",
+						Operation:  event.Deleted,
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Error:      nil,
+					},
+				},
+				{
+					// PruneTask finished
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.DeleteAction,
+						GroupName: "prune-0",
+						Type:      event.Finished,
+					},
+				},
+				{
+					// WaitTask start
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.WaitAction,
+						GroupName: "wait-0",
+						Type:      event.Started,
+					},
+				},
+				// Deployment never becomes NotFound.
+				// WaitTask is expected to be cancelled before DeleteTimeout.
+				{
+					// WaitTask finished
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.WaitAction,
+						GroupName: "wait-0",
+						Type:      event.Finished, // TODO: add Cancelled event type
+					},
+				},
+				// Inventory cannot be deleted, because the objects still exist,
+				// even tho they've been deleted (ex: blocked by finalizer).
+			},
+		},
+		"completed with timeout": {
+			expectRunTimeout: false,
+			runTimeout:       10 * time.Second,
+			testTimeout:      30 * time.Second,
+			invInfo: inventoryInfo{
+				name:      "abc-123",
+				namespace: "test",
+				id:        "test",
+				set: object.ObjMetadataSet{
+					testutil.ToIdentifier(t, resources["deployment"]),
+				},
+			},
+			clusterObjs: object.UnstructuredSet{
+				testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
+			},
+			options: DestroyerOptions{
+				EmitStatusEvents: true,
+				// DeleteTimeout needs to block long enough for completion
+				DeleteTimeout: 1 * time.Minute,
+			},
+			statusEvents: []pollevent.Event{
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.InProgressStatus,
+						Resource:   testutil.Unstructured(t, resources["deployment"], testutil.AddOwningInv(t, "test")),
+					},
+				},
+				{
+					EventType: pollevent.ResourceUpdateEvent,
+					Resource: &pollevent.ResourceStatus{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.NotFoundStatus,
+					},
+				},
+				// Resource becoming NotFound should unblock destroyer.Run WaitTask
+			},
+			expectedStatusEvents: []testutil.ExpEvent{
+				{
+					EventType: event.StatusType,
+					StatusEvent: &testutil.ExpStatusEvent{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.InProgressStatus,
+					},
+				},
+				{
+					EventType: event.StatusType,
+					StatusEvent: &testutil.ExpStatusEvent{
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Status:     status.NotFoundStatus,
+					},
+				},
+			},
+			expectedEvents: []testutil.ExpEvent{
+				{
+					// InitTask
+					EventType: event.InitType,
+					InitEvent: &testutil.ExpInitEvent{},
+				},
+				{
+					// PruneTask start
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.DeleteAction,
+						GroupName: "prune-0",
+						Type:      event.Started,
+					},
+				},
+				{
+					// Delete Deployment
+					EventType: event.DeleteType,
+					DeleteEvent: &testutil.ExpDeleteEvent{
+						GroupName:  "prune-0",
+						Operation:  event.Deleted,
+						Identifier: testutil.ToIdentifier(t, resources["deployment"]),
+						Error:      nil,
+					},
+				},
+				{
+					// PruneTask finished
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.DeleteAction,
+						GroupName: "prune-0",
+						Type:      event.Finished,
+					},
+				},
+				{
+					// WaitTask start
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.WaitAction,
+						GroupName: "wait-0",
+						Type:      event.Started,
+					},
+				},
+				// Deployment becomes NotFound.
+				{
+					// WaitTask finished
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.WaitAction,
+						GroupName: "wait-0",
+						Type:      event.Finished,
+					},
+				},
+				{
+					// DeleteInvTask start
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.InventoryAction,
+						GroupName: "delete-inventory-0",
+						Type:      event.Started,
+					},
+				},
+				{
+					// DeleteInvTask finished
+					EventType: event.ActionGroupType,
+					ActionGroupEvent: &testutil.ExpActionGroupEvent{
+						Action:    event.InventoryAction,
+						GroupName: "delete-inventory-0",
+						Type:      event.Finished,
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			poller := newFakePoller(tc.statusEvents)
+
+			invInfo := tc.invInfo.toWrapped()
+
+			destroyer := newTestDestroyer(t,
+				tc.invInfo,
+				// Add the inventory to the cluster (to allow deletion)
+				append(tc.clusterObjs, inventory.InvInfoToConfigMap(invInfo)),
+				poller,
+			)
+
+			// Context for Destroyer.Run
+			runCtx, runCancel := context.WithTimeout(context.Background(), tc.runTimeout)
+			defer runCancel() // cleanup
+
+			// Context for this test (in case Destroyer.Run never closes the event channel)
+			testCtx, testCancel := context.WithTimeout(context.Background(), tc.testTimeout)
+			defer testCancel() // cleanup
+
+			eventChannel := destroyer.Run(runCtx, invInfo, tc.options)
+
+			// Start sending status events
+			poller.Start()
+
+			var events []event.Event
+
+		loop:
+			for {
+				select {
+				case <-testCtx.Done():
+					// Test timed out
+					runCancel()
+					t.Errorf("Destroyer.Run failed to respond to cancellation (expected: %s, timeout: %s)", tc.runTimeout, tc.testTimeout)
+					break loop
+
+				case e, ok := <-eventChannel:
+					if !ok {
+						// Event channel closed
+						testCancel()
+						break loop
+					}
+					events = append(events, e)
+				}
+			}
+
+			// Convert events to test events for comparison
+			receivedEvents := testutil.EventsToExpEvents(events)
+
+			// Validate & remove expected status events
+			for _, e := range tc.expectedStatusEvents {
+				var removed int
+				receivedEvents, removed = testutil.RemoveEqualEvents(receivedEvents, e)
+				if removed < 1 {
+					t.Errorf("Expected status event not received: %#v", e)
+				}
+			}
+
+			// Validate the rest of the events
+			testutil.AssertEqual(t, receivedEvents, tc.expectedEvents)
+
+			// Validate that the expected timeout was the cause of the run completion.
+			// just in case something else cancelled the run
+			if tc.expectRunTimeout {
+				assert.Equal(t, context.DeadlineExceeded, runCtx.Err(), "Destroyer.Run exited, but not by expected timeout")
+			} else {
+				assert.Nil(t, runCtx.Err(), "Destroyer.Run exited, but not by expected timeout")
+			}
+		})
+	}
+}

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -281,7 +281,7 @@ func (cic *ClusterInventoryClient) getClusterInventoryObjsByLabel(inv InventoryI
 		return nil, err
 	}
 	labelSelector := fmt.Sprintf("%s=%s", common.InventoryLabel, label)
-	klog.V(4).Infof("prune inventory object fetch: %s/%s/%s", groupResource, namespace, labelSelector)
+	klog.V(4).Infof("inventory object fetch by label (group: %q, namespace: %q, selector: %q)", groupResource, namespace, labelSelector)
 	builder := cic.builderFunc()
 	retrievedInventoryInfos, err := builder.
 		Unstructured().
@@ -316,6 +316,7 @@ func (cic *ClusterInventoryClient) getClusterInventoryObjsByName(inv InventoryIn
 		return nil, err
 	}
 
+	klog.V(4).Infof("inventory object fetch by name (namespace: %q, name: %q)", inv.Namespace(), inv.Name())
 	res, err := helper.Get(inv.Namespace(), inv.Name())
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, err

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -174,7 +174,7 @@ func applyAndDestroyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	destroyer := invConfig.DestroyerFactoryFunc()
 
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(inventoryInfo, options))
+	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inventoryInfo, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -175,7 +175,7 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 	By("destroy the resources, including the crd")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -243,7 +243,7 @@ func dependsOnTest(c client.Client, invConfig InventoryConfig, inventoryName, na
 	By("destroy resources in opposite order")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/mutation_test.go
+++ b/test/e2e/mutation_test.go
@@ -216,7 +216,7 @@ func mutationTest(c client.Client, invConfig InventoryConfig, inventoryName, nam
 	By("destroy resources in opposite order")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -254,7 +254,7 @@ func pruneRetrieveErrorTest(c client.Client, invConfig InventoryConfig, inventor
 	destroyer := invConfig.DestroyerFactoryFunc()
 
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(inv, options))
+	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inv, options))
 
 	expEvents3 := []testutil.ExpEvent{
 		{


### PR DESCRIPTION
- Destroyer context added, with cancellation test.
- Added a few logs to help with debugging test failures

After this lands, we can follow up with...
- https://github.com/kubernetes-sigs/cli-utils/issues/433
- https://github.com/kubernetes-sigs/cli-utils/issues/432
