### PR TITLE
Applier constructor and run: functional options

### DIFF
--- a/pkg/apply/applier_options.go
+++ b/pkg/apply/applier_options.go
@@ -1,0 +1,160 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cli-utils/pkg/apply/poller"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type applierConfig struct {
+	// factory is only used to retrieve things that have not been provided explicitly.
+	factory                      util.Factory
+	invClient                    inventory.InventoryClient
+	client                       dynamic.Interface
+	discoClient                  discovery.CachedDiscoveryInterface
+	mapper                       meta.RESTMapper
+	restConfig                   *rest.Config
+	unstructuredClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)
+	statusPoller                 poller.Poller
+}
+
+type ApplierOption func(*applierConfig)
+
+func constructApplierConfig(opts []ApplierOption) (*applierConfig, error) {
+	cfg := defaultApplierConfig()
+	setOptsOnApplierConfig(cfg, opts)
+	err := finalizeApplierConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func defaultApplierConfig() *applierConfig {
+	return &applierConfig{}
+}
+
+func setOptsOnApplierConfig(cfg *applierConfig, opts []ApplierOption) {
+	for _, opt := range opts {
+		opt(cfg)
+	}
+}
+
+func finalizeApplierConfig(cfg *applierConfig) error {
+	var err error
+	if cfg.invClient == nil {
+		return errors.New("inventory client must be provided")
+	}
+	if cfg.client == nil {
+		if cfg.factory == nil {
+			return fmt.Errorf("a factory must be provided or all other options: %v", err)
+		}
+		cfg.client, err = cfg.factory.DynamicClient()
+		if err != nil {
+			return fmt.Errorf("error getting dynamic client: %v", err)
+		}
+	}
+	if cfg.discoClient == nil {
+		if cfg.factory == nil {
+			return fmt.Errorf("a factory must be provided or all other options: %v", err)
+		}
+		cfg.discoClient, err = cfg.factory.ToDiscoveryClient()
+		if err != nil {
+			return fmt.Errorf("error getting discovery client: %v", err)
+		}
+	}
+	if cfg.mapper == nil {
+		if cfg.factory == nil {
+			return fmt.Errorf("a factory must be provided or all other options: %v", err)
+		}
+		cfg.mapper, err = cfg.factory.ToRESTMapper()
+		if err != nil {
+			return fmt.Errorf("error getting rest mapper: %v", err)
+		}
+	}
+	if cfg.restConfig == nil {
+		if cfg.factory == nil {
+			return fmt.Errorf("a factory must be provided or all other options: %v", err)
+		}
+		cfg.restConfig, err = cfg.factory.ToRESTConfig()
+		if err != nil {
+			return fmt.Errorf("error getting rest config: %v", err)
+		}
+	}
+	if cfg.unstructuredClientForMapping == nil {
+		if cfg.factory == nil {
+			return fmt.Errorf("a factory must be provided or all other options: %v", err)
+		}
+		cfg.unstructuredClientForMapping = cfg.factory.UnstructuredClientForMapping
+	}
+	if cfg.statusPoller == nil {
+		c, err := client.New(cfg.restConfig, client.Options{Scheme: scheme.Scheme, Mapper: cfg.mapper})
+		if err != nil {
+			return fmt.Errorf("error creating client: %v", err)
+		}
+		cfg.statusPoller = polling.NewStatusPoller(c, cfg.mapper)
+	}
+	return nil
+}
+
+func WithFactory(factory util.Factory) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.factory = factory
+	}
+}
+
+func WithInventoryClient(invClient inventory.InventoryClient) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.invClient = invClient
+	}
+}
+
+func WithDynamicClient(client dynamic.Interface) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.client = client
+	}
+}
+
+func WithDiscoveryClient(discoClient discovery.CachedDiscoveryInterface) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.discoClient = discoClient
+	}
+}
+
+func WithRestMapper(mapper meta.RESTMapper) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.mapper = mapper
+	}
+}
+
+func WithRestConfig(restConfig *rest.Config) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.restConfig = restConfig
+	}
+}
+
+func WithUnstructuredClientForMapping(unstructuredClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.unstructuredClientForMapping = unstructuredClientForMapping
+	}
+}
+
+func WithStatusPoller(statusPoller poller.Poller) ApplierOption {
+	return func(cfg *applierConfig) {
+		cfg.statusPoller = statusPoller
+	}
+}

--- a/pkg/apply/applier_run_options.go
+++ b/pkg/apply/applier_run_options.go
@@ -1,0 +1,165 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+const defaultPollInterval = 2 * time.Second
+
+type applierRunConfig struct {
+	// Encapsulates the fields for server-side apply.
+	serverSideOptions common.ServerSideOptions
+
+	// reconcileTimeout defines whether the applier should wait
+	// until all applied resources have been reconciled, and if so,
+	// how long to wait.
+	reconcileTimeout time.Duration
+
+	// pollInterval defines how often we should poll for the status
+	// of resources.
+	pollInterval time.Duration
+
+	// emitStatusEvents defines whether status events should be
+	// emitted on the eventChannel to the caller.
+	emitStatusEvents bool
+
+	// prune defines whether pruning of previously applied
+	// objects should happen after apply.
+	prune bool
+
+	// dryRunStrategy defines whether changes should actually be performed,
+	// or if it is just talk and no action.
+	dryRunStrategy common.DryRunStrategy
+
+	// prunePropagationPolicy defines the deletion propagation policy
+	// that should be used for pruning. If this is not provided, the
+	// default is to use the Background policy.
+	prunePropagationPolicy metav1.DeletionPropagation
+
+	// pruneTimeout defines whether we should wait for all resources
+	// to be fully deleted after pruning, and if so, how long we should
+	// wait.
+	pruneTimeout time.Duration
+
+	// inventoryPolicy defines the inventory policy of apply.
+	inventoryPolicy inventory.InventoryPolicy
+
+	// eventListeners is a list of event listeners that are called in specified order when an event happens.
+	// Listeners are never called concurrently with each other.
+	eventListeners []func(event.Event)
+}
+
+type ApplierRunOption func(*applierRunConfig)
+
+// constructApplierRunConfig turns options into a config.
+// It always returns a non-nil config, event if there was an error.
+func constructApplierRunConfig(opts []ApplierRunOption) *applierRunConfig {
+	cfg := defaultApplierRunConfig()
+	setOptsOnApplierRunConfig(cfg, opts)
+	return cfg
+}
+
+func defaultApplierRunConfig() *applierRunConfig {
+	return &applierRunConfig{
+		pollInterval:           defaultPollInterval,
+		prune:                  true,
+		prunePropagationPolicy: metav1.DeletePropagationBackground,
+	}
+}
+
+func setOptsOnApplierRunConfig(cfg *applierRunConfig, opts []ApplierRunOption) {
+	for _, opt := range opts {
+		opt(cfg)
+	}
+}
+
+func ServerSideOptions(serverSideOptions common.ServerSideOptions) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.serverSideOptions = serverSideOptions
+	}
+}
+
+func ReconcileTimeout(reconcileTimeout time.Duration) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.reconcileTimeout = reconcileTimeout
+	}
+}
+
+func PollInterval(pollInterval time.Duration) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.pollInterval = pollInterval
+	}
+}
+
+func EmitStatusEvents(emitStatusEvents bool) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.emitStatusEvents = emitStatusEvents
+	}
+}
+
+func Prune(prune bool) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.prune = prune
+	}
+}
+
+func DryRunStrategy(dryRunStrategy common.DryRunStrategy) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.dryRunStrategy = dryRunStrategy
+	}
+}
+
+func PrunePropagationPolicy(prunePropagationPolicy metav1.DeletionPropagation) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.prunePropagationPolicy = prunePropagationPolicy
+	}
+}
+
+func PruneTimeout(pruneTimeout time.Duration) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.pruneTimeout = pruneTimeout
+	}
+}
+
+func InventoryPolicy(inventoryPolicy inventory.InventoryPolicy) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.inventoryPolicy = inventoryPolicy
+	}
+}
+
+func EventListener(eventListener ...func(event.Event)) ApplierRunOption {
+	return func(cfg *applierRunConfig) {
+		cfg.eventListeners = append(cfg.eventListeners, eventListener...)
+	}
+}
+
+func EventChannelListener(eventChannel chan<- event.Event) ApplierRunOption {
+	return EventListener(func(e event.Event) {
+		eventChannel <- e
+	})
+}
+
+func CollectEventsInto(eventSink *[]event.Event) ApplierRunOption {
+	return EventListener(func(e event.Event) {
+		*eventSink = append(*eventSink, e)
+	})
+}
+
+// CollectErrorInto captures error from the first event of ErrorType type.
+func CollectErrorInto(errSink *error) ApplierRunOption {
+	assigned := false
+	return EventListener(func(e event.Event) {
+		if e.Type == event.ErrorType && !assigned {
+			assigned = true
+			*errSink = e.ErrorEvent.Err
+		}
+	})
+}

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -75,9 +75,12 @@ func newTestApplier(
 
 	invClient := newTestInventory(t, tf, infoHelper)
 
-	applier, err := NewApplier(tf, invClient)
+	applier, err := NewApplier(
+		WithFactory(tf),
+		WithInventoryClient(invClient),
+		WithStatusPoller(statusPoller),
+	)
 	require.NoError(t, err)
-	applier.StatusPoller = statusPoller
 
 	// Inject the fakeInfoHelper to allow generating Info
 	// objects that use the FakeRESTClient as the UnstructuredClient.

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/filter"
+	"sigs.k8s.io/cli-utils/pkg/apply/info"
 	"sigs.k8s.io/cli-utils/pkg/apply/poller"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
 	"sigs.k8s.io/cli-utils/pkg/apply/solver"
@@ -84,7 +85,7 @@ type DestroyerOptions struct {
 
 func setDestroyerDefaults(o *DestroyerOptions) {
 	if o.PollInterval == time.Duration(0) {
-		o.PollInterval = poller.DefaultPollInterval
+		o.PollInterval = defaultPollInterval
 	}
 	if o.DeletePropagationPolicy == "" {
 		o.DeletePropagationPolicy = metav1.DeletePropagationBackground
@@ -115,12 +116,19 @@ func (d *Destroyer) Run(ctx context.Context, inv inventory.InventoryInfo, option
 			return
 		}
 		klog.V(4).Infoln("destroyer building task queue...")
+		dynamicClient, err := d.factory.DynamicClient()
+		if err != nil {
+			handleError(eventChannel, err)
+			return
+		}
 		taskBuilder := &solver.TaskQueueBuilder{
-			Pruner:    d.pruner,
-			Factory:   d.factory,
-			Mapper:    mapper,
-			InvClient: d.invClient,
-			Destroy:   true,
+			Pruner:        d.pruner,
+			DynamicClient: dynamicClient,
+			OpenAPIGetter: d.factory.OpenAPIGetter(),
+			InfoHelper:    info.NewInfoHelper(mapper, d.factory.UnstructuredClientForMapping),
+			Mapper:        mapper,
+			InvClient:     d.invClient,
+			Destroy:       true,
 		}
 		opts := solver.Options{
 			Prune:                  true,
@@ -170,4 +178,13 @@ func (d *Destroyer) Run(ctx context.Context, inv inventory.InventoryInfo, option
 		}
 	}()
 	return eventChannel
+}
+
+func handleError(eventChannel chan event.Event, err error) {
+	eventChannel <- event.Event{
+		Type: event.ErrorType,
+		ErrorEvent: event.ErrorEvent{
+			Err: err,
+		},
+	}
 }

--- a/pkg/apply/info/info_helper.go
+++ b/pkg/apply/info/info_helper.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
@@ -21,16 +20,16 @@ type InfoHelper interface {
 	BuildInfo(obj *unstructured.Unstructured) (*resource.Info, error)
 }
 
-func NewInfoHelper(mapper meta.RESTMapper, factory util.Factory) *infoHelper {
+func NewInfoHelper(mapper meta.RESTMapper, unstructuredClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)) *infoHelper {
 	return &infoHelper{
-		mapper:  mapper,
-		factory: factory,
+		mapper:                       mapper,
+		unstructuredClientForMapping: unstructuredClientForMapping,
 	}
 }
 
 type infoHelper struct {
-	mapper  meta.RESTMapper
-	factory util.Factory
+	mapper                       meta.RESTMapper
+	unstructuredClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)
 }
 
 func (ih *infoHelper) UpdateInfo(info *resource.Info) error {
@@ -41,7 +40,7 @@ func (ih *infoHelper) UpdateInfo(info *resource.Info) error {
 	}
 	info.Mapping = mapping
 
-	c, err := ih.factory.UnstructuredClientForMapping(mapping)
+	c, err := ih.unstructuredClientForMapping(mapping)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/poller/poller.go
+++ b/pkg/apply/poller/poller.go
@@ -5,14 +5,11 @@ package poller
 
 import (
 	"context"
-	"time"
 
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
-
-const DefaultPollInterval = 2 * time.Second
 
 // Poller defines the interface the applier needs to poll for status of resources.
 // The context is the preferred way to shut down the poller.

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -20,8 +20,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
-	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/filter"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
@@ -36,11 +37,12 @@ import (
 )
 
 type TaskQueueBuilder struct {
-	Pruner     *prune.Pruner
-	InfoHelper info.InfoHelper
-	Factory    util.Factory
-	Mapper     meta.RESTMapper
-	InvClient  inventory.InventoryClient
+	Pruner        *prune.Pruner
+	DynamicClient dynamic.Interface
+	OpenAPIGetter discovery.OpenAPISchemaInterface
+	InfoHelper    info.InfoHelper
+	Mapper        meta.RESTMapper
+	InvClient     inventory.InventoryClient
 	// True if we are destroying, which deletes the inventory object
 	// as well (possibly) the inventory namespace.
 	Destroy bool
@@ -160,8 +162,9 @@ func (t *TaskQueueBuilder) AppendApplyTask(applyObjs object.UnstructuredSet,
 		Mutators:          applyMutators,
 		ServerSideOptions: o.ServerSideOptions,
 		DryRunStrategy:    o.DryRunStrategy,
+		DynamicClient:     t.DynamicClient,
+		OpenAPIGetter:     t.OpenAPIGetter,
 		InfoHelper:        t.InfoHelper,
-		Factory:           t.Factory,
 		Mapper:            t.Mapper,
 	})
 	t.applyCounter += 1

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -14,10 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/apply"
 	cmddelete "k8s.io/kubectl/pkg/cmd/delete"
-	"k8s.io/kubectl/pkg/cmd/util"
 	applyerror "sigs.k8s.io/cli-utils/pkg/apply/error"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/filter"
@@ -46,7 +47,8 @@ type applyOptions interface {
 type ApplyTask struct {
 	TaskName string
 
-	Factory           util.Factory
+	DynamicClient     dynamic.Interface
+	OpenAPIGetter     discovery.OpenAPISchemaInterface
 	InfoHelper        info.InfoHelper
 	Mapper            meta.RESTMapper
 	Objects           object.UnstructuredSet
@@ -87,18 +89,6 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 		objects := a.Objects
 		klog.V(2).Infof("apply task starting (name: %q, objects: %d)",
 			a.Name(), len(objects))
-		// Create a new instance of the applyOptions interface and use it
-		// to apply the objects.
-		ao, err := applyOptionsFactoryFunc(a.Name(), taskContext.EventChannel(),
-			a.ServerSideOptions, a.DryRunStrategy, a.Factory)
-		if err != nil {
-			if klog.V(4).Enabled() {
-				klog.Errorf("error creating ApplyOptions (%s)--returning", err)
-			}
-			a.sendBatchApplyEvents(taskContext, objects, err)
-			a.sendTaskResult(taskContext)
-			return
-		}
 		for _, obj := range objects {
 			// Set the client and mapping fields on the provided
 			// info so they can be applied to the cluster.
@@ -157,7 +147,10 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 				continue
 			}
 
-			// Apply the object
+			// Create a new instance of the applyOptions interface and use it
+			// to apply the objects.
+			ao := applyOptionsFactoryFunc(a.Name(), taskContext.EventChannel(),
+				a.ServerSideOptions, a.DryRunStrategy, a.DynamicClient, a.OpenAPIGetter)
 			ao.SetObjects([]*resource.Info{info})
 			klog.V(5).Infof("applying %s/%s...", info.Namespace, info.Name)
 			err = ao.Run()
@@ -189,16 +182,9 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-func newApplyOptions(taskName string, eventChannel chan event.Event, serverSideOptions common.ServerSideOptions,
-	strategy common.DryRunStrategy, factory util.Factory) (applyOptions, error) {
-	discovery, err := factory.ToDiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-	dynamic, err := factory.DynamicClient()
-	if err != nil {
-		return nil, err
-	}
+func newApplyOptions(taskName string, eventChannel chan<- event.Event, serverSideOptions common.ServerSideOptions,
+	strategy common.DryRunStrategy, dynamicClient dynamic.Interface,
+	openAPIGetter discovery.OpenAPISchemaInterface) applyOptions {
 	emptyString := ""
 	return &apply.ApplyOptions{
 		VisitedNamespaces: sets.NewString(),
@@ -227,9 +213,9 @@ func newApplyOptions(taskName string, eventChannel chan event.Event, serverSideO
 			ch:        eventChannel,
 			groupName: taskName,
 		}).toPrinterFunc(),
-		DynamicClient:  dynamic,
-		DryRunVerifier: resource.NewDryRunVerifier(dynamic, discovery),
-	}, nil
+		DynamicClient:  dynamicClient,
+		DryRunVerifier: resource.NewDryRunVerifier(dynamicClient, openAPIGetter),
+	}
 }
 
 func (a *ApplyTask) sendTaskResult(taskContext *taskrunner.TaskContext) {
@@ -283,23 +269,6 @@ func (a *ApplyTask) createApplyFailedEvent(id object.ObjMetadata, err error) eve
 	}
 }
 
-// sendBatchApplyEvents is a helper function to send out multiple apply events for
-// a list of resources when failed to initialize the apply process.
-func (a *ApplyTask) sendBatchApplyEvents(
-	taskContext *taskrunner.TaskContext,
-	objects object.UnstructuredSet,
-	err error,
-) {
-	for _, obj := range objects {
-		id := object.UnstructuredToObjMetaOrDie(obj)
-		taskContext.SendEvent(a.createApplyFailedEvent(
-			id,
-			applyerror.NewInitializeApplyOptionError(err),
-		))
-		taskContext.AddFailedApply(id)
-	}
-}
-
 func isAPIService(obj *unstructured.Unstructured) bool {
 	gk := obj.GroupVersionKind().GroupKind()
 	return gk.Group == "apiregistration.k8s.io" && gk.Kind == "APIService"
@@ -311,11 +280,8 @@ func isStreamError(err error) bool {
 	return strings.Contains(err.Error(), "stream error: stream ID ")
 }
 
-func (a *ApplyTask) clientSideApply(info *resource.Info, eventChannel chan event.Event) error {
-	ao, err := applyOptionsFactoryFunc(a.Name(), eventChannel, common.ServerSideOptions{ServerSideApply: false}, a.DryRunStrategy, a.Factory)
-	if err != nil {
-		return err
-	}
+func (a *ApplyTask) clientSideApply(info *resource.Info, eventChannel chan<- event.Event) error {
+	ao := applyOptionsFactoryFunc(a.Name(), eventChannel, common.ServerSideOptions{ServerSideApply: false}, a.DryRunStrategy, a.DynamicClient, a.OpenAPIGetter)
 	ao.SetObjects([]*resource.Info{info})
 	return ao.Run()
 }

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -15,7 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
@@ -86,8 +87,9 @@ func TestApplyTask_BasicAppliedObjects(t *testing.T) {
 			objs := toUnstructureds(tc.applied)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
-				return &fakeApplyOptions{}, nil
+			applyOptionsFactoryFunc = func(string, chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy,
+				dynamic.Interface, discovery.OpenAPISchemaInterface) applyOptions {
+				return &fakeApplyOptions{}
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
 
@@ -177,8 +179,9 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 			objs := toUnstructureds(tc.rss)
 
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
-				return &fakeApplyOptions{}, nil
+			applyOptionsFactoryFunc = func(string, chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy,
+				dynamic.Interface, discovery.OpenAPISchemaInterface) applyOptions {
+				return &fakeApplyOptions{}
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
 			applyTask := &ApplyTask{
@@ -298,8 +301,9 @@ func TestApplyTask_DryRun(t *testing.T) {
 
 				ao := &fakeApplyOptions{}
 				oldAO := applyOptionsFactoryFunc
-				applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
-					return ao, nil
+				applyOptionsFactoryFunc = func(string, chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy,
+					dynamic.Interface, discovery.OpenAPISchemaInterface) applyOptions {
+					return ao
 				}
 				defer func() { applyOptionsFactoryFunc = oldAO }()
 
@@ -445,8 +449,9 @@ func TestApplyTaskWithError(t *testing.T) {
 
 			ao := &fakeApplyOptions{}
 			oldAO := applyOptionsFactoryFunc
-			applyOptionsFactoryFunc = func(string, chan event.Event, common.ServerSideOptions, common.DryRunStrategy, util.Factory) (applyOptions, error) {
-				return ao, nil
+			applyOptionsFactoryFunc = func(string, chan<- event.Event, common.ServerSideOptions, common.DryRunStrategy,
+				dynamic.Interface, discovery.OpenAPISchemaInterface) applyOptions {
+				return ao
 			}
 			defer func() { applyOptionsFactoryFunc = oldAO }()
 

--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -80,7 +80,7 @@ func NewInventoryClient(factory cmdutil.Factory,
 		validator:             validator,
 		InventoryFactoryFunc:  invFunc,
 		invToUnstructuredFunc: invToUnstructuredFunc,
-		InfoHelper:            info.NewInfoHelper(mapper, factory),
+		InfoHelper:            info.NewInfoHelper(mapper, factory.UnstructuredClientForMapping),
 	}
 	return &clusterInventoryClient, nil
 }

--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -32,10 +32,12 @@ func applyAndDestroyTest(ctx context.Context, c client.Client, invConfig Invento
 		deployment1Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inventoryInfo, resources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -172,32 +172,10 @@ func randomString(prefix string) string {
 	return fmt.Sprintf("%s%s", prefix, randomSuffix)
 }
 
-func run(ch <-chan event.Event) error {
-	var err error
-	for e := range ch {
-		if e.Type == event.ErrorType {
-			err = e.ErrorEvent.Err
-		}
-	}
-	return err
-}
-
-func runWithNoErr(ch <-chan event.Event) {
-	runCollectNoErr(ch)
-}
-
 func runCollect(ch <-chan event.Event) []event.Event {
 	var events []event.Event
 	for e := range ch {
 		events = append(events, e)
-	}
-	return events
-}
-
-func runCollectNoErr(ch <-chan event.Event) []event.Event {
-	events := runCollect(ch)
-	for _, e := range events {
-		Expect(e.Type).NotTo(Equal(event.ErrorType))
 	}
 	return events
 }

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -32,7 +32,8 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig Invento
 		pod1Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resources, apply.CollectEventsInto(&applierEvents))
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -34,10 +34,12 @@ func crdTest(ctx context.Context, _ client.Client, invConfig InventoryConfig, in
 		crdObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: false,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(false),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/deletion_prevention_test.go
+++ b/test/e2e/deletion_prevention_test.go
@@ -30,9 +30,7 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 		withAnnotation(withNamespace(manifestToUnstructured(pod2), namespaceName), common.LifecycleDeleteAnnotation, common.PreventDeletion),
 	}
 
-	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-	}))
+	applier.Run(ctx, inventoryInfo, resources, apply.ReconcileTimeout(2*time.Minute))
 
 	By("Verify deployment created")
 	obj := assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
@@ -54,11 +52,10 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
 
-	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		DryRunStrategy:   common.DryRunClient,
-	}))
-
+	applier.Run(ctx, inventoryInfo, resources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.DryRunStrategy(common.DryRunClient),
+	)
 	By("Verify deployment still exists and has the config.k8s.io/owning-inventory annotation")
 	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
@@ -79,9 +76,7 @@ func deletionPreventionTest(ctx context.Context, c client.Client, invConfig Inve
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
 
-	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-	}))
+	applier.Run(ctx, inventoryInfo, resources, apply.ReconcileTimeout(2*time.Minute))
 
 	By("Verify deployment still exists and has the config.k8s.io/owning-inventory annotation")
 	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -36,9 +36,11 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig InventoryConf
 		pod3Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{
-		EmitStatusEvents: false,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resources,
+		apply.EmitStatusEvents(false),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -387,7 +387,10 @@ func newApplierFromInvFactory(invFactory inventory.InventoryClientFactory) *appl
 	invClient, err := invFactory.NewInventoryClient(f)
 	Expect(err).NotTo(HaveOccurred())
 
-	a, err := apply.NewApplier(f, invClient)
+	a, err := apply.NewApplier(
+		apply.WithFactory(f),
+		apply.WithInventoryClient(invClient),
+	)
 	Expect(err).NotTo(HaveOccurred())
 	return a
 }

--- a/test/e2e/inventory_policy_test.go
+++ b/test/e2e/inventory_policy_test.go
@@ -31,10 +31,13 @@ func inventoryPolicyMustMatchTest(ctx context.Context, c client.Client, invConfi
 		deployment1Obj,
 	}
 
-	runWithNoErr(applier.Run(ctx, firstInv, firstResources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-	}))
+	var err error
+	applier.Run(ctx, firstInv, firstResources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.CollectErrorInto(&err),
+	)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Apply second set of resources")
 	secondInvName := randomString("second-inv-")
@@ -44,11 +47,13 @@ func inventoryPolicyMustMatchTest(ctx context.Context, c client.Client, invConfi
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, secondInv, secondResources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-		InventoryPolicy:  inventory.InventoryPolicyMustMatch,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, secondInv, secondResources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.InventoryPolicy(inventory.InventoryPolicyMustMatch),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	By("Verify the events")
 	expEvents := []testutil.ExpEvent{
@@ -202,11 +207,13 @@ func inventoryPolicyAdoptIfNoInventoryTest(ctx context.Context, c client.Client,
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-		InventoryPolicy:  inventory.AdoptIfNoInventory,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.InventoryPolicy(inventory.AdoptIfNoInventory),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	By("Verify the events")
 	expEvents := []testutil.ExpEvent{
@@ -371,10 +378,13 @@ func inventoryPolicyAdoptAllTest(ctx context.Context, c client.Client, invConfig
 		deployment1Obj,
 	}
 
-	runWithNoErr(applier.Run(ctx, firstInv, firstResources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-	}))
+	var err error
+	applier.Run(ctx, firstInv, firstResources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.CollectErrorInto(&err),
+	)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Apply resources")
 	secondInvName := randomString("test-inv-")
@@ -384,11 +394,13 @@ func inventoryPolicyAdoptAllTest(ctx context.Context, c client.Client, invConfig
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, secondInv, secondResources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-		InventoryPolicy:  inventory.AdoptAll,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, secondInv, secondResources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.InventoryPolicy(inventory.AdoptAll),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	By("Verify the events")
 	expEvents := []testutil.ExpEvent{

--- a/test/e2e/mutation_test.go
+++ b/test/e2e/mutation_test.go
@@ -48,9 +48,11 @@ func mutationTest(ctx context.Context, c client.Client, invConfig InventoryConfi
 		podBObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{
-		EmitStatusEvents: false,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resources,
+		apply.EmitStatusEvents(false),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -31,9 +31,11 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig Inve
 		pod1Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resource1, apply.Options{
-		EmitStatusEvents: false,
-	}))
+	var applierEvents []event.Event
+	applier.Run(ctx, inv, resource1,
+		apply.EmitStatusEvents(false),
+		apply.CollectEventsInto(&applierEvents),
+	)
 
 	expEvents := []testutil.ExpEvent{
 		{
@@ -165,9 +167,11 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig Inve
 		pod2Obj,
 	}
 
-	applierEvents2 := runCollect(applier.Run(ctx, inv, resource2, apply.Options{
-		EmitStatusEvents: false,
-	}))
+	var applierEvents2 []event.Event
+	applier.Run(ctx, inv, resource2,
+		apply.EmitStatusEvents(false),
+		apply.CollectEventsInto(&applierEvents2),
+	)
 
 	expEvents2 := []testutil.ExpEvent{
 		{

--- a/test/e2e/serverside_apply_test.go
+++ b/test/e2e/serverside_apply_test.go
@@ -27,15 +27,18 @@ func serversideApplyTest(ctx context.Context, c client.Client, invConfig Invento
 		manifestToUnstructured(apiservice1),
 	}
 
-	runWithNoErr(applier.Run(ctx, inv, firstResources, apply.Options{
-		ReconcileTimeout: 2 * time.Minute,
-		EmitStatusEvents: true,
-		ServerSideOptions: common.ServerSideOptions{
+	var err error
+	applier.Run(ctx, inv, firstResources,
+		apply.ReconcileTimeout(2*time.Minute),
+		apply.EmitStatusEvents(true),
+		apply.ServerSideOptions(common.ServerSideOptions{
 			ServerSideApply: true,
 			ForceConflicts:  true,
 			FieldManager:    "test",
-		},
-	}))
+		}),
+		apply.CollectErrorInto(&err),
+	)
+	Expect(err).NotTo(HaveOccurred())
 
 	By("Verify deployment is server-side applied")
 	result := assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))


### PR DESCRIPTION
This is a draft for API refactoring using the functional options pattern. The purpose of this PR is to start the conversation on how this can look.

It's easier to look at with the "hide whitespace" diff option enabled.

I suggest to look at this PR in the following order:
1. pkg/apply/applier.go `NewApplier()`. See how the new constructor looks.
1. pkg/apply/applier_options.go. See the new options to configure the applier. New ones may be added later as necessary.
1. pkg/apply/applier.go `Run()`. See how the new signature looks.
1. pkg/apply/applier_run_options.go. See the new options to configure the Run of the applier. New ones may be added later as necessary.
1. See cmd/* and then tests for usage examples.

TODO:
- [ ] Refactor `NewDestroyer()` to use functional options (in a separate PR).
- [ ] Refactor printers to be callbacks rather than channel consumers (in a separate PR). That would allow to remove some goroutines and cleanup a few places with Run() invocations.
- [x] Refactor `Applier.Run()` to use functional options. This is the most interesting part. Ran out of time today.
- [x] Fix tests

WDYT @karlkfi @mortent @seans3 