### PR TITLE
Add UnstructuredSet to encapsulate set functions

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -69,8 +68,8 @@ type Applier struct {
 
 // prepareObjects returns the set of objects to apply and to prune or
 // an error if one occurred.
-func (a *Applier) prepareObjects(localInv inventory.InventoryInfo, localObjs []*unstructured.Unstructured,
-	o Options) ([]*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+func (a *Applier) prepareObjects(localInv inventory.InventoryInfo, localObjs object.UnstructuredSet,
+	o Options) (object.UnstructuredSet, object.UnstructuredSet, error) {
 	if localInv == nil {
 		return nil, nil, fmt.Errorf("the local inventory can't be nil")
 	}
@@ -119,7 +118,7 @@ func (a *Applier) prepareObjects(localInv inventory.InventoryInfo, localObjs []*
 // before all the given resources have been applied to the cluster. Any
 // cancellation or timeout will only affect how long we Wait for the
 // resources to become current.
-func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, objects []*unstructured.Unstructured, options Options) <-chan event.Event {
+func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, objects object.UnstructuredSet, options Options) <-chan event.Event {
 	klog.V(4).Infof("apply run for %d objects", len(objects))
 	eventChannel := make(chan event.Event)
 	setDefaults(&options)

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
@@ -97,7 +96,7 @@ func (d *Destroyer) Run(inv inventory.InventoryInfo, options DestroyerOptions) <
 		defer close(eventChannel)
 		// Retrieve the objects to be deleted from the cluster. Second parameter is empty
 		// because no local objects returns all inventory objects for deletion.
-		emptyLocalObjs := []*unstructured.Unstructured{}
+		emptyLocalObjs := object.UnstructuredSet{}
 		deleteObjs, err := d.pruneOptions.GetPruneObjs(inv, emptyLocalObjs, prune.Options{
 			DryRunStrategy: options.DryRunStrategy,
 		})

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -87,7 +87,7 @@ type Options struct {
 //   taskContext - task for apply/prune
 //   taskName - name of the parent task group, for events
 //   o - options for dry-run
-func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
+func (po *PruneOptions) Prune(pruneObjs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter,
 	taskContext *taskrunner.TaskContext,
 	taskName string,
@@ -158,14 +158,14 @@ func (po *PruneOptions) Prune(pruneObjs []*unstructured.Unstructured,
 // objects minus the set of currently applied objects. Returns an error
 // if one occurs.
 func (po *PruneOptions) GetPruneObjs(inv inventory.InventoryInfo,
-	localObjs []*unstructured.Unstructured, o Options) ([]*unstructured.Unstructured, error) {
+	localObjs object.UnstructuredSet, o Options) (object.UnstructuredSet, error) {
 	localIds := object.UnstructuredsToObjMetasOrDie(localObjs)
 	prevInvIds, err := po.InvClient.GetClusterObjs(inv, o.DryRunStrategy)
 	if err != nil {
 		return nil, err
 	}
 	pruneIds := prevInvIds.Diff(localIds)
-	pruneObjs := []*unstructured.Unstructured{}
+	pruneObjs := object.UnstructuredSet{}
 	for _, pruneID := range pruneIds {
 		pruneObj, err := po.GetObject(pruneID)
 		if err != nil {

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -20,7 +20,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -107,7 +106,7 @@ func (t *TaskQueueBuilder) Build() (*TaskQueue, error) {
 
 // AppendInvAddTask appends an inventory add task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyObjs []*unstructured.Unstructured,
+func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyObjs object.UnstructuredSet,
 	dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding inventory add task")
 	t.tasks = append(t.tasks, &task.InvAddTask{
@@ -157,7 +156,7 @@ func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo, dryR
 
 // AppendInvAddTask appends a task to the task queue to apply the passed objects
 // to the cluster. Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendApplyTask(applyObjs []*unstructured.Unstructured,
+func (t *TaskQueueBuilder) AppendApplyTask(applyObjs object.UnstructuredSet,
 	applyFilters []filter.ValidationFilter, applyMutators []mutator.Interface, o Options) *TaskQueueBuilder {
 	klog.V(2).Infof("adding apply task (%d objects)", len(applyObjs))
 	t.tasks = append(t.tasks, &task.ApplyTask{
@@ -193,7 +192,7 @@ func (t *TaskQueueBuilder) AppendWaitTask(waitIds object.ObjMetadataSet, conditi
 
 // AppendInvAddTask appends a task to delete objects from the cluster to the task queue.
 // Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs []*unstructured.Unstructured,
+func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter, o Options) *TaskQueueBuilder {
 	klog.V(2).Infof("adding prune task (%d objects)", len(pruneObjs))
 	t.tasks = append(t.tasks,
@@ -214,7 +213,7 @@ func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs []*unstructured.Unstructure
 // AppendApplyWaitTasks adds apply and wait tasks to the task queue,
 // depending on build variables (like dry-run) and resource types
 // (like CRD's). Returns a pointer to the Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendApplyWaitTasks(applyObjs []*unstructured.Unstructured,
+func (t *TaskQueueBuilder) AppendApplyWaitTasks(applyObjs object.UnstructuredSet,
 	applyFilters []filter.ValidationFilter, applyMutators []mutator.Interface, o Options) *TaskQueueBuilder {
 	// Use the "depends-on" annotation to create a graph, ands sort the
 	// objects to apply into sets using a topological sort.
@@ -237,7 +236,7 @@ func (t *TaskQueueBuilder) AppendApplyWaitTasks(applyObjs []*unstructured.Unstru
 // AppendPruneWaitTasks adds prune and wait tasks to the task queue
 // based on build variables (like dry-run). Returns a pointer to the
 // Builder to chain function calls.
-func (t *TaskQueueBuilder) AppendPruneWaitTasks(pruneObjs []*unstructured.Unstructured,
+func (t *TaskQueueBuilder) AppendPruneWaitTasks(pruneObjs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter, o Options) *TaskQueueBuilder {
 	if o.Prune {
 		// Use the "depends-on" annotation to create a graph, ands sort the

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -49,7 +49,7 @@ type ApplyTask struct {
 	Factory           util.Factory
 	InfoHelper        info.InfoHelper
 	Mapper            meta.RESTMapper
-	Objects           []*unstructured.Unstructured
+	Objects           object.UnstructuredSet
 	Filters           []filter.ValidationFilter
 	Mutators          []mutator.Interface
 	DryRunStrategy    common.DryRunStrategy
@@ -279,7 +279,7 @@ func (a *ApplyTask) createApplyFailedEvent(id object.ObjMetadata, err error) eve
 // a list of resources when failed to initialize the apply process.
 func (a *ApplyTask) sendBatchApplyEvents(
 	taskContext *taskrunner.TaskContext,
-	objects []*unstructured.Unstructured,
+	objects object.UnstructuredSet,
 	err error,
 ) {
 	for _, obj := range objects {

--- a/pkg/apply/task/inv_add_task.go
+++ b/pkg/apply/task/inv_add_task.go
@@ -20,7 +20,7 @@ type InvAddTask struct {
 	TaskName  string
 	InvClient inventory.InventoryClient
 	InvInfo   inventory.InventoryInfo
-	Objects   []*unstructured.Unstructured
+	Objects   object.UnstructuredSet
 	DryRun    common.DryRunStrategy
 }
 
@@ -66,7 +66,7 @@ func (i *InvAddTask) ClearTimeout() {}
 // inventoryNamespaceInSet returns the the namespace the passed inventory
 // object will be applied to, or nil if this namespace object does not exist
 // in the passed slice "infos" or the inventory object is cluster-scoped.
-func inventoryNamespaceInSet(inv inventory.InventoryInfo, objs []*unstructured.Unstructured) *unstructured.Unstructured {
+func inventoryNamespaceInSet(inv inventory.InventoryInfo, objs object.UnstructuredSet) *unstructured.Unstructured {
 	if inv == nil {
 		return nil
 	}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -5,7 +5,6 @@ package task
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/filter"
@@ -22,7 +21,7 @@ type PruneTask struct {
 	TaskName string
 
 	PruneOptions      *prune.PruneOptions
-	Objects           []*unstructured.Unstructured
+	Objects           object.UnstructuredSet
 	Filters           []filter.ValidationFilter
 	DryRunStrategy    common.DryRunStrategy
 	PropagationPolicy metav1.DeletionPropagation

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -95,6 +95,6 @@ func (fic *FakeInventoryClient) GetClusterInventoryInfo(InventoryInfo, common.Dr
 	return nil, nil
 }
 
-func (fic *FakeInventoryClient) GetClusterInventoryObjs(_ InventoryInfo) ([]*unstructured.Unstructured, error) {
-	return []*unstructured.Unstructured{}, nil
+func (fic *FakeInventoryClient) GetClusterInventoryObjs(_ InventoryInfo) (object.UnstructuredSet, error) {
+	return object.UnstructuredSet{}, nil
 }

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -46,7 +46,7 @@ type InventoryToUnstructuredFunc func(InventoryInfo) *unstructured.Unstructured
 
 // FindInventoryObj returns the "Inventory" object (ConfigMap with
 // inventory label) if it exists, or nil if it does not exist.
-func FindInventoryObj(objs []*unstructured.Unstructured) *unstructured.Unstructured {
+func FindInventoryObj(objs object.UnstructuredSet) *unstructured.Unstructured {
 	for _, obj := range objs {
 		if IsInventoryObject(obj) {
 			return obj
@@ -79,10 +79,10 @@ func retrieveInventoryLabel(obj *unstructured.Unstructured) (string, error) {
 	return inventoryLabel, nil
 }
 
-// ValidateNoInventory takes a slice of unstructured.Unstructured objects and
+// ValidateNoInventory takes a set of unstructured.Unstructured objects and
 // validates that no inventory object is in the input slice.
-func ValidateNoInventory(objs []*unstructured.Unstructured) error {
-	invs := make([]*unstructured.Unstructured, 0)
+func ValidateNoInventory(objs object.UnstructuredSet) error {
+	invs := make(object.UnstructuredSet, 0)
 	for _, obj := range objs {
 		if IsInventoryObject(obj) {
 			invs = append(invs, obj)
@@ -96,12 +96,12 @@ func ValidateNoInventory(objs []*unstructured.Unstructured) error {
 	}
 }
 
-// splitUnstructureds takes a slice of unstructured.Unstructured objects and
-// splits it into one slice that contains the inventory object templates and
+// splitUnstructureds takes a set of unstructured.Unstructured objects and
+// splits it into one set that contains the inventory object templates and
 // another one that contains the remaining resources.
-func SplitUnstructureds(objs []*unstructured.Unstructured) (*unstructured.Unstructured, []*unstructured.Unstructured, error) {
-	invs := make([]*unstructured.Unstructured, 0)
-	resources := make([]*unstructured.Unstructured, 0)
+func SplitUnstructureds(objs object.UnstructuredSet) (*unstructured.Unstructured, object.UnstructuredSet, error) {
+	invs := make(object.UnstructuredSet, 0)
+	resources := make(object.UnstructuredSet, 0)
 	for _, obj := range objs {
 		if IsInventoryObject(obj) {
 			invs = append(invs, obj)

--- a/pkg/inventory/inventory_error.go
+++ b/pkg/inventory/inventory_error.go
@@ -5,9 +5,7 @@
 
 package inventory
 
-import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-)
+import "sigs.k8s.io/cli-utils/pkg/object"
 
 const noInventoryErrorStr = `Package uninitialized. Please run "init" command.
 
@@ -34,7 +32,7 @@ func (g NoInventoryObjError) Error() string {
 }
 
 type MultipleInventoryObjError struct {
-	InventoryObjectTemplates []*unstructured.Unstructured
+	InventoryObjectTemplates object.UnstructuredSet
 }
 
 func (g MultipleInventoryObjError) Error() string {

--- a/pkg/object/graph/depends_test.go
+++ b/pkg/object/graph/depends_test.go
@@ -97,19 +97,19 @@ metadata:
 func TestSortObjs(t *testing.T) {
 	testCases := map[string]struct {
 		objs     []*unstructured.Unstructured
-		expected [][]*unstructured.Unstructured
+		expected []object.UnstructuredSet
 		isError  bool
 	}{
 		"no objects returns no object sets": {
 			objs:     []*unstructured.Unstructured{},
-			expected: [][]*unstructured.Unstructured{},
+			expected: []object.UnstructuredSet{},
 			isError:  false,
 		},
 		"one object returns single object set": {
 			objs: []*unstructured.Unstructured{
 				testutil.Unstructured(t, resources["deployment"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["deployment"]),
 				},
@@ -121,7 +121,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["deployment"]),
 				testutil.Unstructured(t, resources["secret"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["deployment"]),
 					testutil.Unstructured(t, resources["secret"]),
@@ -135,7 +135,7 @@ func TestSortObjs(t *testing.T) {
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["secret"]))),
 				testutil.Unstructured(t, resources["secret"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["secret"]),
 				},
@@ -153,7 +153,7 @@ func TestSortObjs(t *testing.T) {
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["pod"]))),
 				testutil.Unstructured(t, resources["pod"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["pod"]),
 				},
@@ -174,7 +174,7 @@ func TestSortObjs(t *testing.T) {
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["secret"]))),
 				testutil.Unstructured(t, resources["secret"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["secret"]),
 				},
@@ -191,7 +191,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["namespace"]),
 				testutil.Unstructured(t, resources["secret"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["namespace"]),
 				},
@@ -208,7 +208,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["crontab2"]),
 				testutil.Unstructured(t, resources["crd"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["crd"]),
 				},
@@ -226,7 +226,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["namespace"]),
 				testutil.Unstructured(t, resources["crd"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["crd"]),
 					testutil.Unstructured(t, resources["namespace"]),
@@ -245,7 +245,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["secret"],
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["deployment"]))),
 			},
-			expected: [][]*unstructured.Unstructured{},
+			expected: []object.UnstructuredSet{},
 			isError:  true,
 		},
 		"three objects in cyclic dependency": {
@@ -257,7 +257,7 @@ func TestSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["pod"],
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["deployment"]))),
 			},
-			expected: [][]*unstructured.Unstructured{},
+			expected: []object.UnstructuredSet{},
 			isError:  true,
 		},
 	}
@@ -278,19 +278,19 @@ func TestSortObjs(t *testing.T) {
 func TestReverseSortObjs(t *testing.T) {
 	testCases := map[string]struct {
 		objs     []*unstructured.Unstructured
-		expected [][]*unstructured.Unstructured
+		expected []object.UnstructuredSet
 		isError  bool
 	}{
 		"no objects returns no object sets": {
 			objs:     []*unstructured.Unstructured{},
-			expected: [][]*unstructured.Unstructured{},
+			expected: []object.UnstructuredSet{},
 			isError:  false,
 		},
 		"one object returns single object set": {
 			objs: []*unstructured.Unstructured{
 				testutil.Unstructured(t, resources["deployment"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["deployment"]),
 				},
@@ -305,7 +305,7 @@ func TestReverseSortObjs(t *testing.T) {
 					testutil.AddDependsOn(t, testutil.ToIdentifier(t, resources["pod"]))),
 				testutil.Unstructured(t, resources["pod"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["deployment"]),
 				},
@@ -324,7 +324,7 @@ func TestReverseSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["namespace"]),
 				testutil.Unstructured(t, resources["secret"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["secret"]),
 					testutil.Unstructured(t, resources["deployment"]),
@@ -342,7 +342,7 @@ func TestReverseSortObjs(t *testing.T) {
 				testutil.Unstructured(t, resources["namespace"]),
 				testutil.Unstructured(t, resources["crd"]),
 			},
-			expected: [][]*unstructured.Unstructured{
+			expected: []object.UnstructuredSet{
 				{
 					testutil.Unstructured(t, resources["crontab1"]),
 					testutil.Unstructured(t, resources["crontab2"]),
@@ -716,7 +716,7 @@ func TestAddCRDEdges(t *testing.T) {
 
 // verifyObjSets ensures the expected and actual slice of object sets are the same,
 // and the sets are in order.
-func verifyObjSets(t *testing.T, expected [][]*unstructured.Unstructured, actual [][]*unstructured.Unstructured) {
+func verifyObjSets(t *testing.T, expected []object.UnstructuredSet, actual []object.UnstructuredSet) {
 	if len(expected) != len(actual) {
 		t.Fatalf("expected (%d) object sets, got (%d)", len(expected), len(actual))
 		return

--- a/pkg/object/objmetadata_set_test.go
+++ b/pkg/object/objmetadata_set_test.go
@@ -87,7 +87,7 @@ func TestObjMetadataSetEquals(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := tc.setA.Equal(tc.setB)
 			if tc.isEqual != actual {
-				t.Errorf("SetEqual expected (%t), got (%t)", tc.isEqual, actual)
+				t.Errorf("Equal expected (%t), got (%t)", tc.isEqual, actual)
 			}
 		})
 	}
@@ -135,7 +135,7 @@ func TestObjMetadataSetUnion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := tc.setA.Union(tc.setB)
 			if !tc.expected.Equal(actual) {
-				t.Errorf("SetDiff expected set (%s), got (%s)", tc.expected, actual)
+				t.Errorf("Union expected set (%s), got (%s)", tc.expected, actual)
 			}
 		})
 	}
@@ -183,7 +183,7 @@ func TestObjMetadataSetDiff(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			actual := tc.setA.Diff(tc.setB)
 			if !tc.expected.Equal(actual) {
-				t.Errorf("SetDiff expected set (%s), got (%s)", tc.expected, actual)
+				t.Errorf("Diff expected set (%s), got (%s)", tc.expected, actual)
 			}
 		})
 	}
@@ -219,7 +219,7 @@ func TestObjMetadataSetHash(t *testing.T) {
 				t.Fatalf("Received unexpected error: %s", err)
 			}
 			if tc.expected != actual {
-				t.Errorf("expected hash string (%s), got (%s)", tc.expected, actual)
+				t.Errorf("Hash expected (%s), got (%s)", tc.expected, actual)
 			}
 		})
 	}

--- a/pkg/object/unstructured_set.go
+++ b/pkg/object/unstructured_set.go
@@ -1,0 +1,54 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package object
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// UnstructuredSet is an ordered list of Unstructured that acts like an
+// unordered set for comparison purposes.
+type UnstructuredSet []*unstructured.Unstructured
+
+// UnstructuredSetEquals returns true if the slice of objects in setA equals
+// the slice of objects in setB.
+func UnstructuredSetEquals(setA []*unstructured.Unstructured, setB []*unstructured.Unstructured) bool {
+	return UnstructuredSet(setA).Equal(UnstructuredSet(setB))
+}
+
+func (setA UnstructuredSet) Equal(setB UnstructuredSet) bool {
+	mapA := make(map[string]string, len(setA))
+	for _, a := range setA {
+		jsonBytes, err := a.MarshalJSON()
+		if err != nil {
+			mapA[string(jsonBytes)] = err.Error()
+		} else {
+			mapA[string(jsonBytes)] = ""
+		}
+	}
+	mapB := make(map[string]string, len(setB))
+	for _, b := range setB {
+		jsonBytes, err := b.MarshalJSON()
+		if err != nil {
+			mapB[string(jsonBytes)] = err.Error()
+		} else {
+			mapB[string(jsonBytes)] = ""
+		}
+	}
+	if len(mapA) != len(mapB) {
+		return false
+	}
+	for b, errB := range mapB {
+		if errA, exists := mapA[b]; !exists {
+			if !exists {
+				return false
+			}
+			if errA != errB {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/object/unstructured_set_test.go
+++ b/pkg/object/unstructured_set_test.go
@@ -1,0 +1,117 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package object
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
+)
+
+var resources = map[string]string{
+	"pod1": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+`,
+	"pod1dupe": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+  namespace: default
+`,
+	"pod2": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+  namespace: default
+`,
+	"pod3": `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod3
+  namespace: default
+`,
+	"pod4": `
+apiVersion: v1
+kind: Pod
+metadata:
+name: pod4
+namespace: default
+`,
+}
+
+func TestUnstructuredSetEquals(t *testing.T) {
+	pod1 := testutil.YamlToUnstructured(t, resources["pod1"])
+	pod1dupe := testutil.YamlToUnstructured(t, resources["pod1dupe"])
+	pod2 := testutil.YamlToUnstructured(t, resources["pod2"])
+	pod3 := testutil.YamlToUnstructured(t, resources["pod3"])
+	pod4 := testutil.YamlToUnstructured(t, resources["pod4"])
+
+	testCases := map[string]struct {
+		setA    UnstructuredSet
+		setB    UnstructuredSet
+		isEqual bool
+	}{
+		"Empty sets": {
+			setA:    UnstructuredSet{},
+			setB:    UnstructuredSet{},
+			isEqual: true,
+		},
+		"Empty first set": {
+			setA:    UnstructuredSet{},
+			setB:    UnstructuredSet{pod1, pod2},
+			isEqual: false,
+		},
+		"Empty second set": {
+			setA:    UnstructuredSet{pod1, pod2},
+			setB:    UnstructuredSet{},
+			isEqual: false,
+		},
+		"Different order": {
+			setA:    UnstructuredSet{pod1, pod2},
+			setB:    UnstructuredSet{pod2, pod1},
+			isEqual: true,
+		},
+		"One item overlap": {
+			setA:    UnstructuredSet{pod1, pod2},
+			setB:    UnstructuredSet{pod2, pod3},
+			isEqual: false,
+		},
+		"Disjoint sets": {
+			setA:    UnstructuredSet{pod1, pod2},
+			setB:    UnstructuredSet{pod3, pod4},
+			isEqual: false,
+		},
+		"Duplicate pointer": {
+			setA:    UnstructuredSet{pod1, pod1},
+			setB:    UnstructuredSet{pod1},
+			isEqual: true,
+		},
+		"Duplicate value": {
+			setA:    UnstructuredSet{pod1, pod1dupe},
+			setB:    UnstructuredSet{pod1},
+			isEqual: true,
+		},
+		"Same value": {
+			setA:    UnstructuredSet{pod1},
+			setB:    UnstructuredSet{pod1dupe},
+			isEqual: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.setA.Equal(tc.setB)
+			if tc.isEqual != actual {
+				t.Errorf("Equal expected (%t), got (%t)", tc.isEqual, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Refactor usages of []Unstructured to use UnstructuredSet
- Add UnstructuredSet.Equal to handle set equality comparison
- Avoid updating tests to prove reverse compatibility
  (except: Graph.SortObj, which returns a list of sets)

This can be followed up with a PR updating the tests to remove complex comparison functions. With this change we can now use cmp.Equal and cmp.Diff for deep comparison of objects (like events and tasks) that contain UnstructuredSet and ObjMetadataSet.