### PR TITLE
Update owners file to only include active contributors

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - pwittrock
   - seans3
-  - soltysh
   - liujingfang1
-  - barney-s
   - mortent
+
+reviewers:
+  - seans3
+  - liujingfang1
+  - mortent
+  - ash2k
+  - karlkfi
+  - haiyanmeng


### PR DESCRIPTION
Update the OWNERS file to only include people who are actively contributing. I think this will make sure that the right people automatically assigned to PRs.