### PR TITLE
Check versions a CRD defines

### DIFF
--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -21,12 +21,12 @@ import (
 
 // UnknownTypesError captures information about unknown types encountered.
 type UnknownTypesError struct {
-	GroupKinds []schema.GroupKind
+	GroupVersionKinds []schema.GroupVersionKind
 }
 
 func (e *UnknownTypesError) Error() string {
 	var gks []string
-	for _, gk := range e.GroupKinds {
+	for _, gk := range e.GroupVersionKinds {
 		gks = append(gks, gk.String())
 	}
 	return fmt.Sprintf("unknown resource types: %s", strings.Join(gks, ","))
@@ -62,7 +62,7 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 		}
 	}
 
-	var unknownGKs []schema.GroupKind
+	var unknownGVKs []schema.GroupVersionKind
 	for _, obj := range objs {
 		// Exclude any inventory objects here since we don't want to change
 		// their namespace.
@@ -78,7 +78,7 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 			if errors.As(err, &unknownTypeError) {
 				// If no scope was found, just add the resource type to the list
 				// of unknown types.
-				unknownGKs = append(unknownGKs, unknownTypeError.GroupKind)
+				unknownGVKs = append(unknownGVKs, unknownTypeError.GroupVersionKind)
 				continue
 			} else {
 				// If something went wrong when looking up the scope, just
@@ -108,9 +108,9 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 			return fmt.Errorf("unknown RESTScope %q", scope.Name())
 		}
 	}
-	if len(unknownGKs) > 0 {
+	if len(unknownGVKs) > 0 {
 		return &UnknownTypesError{
-			GroupKinds: unknownGKs,
+			GroupVersionKinds: unknownGVKs,
 		}
 	}
 	return nil

--- a/pkg/object/unstructured.go
+++ b/pkg/object/unstructured.go
@@ -128,7 +128,7 @@ func LookupResourceScope(u *unstructured.Unstructured, crds []*unstructured.Unst
 	gvk := u.GroupVersionKind()
 	// First see if we can find the type (and the scope) in the cluster through
 	// the RESTMapper.
-	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err == nil {
 		// If we find the type in the cluster, we just look up the scope there.
 		return mapping.Scope, nil

--- a/pkg/object/unstructured.go
+++ b/pkg/object/unstructured.go
@@ -5,6 +5,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -112,11 +113,11 @@ func GetCRDGroupKind(u *unstructured.Unstructured) (schema.GroupKind, bool) {
 // UnknownTypeError captures information about a type for which no information
 // could be found in the cluster or among the known CRDs.
 type UnknownTypeError struct {
-	GroupKind schema.GroupKind
+	GroupVersionKind schema.GroupVersionKind
 }
 
 func (e *UnknownTypeError) Error() string {
-	return fmt.Sprintf("unknown resource type: %q", e.GroupKind.String())
+	return fmt.Sprintf("unknown resource type: %q", e.GroupVersionKind.String())
 }
 
 // LookupResourceScope tries to look up the scope of the type of the provided
@@ -128,41 +129,86 @@ func LookupResourceScope(u *unstructured.Unstructured, crds []*unstructured.Unst
 	// First see if we can find the type (and the scope) in the cluster through
 	// the RESTMapper.
 	mapping, err := mapper.RESTMapping(gvk.GroupKind())
+	if err == nil {
+		// If we find the type in the cluster, we just look up the scope there.
+		return mapping.Scope, nil
+	}
 	// Not finding a match is not an error here, so only error out for other
 	// error types.
-	if err != nil && !meta.IsNoMatchError(err) {
+	if !meta.IsNoMatchError(err) {
 		return nil, err
 	}
 
-	var scope meta.RESTScope
-	if err == nil {
-		// If we find the type in the cluster, we just look up the scope there.
-		scope = mapping.Scope
-	} else {
-		// If we couldn't find the type in the cluster, check if we find a
-		// match in any of the provided CRDs.
-		for _, crd := range crds {
-			group, _, _ := unstructured.NestedString(crd.Object, "spec", "group")
-			kind, _, _ := unstructured.NestedString(crd.Object, "spec", "names", "kind")
-			if gvk.Kind == kind && gvk.Group == group {
-				scopeName, _, _ := unstructured.NestedString(crd.Object, "spec", "scope")
-				switch scopeName {
-				case "Namespaced":
-					scope = meta.RESTScopeNamespace
-				case "Cluster":
-					scope = meta.RESTScopeRoot
-				default:
-					return nil, fmt.Errorf("unknown scope %q", scopeName)
-				}
-				break
+	// If we couldn't find the type in the cluster, check if we find a
+	// match in any of the provided CRDs.
+	for _, crd := range crds {
+		group, found, err := unstructured.NestedString(crd.Object, "spec", "group")
+		if err != nil {
+			return nil, fmt.Errorf("spec.group: %v", err)
+		}
+		if !found || group == "" {
+			return nil, errors.New("spec.group not found")
+		}
+		kind, found, err := unstructured.NestedString(crd.Object, "spec", "names", "kind")
+		if err != nil {
+			return nil, fmt.Errorf("spec.kind: %v", err)
+		}
+		if !found || kind == "" {
+			return nil, errors.New("spec.kind not found")
+		}
+		if gvk.Kind != kind || gvk.Group != group {
+			continue
+		}
+		versionDefined, err := crdDefinesVersion(crd, gvk.Version)
+		if err != nil {
+			return nil, err
+		}
+		if !versionDefined {
+			return nil, &UnknownTypeError{
+				GroupVersionKind: gvk,
 			}
 		}
-	}
-
-	if scope == nil {
-		return nil, &UnknownTypeError{
-			GroupKind: gvk.GroupKind(),
+		scopeName, _, err := unstructured.NestedString(crd.Object, "spec", "scope")
+		if err != nil {
+			return nil, fmt.Errorf("spec.scope: %v", err)
+		}
+		switch scopeName {
+		case "Namespaced":
+			return meta.RESTScopeNamespace, nil
+		case "Cluster":
+			return meta.RESTScopeRoot, nil
+		default:
+			return nil, fmt.Errorf("unknown scope %q", scopeName)
 		}
 	}
-	return scope, nil
+	return nil, &UnknownTypeError{
+		GroupVersionKind: gvk,
+	}
+}
+
+func crdDefinesVersion(crd *unstructured.Unstructured, version string) (bool, error) {
+	versionsSlice, found, err := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	if err != nil {
+		return false, fmt.Errorf("spec.versions: %v", err)
+	}
+	if !found || len(versionsSlice) == 0 {
+		return false, errors.New("spec.versions not found")
+	}
+	for i, ver := range versionsSlice {
+		verObj, ok := ver.(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("spec.versions[%d]: expecting map, got: %T", i, ver)
+		}
+		name, found, err := unstructured.NestedString(verObj, "name")
+		if err != nil {
+			return false, fmt.Errorf("spec.versions[%d].name: %w", i, err)
+		}
+		if !found {
+			return false, fmt.Errorf("spec.versions[%d].name not found", i)
+		}
+		if name == version {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/object/unstructured_test.go
+++ b/pkg/object/unstructured_test.go
@@ -33,6 +33,22 @@ spec:
   scope: Cluster
   names:
     kind: crontab
+  versions:
+  - name: v1
+`
+
+var testCRDv2 = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: test-crd
+spec:
+  group: example.com
+  scope: Cluster
+  names:
+    kind: crontab
+  versions:
+  - name: v2
 `
 
 var testCR = `
@@ -269,9 +285,23 @@ func TestLookupResourceScope(t *testing.T) {
 		"CR not found in the RESTMapper or the provided CRDs": {
 			resource: testutil.Unstructured(t, testCR),
 			expectedErr: &UnknownTypeError{
-				GroupKind: schema.GroupKind{
-					Group: "example.com",
-					Kind:  "crontab",
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "example.com",
+					Version: "v1",
+					Kind:    "crontab",
+				},
+			},
+		},
+		"CR not found in the RESTMapper or the provided CRDs because version is missing": {
+			resource: testutil.Unstructured(t, testCR),
+			crds: []*unstructured.Unstructured{
+				testutil.Unstructured(t, testCRDv2),
+			},
+			expectedErr: &UnknownTypeError{
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   "example.com",
+					Version: "v1",
+					Kind:    "crontab",
 				},
 			},
 		},

--- a/pkg/object/validate_test.go
+++ b/pkg/object/validate_test.go
@@ -190,6 +190,8 @@ spec:
   names:
     kind: Custom
   scope: Cluster
+  versions:
+  - name: v1
 `,
 				),
 				testutil.Unstructured(t, `


### PR DESCRIPTION
If a CRD does not define a version that a CR has, then it's an error and CR scope cannot be decided.