### PR TITLE
Change the behavior of hanlding a WaitTask timeout

### DIFF
--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -21,6 +21,7 @@ const (
 	StatusType
 	PruneType
 	DeleteType
+	WaitType
 )
 
 // Event is the type of the objects that will be returned through
@@ -58,6 +59,9 @@ type Event struct {
 	// DeleteEvent contains information about object that have been
 	// deleted.
 	DeleteEvent DeleteEvent
+
+	// WaitEvent contains information about any errors encountered in a WaitTask.
+	WaitEvent WaitEvent
 }
 
 type InitEvent struct {
@@ -83,6 +87,11 @@ type ActionGroup struct {
 
 type ErrorEvent struct {
 	Err error
+}
+
+type WaitEvent struct {
+	GroupName string
+	Error     error
 }
 
 //go:generate stringer -type=ActionGroupEventType

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -222,8 +222,9 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 				}
 			}
 		// A message on the taskChannel means that the current task
-		// has either completed or failed. If it has failed, we return
-		// the error. If the abort flag is true, which means something
+		// has either completed or failed.
+		// If it has failed, we return the error.
+		// If the abort flag is true, which means something
 		// else has gone wrong and we are waiting for the current task to
 		// finish, we exit.
 		// If everything is ok, we fetch and start the next task.
@@ -238,7 +239,6 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 				},
 			}
 			if msg.Err != nil {
-				b.amendTimeoutError(taskContext, msg.Err)
 				return msg.Err
 			}
 			if abort {
@@ -259,24 +259,6 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 			abortReason = ctx.Err() // always non-nil when doneCh is closed
 			completeIfWaitTask(currentTask, taskContext)
 		}
-	}
-}
-
-func (b *baseRunner) amendTimeoutError(taskContext *TaskContext, err error) {
-	if timeoutErr, ok := err.(*TimeoutError); ok {
-		var timedOutResources []TimedOutResource
-		for _, id := range timeoutErr.Identifiers {
-			result := taskContext.ResourceCache().Get(id)
-			if timeoutErr.Condition.Meets(result.Status) {
-				continue
-			}
-			timedOutResources = append(timedOutResources, TimedOutResource{
-				Identifier: id,
-				Status:     result.Status,
-				Message:    result.StatusMessage,
-			})
-		}
-		timeoutErr.TimedOutResources = timedOutResources
 	}
 }
 

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -102,7 +102,7 @@ func (w *WaitTask) Start(taskContext *TaskContext) {
 
 // setTimer creates the timer with the timeout value taken from
 // the WaitTask struct. Once the timer expires, it will send
-// a message on the TaskChannel provided in the taskContext.
+// a message on the EventChannel provided in the taskContext.
 func (w *WaitTask) setTimer(taskContext *TaskContext) {
 	timer := time.NewTimer(w.Timeout)
 	go func() {
@@ -111,22 +111,47 @@ func (w *WaitTask) setTimer(taskContext *TaskContext) {
 		// Timeout is cancelled.
 		<-timer.C
 		select {
-		// We only send the taskResult if no one has gotten
+		// We only send the TimeoutError to the eventChannel if no one has gotten
 		// to the token first.
 		case <-w.token:
-			taskContext.TaskChannel() <- TaskResult{
-				Err: &TimeoutError{
-					Identifiers: w.Ids,
-					Timeout:     w.Timeout,
-					Condition:   w.Condition,
+			err := &TimeoutError{
+				Identifiers: w.Ids,
+				Timeout:     w.Timeout,
+				Condition:   w.Condition,
+			}
+			amendTimeoutError(taskContext, err)
+			taskContext.EventChannel() <- event.Event{
+				Type: event.WaitType,
+				WaitEvent: event.WaitEvent{
+					GroupName: w.Name(),
+					Error:     err,
 				},
 			}
+			taskContext.TaskChannel() <- TaskResult{}
 		default:
 			return
 		}
 	}()
 	w.cancelFunc = func() {
 		timer.Stop()
+	}
+}
+
+func amendTimeoutError(taskContext *TaskContext, err error) {
+	if timeoutErr, ok := err.(*TimeoutError); ok {
+		var timedOutResources []TimedOutResource
+		for _, id := range timeoutErr.Identifiers {
+			result := taskContext.ResourceCache().Get(id)
+			if timeoutErr.Condition.Meets(result.Status) {
+				continue
+			}
+			timedOutResources = append(timedOutResources, TimedOutResource{
+				Identifier: id,
+				Status:     result.Status,
+				Message:    result.StatusMessage,
+			})
+		}
+		timeoutErr.TimedOutResources = timedOutResources
 	}
 }
 


### PR DESCRIPTION
Today, when a WaitTask timeout happens, the WaitTask sends the
TimeoutError on the TaskChannel. After receiving the TimeoutError,
`baseRunner.run` terminates immediately by returning the error to its
caller (Applier.Run or Destroyer.Run). The caller then sends the error
onto the EventChannel and terminates.

With this PR, when a WaitTask timeout happens, the WaitTask sends a
WaitType Event including the TimeoutError on the EventChannel, and then
sends an empty TaskResult on the TaskChannel. An empty TaskResult
suggests that the task finished successfully, and therefore
`baseRunner.run` would continue instead of terminate.

The motivation of this change is to make sure that cli-utils only
terminates on fatal errors (such as inventory-related errors, and
ApplyOptions creation errors). A WaitTask timeout may not always mean a
fatal error (it may happen because the StatusPoller has not finished
polling everything, or some but not all the resources have not reached
the desired status), and therefore should not terminate cli-utils.
