### PR TITLE
feat: Always wait for reconciliation

### DIFF
--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -114,7 +114,7 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 			expectedTasks: []taskrunner.Task{},
 			isError:       false,
 		},
-		"single resource, one apply task": {
+		"single resource, one apply task, one wait task": {
 			applyObjs: []*unstructured.Unstructured{
 				testutil.Unstructured(t, resources["deployment"]),
 			},
@@ -125,6 +125,39 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.Unstructured(t, resources["deployment"]),
 					},
 				},
+				taskrunner.NewWaitTask(
+					"wait-0",
+					object.ObjMetadataSet{
+						testutil.ToIdentifier(t, resources["deployment"]),
+					},
+					taskrunner.AllCurrent, 1*time.Second,
+					testutil.NewFakeRESTMapper(),
+				),
+			},
+			isError: false,
+		},
+		"multiple resource with no timeout": {
+			applyObjs: []*unstructured.Unstructured{
+				testutil.Unstructured(t, resources["deployment"]),
+				testutil.Unstructured(t, resources["secret"]),
+			},
+			expectedTasks: []taskrunner.Task{
+				&task.ApplyTask{
+					TaskName: "apply-0",
+					Objects: []*unstructured.Unstructured{
+						testutil.Unstructured(t, resources["deployment"]),
+						testutil.Unstructured(t, resources["secret"]),
+					},
+				},
+				taskrunner.NewWaitTask(
+					"wait-0",
+					object.ObjMetadataSet{
+						testutil.ToIdentifier(t, resources["deployment"]),
+						testutil.ToIdentifier(t, resources["secret"]),
+					},
+					taskrunner.AllCurrent, 1*time.Second,
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -151,7 +184,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["secret"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -216,7 +250,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["crd"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.ApplyTask{
 					TaskName: "apply-1",
 					Objects: []*unstructured.Unstructured{
@@ -231,7 +266,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["crontab2"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -281,7 +317,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["namespace"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.ApplyTask{
 					TaskName: "apply-1",
 					Objects: []*unstructured.Unstructured{
@@ -296,7 +333,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["secret"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -319,7 +357,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["secret"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.ApplyTask{
 					TaskName: "apply-1",
 					Objects: []*unstructured.Unstructured{
@@ -332,7 +371,8 @@ func TestTaskQueueBuilder_AppendApplyWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["deployment"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -408,7 +448,7 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 			expectedTasks: []taskrunner.Task{},
 			isError:       false,
 		},
-		"single resource, one prune task": {
+		"single resource, one prune task, one wait task": {
 			pruneObjs: []*unstructured.Unstructured{
 				testutil.Unstructured(t, resources["default-pod"]),
 			},
@@ -420,10 +460,18 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.Unstructured(t, resources["default-pod"]),
 					},
 				},
+				taskrunner.NewWaitTask(
+					"wait-0",
+					object.ObjMetadataSet{
+						testutil.ToIdentifier(t, resources["default-pod"]),
+					},
+					taskrunner.AllCurrent, 1*time.Second,
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
-		"multiple resources, one prune task": {
+		"multiple resources, one prune task, one wait task": {
 			pruneObjs: []*unstructured.Unstructured{
 				testutil.Unstructured(t, resources["default-pod"]),
 				testutil.Unstructured(t, resources["pod"]),
@@ -437,6 +485,15 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.Unstructured(t, resources["pod"]),
 					},
 				},
+				taskrunner.NewWaitTask(
+					"wait-0",
+					object.ObjMetadataSet{
+						testutil.ToIdentifier(t, resources["default-pod"]),
+						testutil.ToIdentifier(t, resources["pod"]),
+					},
+					taskrunner.AllCurrent, 1*time.Second,
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -461,7 +518,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["pod"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.PruneTask{
 					TaskName: "prune-1",
 					Objects: []*unstructured.Unstructured{
@@ -474,7 +532,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["secret"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -500,7 +559,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 					},
 					taskrunner.AllCurrent,
 					3*time.Minute,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -549,7 +609,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["crontab2"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.PruneTask{
 					TaskName: "prune-1",
 					Objects: []*unstructured.Unstructured{
@@ -562,7 +623,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["crd"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -616,7 +678,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["secret"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 				&task.PruneTask{
 					TaskName: "prune-1",
 					Objects: []*unstructured.Unstructured{
@@ -629,7 +692,8 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 						testutil.ToIdentifier(t, resources["namespace"]),
 					},
 					taskrunner.AllCurrent, 1*time.Second,
-					testutil.NewFakeRESTMapper()),
+					testutil.NewFakeRESTMapper(),
+				),
 			},
 			isError: false,
 		},
@@ -682,11 +746,7 @@ func TestTaskQueueBuilder_AppendPruneWaitTasks(t *testing.T) {
 					}
 					assert.Equal(t, taskrunner.AllNotFound, actWaitTask.Condition)
 					// Validate the prune wait timeout.
-					expectedTimeout := defaultWaitTimeout
-					if tc.options.PruneTimeout != time.Duration(0) {
-						expectedTimeout = tc.options.PruneTimeout
-					}
-					assert.Equal(t, expectedTimeout, actualTask.(*taskrunner.WaitTask).Timeout)
+					assert.Equal(t, tc.options.PruneTimeout, actualTask.(*taskrunner.WaitTask).Timeout)
 				}
 			}
 		})

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -86,12 +86,12 @@ func TestBaseRunner(t *testing.T) {
 				event.ApplyType,
 				event.ActionGroupType,
 				event.ActionGroupType,
-				event.WaitType, // deployment pending
-				event.WaitType, // configmap pending
-				event.StatusType,
-				event.WaitType, // configmap current
-				event.StatusType,
-				event.WaitType, // deployment current
+				event.WaitType,   // deployment pending
+				event.WaitType,   // configmap pending
+				event.StatusType, // configmap current
+				event.WaitType,   // configmap reconciled
+				event.StatusType, // deployment current
+				event.WaitType,   // deployment reconciled
 				event.ActionGroupType,
 				event.ActionGroupType,
 				event.PruneType,
@@ -137,11 +137,11 @@ func TestBaseRunner(t *testing.T) {
 			},
 			expectedEventTypes: []event.Type{
 				event.ActionGroupType,
-				event.WaitType, // configmap pending
-				event.WaitType, // deployment pending
-				event.StatusType,
-				event.WaitType, // configmap current
-				event.WaitType, // deployment timeout error
+				event.WaitType,   // configmap pending
+				event.WaitType,   // deployment pending
+				event.StatusType, // configmap current
+				event.WaitType,   // configmap reconciled
+				event.WaitType,   // deployment timeout error
 				event.ActionGroupType,
 			},
 			expectedWaitEvents: []event.WaitEvent{
@@ -191,12 +191,12 @@ func TestBaseRunner(t *testing.T) {
 			},
 			expectedEventTypes: []event.Type{
 				event.ActionGroupType,
-				event.WaitType, // configmap pending
-				event.WaitType, // deployment pending
-				event.StatusType,
-				event.WaitType, // configmap current
-				event.StatusType,
-				event.WaitType, // deployment timeout error
+				event.WaitType,   // configmap pending
+				event.WaitType,   // deployment pending
+				event.StatusType, // configmap current
+				event.WaitType,   // configmap reconciled
+				event.StatusType, // deployment inprogress
+				event.WaitType,   // deployment timeout error
 				event.ActionGroupType,
 			},
 			expectedWaitEvents: []event.WaitEvent{

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -468,7 +468,6 @@ func TestWaitTask_SingleTaskResult(t *testing.T) {
 	eventChannel := make(chan event.Event, 10)
 	resourceCache := cache.NewResourceCacheMap()
 	taskContext := NewTaskContext(eventChannel, resourceCache)
-	taskContext.taskChannel = make(chan TaskResult, 10)
 	defer close(eventChannel)
 
 	// mark the deployment as applied
@@ -522,20 +521,17 @@ loop:
 				Operation:  event.ReconcilePending,
 			},
 		},
-	}
-	// Expect an event for every call to StatusUpdate,
-	// because the object is already Current.
-	for i := 0; i < 10; i++ {
-		expectedEvents = append(expectedEvents, event.Event{
+		// deployment1 reconciled
+		{
 			Type: event.WaitType,
 			WaitEvent: event.WaitEvent{
 				GroupName:  taskName,
 				Identifier: testDeploymentID,
 				Operation:  event.Reconciled,
 			},
-		})
+		},
 	}
-	assert.Equal(t, expectedEvents, receivedEvents)
+	testutil.AssertEqual(t, receivedEvents, expectedEvents)
 
 	expectedResults := []TaskResult{
 		{}, // Empty result means success

--- a/pkg/object/graph/depends.go
+++ b/pkg/object/graph/depends.go
@@ -7,11 +7,14 @@
 package graph
 
 import (
+	"sort"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/object/dependson"
 	"sigs.k8s.io/cli-utils/pkg/object/mutation"
+	"sigs.k8s.io/cli-utils/pkg/ordering"
 )
 
 // SortObjs returns a slice of the sets of objects to apply (in order).
@@ -50,6 +53,8 @@ func SortObjs(objs object.UnstructuredSet) ([]object.UnstructuredSet, error) {
 				currentSet = append(currentSet, obj)
 			}
 		}
+		// Sort each set in apply order
+		sort.Sort(ordering.SortableUnstructureds(currentSet))
 		objSets = append(objSets, currentSet)
 	}
 	return objSets, nil
@@ -65,6 +70,12 @@ func ReverseSortObjs(objs object.UnstructuredSet) ([]object.UnstructuredSet, err
 	// Reverse the ordering of the object sets using swaps.
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
+	}
+	// Reverse the ordering of the objects in each set using swaps.
+	for _, c := range s {
+		for i, j := 0, len(c)-1; i < j; i, j = i+1, j-1 {
+			c[i], c[j] = c[j], c[i]
+		}
 	}
 	return s, nil
 }

--- a/pkg/testutil/events.go
+++ b/pkg/testutil/events.go
@@ -421,6 +421,17 @@ func (ape GroupedEventsByID) Less(i, j int) bool {
 			// don't change order if not the same task group
 			return false
 		}
+		if ape[i].WaitEvent.Operation != ape[j].WaitEvent.Operation {
+			// don't change order if not the same operation
+			return false
+		}
+		if ape[i].WaitEvent.Operation != event.Reconciled {
+			// pending, skipped, and timeout operations are predictably ordered
+			// using the order in WaitTask.Ids.
+			// So we only need to sort Reconciled events, which occur in the
+			// order the Waitask receives StatusEvents with Current/NotFound.
+			return false
+		}
 		return ape[i].WaitEvent.Identifier.String() < ape[j].WaitEvent.Identifier.String()
 	default:
 		// don't change order if not ApplyType, PruneType, or DeleteType

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -229,25 +229,42 @@ func applyAndDestroyTest(ctx context.Context, c client.Client, invConfig Invento
 				Type:      event.Finished,
 			},
 		},
-		// TODO: Why is waiting skipped on destroy?
-		// {
-		// 	// WaitTask start
-		// 	EventType: event.ActionGroupType,
-		// 	ActionGroupEvent: &testutil.ExpActionGroupEvent{
-		// 		Action: event.WaitAction,
-		// 		Name:   "wait-0",
-		// 		Type:   event.Started,
-		// 	},
-		// },
-		// {
-		// 	// WaitTask finished
-		// 	EventType: event.ActionGroupType,
-		// 	ActionGroupEvent: &testutil.ExpActionGroupEvent{
-		// 		Action: event.WaitAction,
-		// 		Name:   "wait-0",
-		// 		Type:   event.Finished,
-		// 	},
-		// },
+		{
+			// WaitTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
+			},
+		},
+		{
+			// Deployment reconcile Pending .
+			EventType: event.WaitType,
+			WaitEvent: &testutil.ExpWaitEvent{
+				GroupName:  "wait-0",
+				Operation:  event.ReconcilePending,
+				Identifier: object.UnstructuredToObjMetaOrDie(deployment1Obj),
+			},
+		},
+		{
+			// Deployment confirmed NotFound.
+			EventType: event.WaitType,
+			WaitEvent: &testutil.ExpWaitEvent{
+				GroupName:  "wait-0",
+				Operation:  event.Reconciled,
+				Identifier: object.UnstructuredToObjMetaOrDie(deployment1Obj),
+			},
+		},
+		{
+			// WaitTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
+			},
+		},
 		{
 			// DeleteInvTask start
 			EventType: event.ActionGroupType,

--- a/test/e2e/deletion_prevention_test.go
+++ b/test/e2e/deletion_prevention_test.go
@@ -49,6 +49,7 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 	By("Verify the inventory size is 3")
 	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 3)
 
+	By("Dry-run apply resources")
 	resources = []*unstructured.Unstructured{
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
@@ -57,6 +58,7 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 		ReconcileTimeout: 2 * time.Minute,
 		DryRunStrategy:   common.DryRunClient,
 	}))
+
 	By("Verify deployment still exists and has the config.k8s.io/owning-inventory annotation")
 	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
@@ -72,6 +74,7 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 	By("Verify the inventory size is still 3")
 	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 3)
 
+	By("Apply resources")
 	resources = []*unstructured.Unstructured{
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -287,10 +287,7 @@ func createRandomNamespace(ctx context.Context, c client.Client) *v1.Namespace {
 
 func deleteInventoryCRD(ctx context.Context, c client.Client) {
 	invCRD := manifestToUnstructured(customprovider.InventoryCRD)
-	err := c.Delete(ctx, invCRD)
-	if err != nil && !apierrors.IsNotFound(err) {
-		Expect(err).ToNot(HaveOccurred())
-	}
+	deleteUnstructuredIfExists(ctx, c, invCRD)
 }
 
 func deleteUnstructuredIfExists(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {


### PR DESCRIPTION
- Converted WaitTask to use a context for timeout/cancellation, to
  improve readability and reduce error cases. Now it only sends
  TaskResult events from one place, removing the need for a token to
  silence subsequent complete() calls.
- Add pending object tracking to WaitTask to ensure all objects are
  accounted for at least one WaitEvent.
- Upgraded applier tests to use full event comparison, for better signal
  on breaking changes.
- Enhanced task tests to consume all events before validating and test
  actual event output.
- Add set sorting to graph.SortObjs, to make wait event ordering more
  consistent, to make testing easier.

BREAKING CHANGE: wait tasks always execute after apply/prune/delete (except dry runs)
BREAKING CHANGE: wait tasks default to waiting until cancelled (previously 1m default)

fixes: https://github.com/kubernetes-sigs/cli-utils/issues/438