### PR TITLE
Ignore receiver name lint error

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -90,6 +90,7 @@ const (
 )
 
 // ClientDryRun returns true if input drs is DryRunClient
+//nolint:stylecheck  // Prevent lint errors on receiver names caused by string generation above
 func (drs DryRunStrategy) ClientDryRun() bool {
 	return drs == DryRunClient
 }


### PR DESCRIPTION
* Ignores lint error caused by string generation, which creates a function receiver name of `i`.
* Lint error is:
```
pkg/common/common.go:94:27: ST1016: methods on the same type should have the same receiver name (seen 4x "drs", 1x "i") (stylecheck)
```