### PR TITLE
[WIP] Support apply of Gatekeeper Template and Constraint in the same set

### DIFF
--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"time"
 
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
@@ -163,9 +161,7 @@ func (w *WaitTask) startAndComplete(taskContext *TaskContext) {
 func (w *WaitTask) complete(taskContext *TaskContext) {
 	var err error
 	for _, obj := range w.Ids {
-		if (obj.GroupKind.Group == v1.SchemeGroupVersion.Group ||
-			obj.GroupKind.Group == v1beta1.SchemeGroupVersion.Group) &&
-			obj.GroupKind.Kind == "CustomResourceDefinition" {
+		if object.IsCRD(obj.GroupKind) || object.IsConstraintTemplate(obj.GroupKind) {
 			ddRESTMapper, err := extractDeferredDiscoveryRESTMapper(w.mapper)
 			if err == nil {
 				ddRESTMapper.Reset()

--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -57,7 +57,7 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 
 	// find any crds in the set of resources.
 	for _, obj := range objs {
-		if object.IsCRD(obj) {
+		if object.IsCRD(obj.GroupVersionKind().GroupKind()) {
 			crdObjs = append(crdObjs, obj)
 		}
 	}
@@ -76,15 +76,12 @@ func SetNamespaces(mapper meta.RESTMapper, objs []*unstructured.Unstructured,
 		if err != nil {
 			var unknownTypeError *object.UnknownTypeError
 			if errors.As(err, &unknownTypeError) {
-				// If no scope was found, just add the resource type to the list
-				// of unknown types.
-				unknownGKs = append(unknownGKs, unknownTypeError.GroupKind)
+				unknownGKs = append(unknownGKs, obj.GroupVersionKind().GroupKind())
 				continue
-			} else {
-				// If something went wrong when looking up the scope, just
-				// give up.
-				return err
 			}
+			// If something went wrong when looking up the scope, just
+			// give up.
+			return err
 		}
 
 		switch scope {

--- a/pkg/object/unstructured_test.go
+++ b/pkg/object/unstructured_test.go
@@ -174,7 +174,7 @@ func TestIsCRD(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := IsCRD(tc.obj)
+			actual := IsCRD(tc.obj.GroupVersionKind().GroupKind())
 			if tc.isCRD != actual {
 				t.Errorf("expected IsCRD (%t), got (%t) for (%s)", tc.isCRD, actual, tc.obj)
 			}

--- a/pkg/object/validate.go
+++ b/pkg/object/validate.go
@@ -105,7 +105,7 @@ func isFieldError(err error) (*field.Error, bool) {
 func findCRDs(us []*unstructured.Unstructured) []*unstructured.Unstructured {
 	var crds []*unstructured.Unstructured
 	for _, u := range us {
-		if IsCRD(u) {
+		if IsCRD(u.GroupVersionKind().GroupKind()) {
 			crds = append(crds, u)
 		}
 	}


### PR DESCRIPTION
cli-utils currently doesn't support applying Gatekeeper templates and constraints in the same set, even with the `depends-on` annotation. This is a POC on how to implement support directly in the library and meant for discussion rather than merging it as is.

There are three challenges here:

**The library needs to be able to determine the namespace of gatekeeper constraints, even when the CRD for the template doesn't exist in the cluster**
This is very similar as for CRs and CRDs, although it is somewhat easier here since we know that all gatekeeper constraints are cluster-scoped. This PR doesn't actually check that we have the template in the same apply set, but just uses the group for gatekeeper constraints to determine the scope. We could make the check more thorough and error out early if we can't find the template in either the apply set or in the cluster.
A related question here is whether the library should verify the namespace field for provided resources or just accept what is passed in by the user.

**The library needs to apply the template before the constrain and make sure the CRD for the template has been generated**
This PR handles this in the solver, similar to how we manage CRDs and namespaces. But ideally I think we would rather let users use the `depends-on` annotation for this rather than us having to code support for this specifically in the library.
This also adds a rule for determining when a Gatekeeper template has reconciled. Adding rules for all possible types to the library obviously doesn't scale, so we should allow users to provide custom rules for this. It has always been the goal of the library, we just have never gotten around to it.

**Refresh the RESTMapper to pick up the type generated from a template**
Since Gatekeeper templates results in a CRD, we need to make sure the new type is seen by the RESTMapper after a template has reconciled. This PR does this the same way as for CRDs, but this is not a good long-term solution. We have discussed letting the library just check for new types on-demand, rather than invalidating the full RESTMapper after specific types has applied and reconciled. 
