### PR TITLE
Clean up prune package

### DIFF
--- a/pkg/apply/prune/main_test.go
+++ b/pkg/apply/prune/main_test.go
@@ -1,0 +1,19 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package prune
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+// TestMain executes the tests for this package, with optional logging.
+// To see all logs, use:
+// go test sigs.k8s.io/cli-utils/pkg/apply/prune -v -args -v=5
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	os.Exit(m.Run())
+}

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -38,11 +38,11 @@ import (
 const defaultWaitTimeout = 1 * time.Minute
 
 type TaskQueueBuilder struct {
-	PruneOptions *prune.PruneOptions
-	InfoHelper   info.InfoHelper
-	Factory      util.Factory
-	Mapper       meta.RESTMapper
-	InvClient    inventory.InventoryClient
+	Pruner     *prune.Pruner
+	InfoHelper info.InfoHelper
+	Factory    util.Factory
+	Mapper     meta.RESTMapper
+	InvClient  inventory.InventoryClient
 	// True if we are destroying, which deletes the inventory object
 	// as well (possibly) the inventory namespace.
 	Destroy bool
@@ -200,7 +200,7 @@ func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs object.UnstructuredSet,
 			TaskName:          fmt.Sprintf("prune-%d", t.pruneCounter),
 			Objects:           pruneObjs,
 			Filters:           pruneFilters,
-			PruneOptions:      t.PruneOptions,
+			Pruner:            t.Pruner,
 			PropagationPolicy: o.PrunePropagationPolicy,
 			DryRunStrategy:    o.DryRunStrategy,
 			Destroy:           t.Destroy,

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	pruneOptions = &prune.PruneOptions{}
-	resources    = map[string]string{
+	pruner    = &prune.Pruner{}
+	resources = map[string]string{
 		"pod": `
 kind: Pod
 apiVersion: v1
@@ -353,9 +353,9 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 			applyIds := object.UnstructuredsToObjMetasOrDie(tc.applyObjs)
 			fakeInvClient := inventory.NewFakeInventoryClient(applyIds)
 			tqb := TaskQueueBuilder{
-				PruneOptions: pruneOptions,
-				Mapper:       testutil.NewFakeRESTMapper(),
-				InvClient:    fakeInvClient,
+				Pruner:    pruner,
+				Mapper:    testutil.NewFakeRESTMapper(),
+				InvClient: fakeInvClient,
 			}
 			tq, err := tqb.AppendApplyWaitTasks(
 				tc.applyObjs,
@@ -651,9 +651,9 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 			pruneIds := object.UnstructuredsToObjMetasOrDie(tc.pruneObjs)
 			fakeInvClient := inventory.NewFakeInventoryClient(pruneIds)
 			tqb := TaskQueueBuilder{
-				PruneOptions: pruneOptions,
-				Mapper:       testutil.NewFakeRESTMapper(),
-				InvClient:    fakeInvClient,
+				Pruner:    pruner,
+				Mapper:    testutil.NewFakeRESTMapper(),
+				InvClient: fakeInvClient,
 			}
 			emptyPruneFilters := []filter.ValidationFilter{}
 			tq, err := tqb.AppendPruneWaitTasks(tc.pruneObjs, emptyPruneFilters, tc.options).Build()

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -20,7 +20,7 @@ import (
 type PruneTask struct {
 	TaskName string
 
-	PruneOptions      *prune.PruneOptions
+	Pruner            *prune.Pruner
 	Objects           object.UnstructuredSet
 	Filters           []filter.ValidationFilter
 	DryRunStrategy    common.DryRunStrategy
@@ -59,7 +59,7 @@ func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 			CurrentUIDs: taskContext.AppliedResourceUIDs(),
 		}
 		p.Filters = append(p.Filters, uidFilter)
-		err := p.PruneOptions.Prune(
+		err := p.Pruner.Prune(
 			p.Objects,
 			p.Filters,
 			taskContext,


### PR DESCRIPTION
- Rename PruneOptions to Pruner (it does the work itself)
- Rename variables and internal methods for clarity
- Extract deleteObject method to improve readability
- Rename GetObject to getObject (only used internally and by test)
- Modify log messages for readability
- Add log support for prune tests

This is mostly just reducing tech debt to improve my sanity and make it easier to tackle harder problems.