### PR TITLE
Allow the users to specify whether to continue on error

### DIFF
--- a/pkg/apply/error/error.go
+++ b/pkg/apply/error/error.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package error
 
+import "sigs.k8s.io/cli-utils/pkg/apply/event"
+
 type UnknownTypeError struct {
 	err error
 }
@@ -36,4 +38,14 @@ func (e *InitializeApplyOptionError) Error() string {
 
 func NewInitializeApplyOptionError(err error) *InitializeApplyOptionError {
 	return &InitializeApplyOptionError{err: err}
+}
+
+// HandleError sends a ErrorType event onto eventChannel.
+func HandleError(eventChannel chan event.Event, err error) {
+	eventChannel <- event.Event{
+		Type: event.ErrorType,
+		ErrorEvent: event.ErrorEvent{
+			Err: err,
+		},
+	}
 }


### PR DESCRIPTION
Today, cli-utils continues on all errors with one exception: it
terminates immediately on a WaitTask TimeoutError.

This PR allows the users to specify whether to continue on error through
a bool-type field named `ContinueOnError` of the applier/destroyer
Options. The default value is false: cli-utils would terminate
immediately on a WaitTask TimeoutError. If the field is set to true,
cli-utils would not terminate, but instead log the error and send the
error to the event channel before continuing.
