### PR TITLE
fix: skipped deletes no longer cause waiting

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -125,15 +125,11 @@ func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyOb
 func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo, dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding inventory set task")
 	prevInvIds, _ := t.InvClient.GetClusterObjs(inv, dryRun)
-	prevInventory := make(map[object.ObjMetadata]bool, len(prevInvIds))
-	for _, prevInvID := range prevInvIds {
-		prevInventory[prevInvID] = true
-	}
 	t.tasks = append(t.tasks, &task.InvSetTask{
 		TaskName:      fmt.Sprintf("inventory-set-%d", t.invSetCounter),
 		InvClient:     t.InvClient,
 		InvInfo:       inv,
-		PrevInventory: prevInventory,
+		PrevInventory: prevInvIds,
 		DryRun:        dryRun,
 	})
 	t.invSetCounter += 1

--- a/pkg/apply/taskrunner/condition_test.go
+++ b/pkg/apply/taskrunner/condition_test.go
@@ -158,7 +158,7 @@ func TestCollector_ConditionMet(t *testing.T) {
 
 			if tc.appliedGen != nil {
 				for id, gen := range tc.appliedGen {
-					taskContext.ResourceApplied(id, types.UID("unused"), gen)
+					taskContext.AddSuccessfulApply(id, types.UID("unused"), gen)
 				}
 			}
 

--- a/pkg/apply/taskrunner/task.go
+++ b/pkg/apply/taskrunner/task.go
@@ -142,8 +142,12 @@ func (w *WaitTask) checkCondition(taskContext *TaskContext) bool {
 func (w *WaitTask) pending(taskContext *TaskContext) object.ObjMetadataSet {
 	var ids object.ObjMetadataSet
 	for _, id := range w.Ids {
-		if (w.Condition == AllCurrent && taskContext.ResourceFailed(id)) ||
-			(w.Condition == AllNotFound && taskContext.PruneFailed(id)) {
+		if w.Condition == AllCurrent &&
+			taskContext.IsFailedApply(id) || taskContext.IsSkippedApply(id) {
+			continue
+		}
+		if w.Condition == AllNotFound &&
+			taskContext.IsFailedDelete(id) || taskContext.IsSkippedDelete(id) {
 			continue
 		}
 		ids = append(ids, id)

--- a/pkg/object/objmetadata_set.go
+++ b/pkg/object/objmetadata_set.go
@@ -20,6 +20,15 @@ func ObjMetadataSetEquals(setA []ObjMetadata, setB []ObjMetadata) bool {
 	return ObjMetadataSet(setA).Equal(ObjMetadataSet(setB))
 }
 
+// ObjMetadataSetFromMap constructs a set from a map
+func ObjMetadataSetFromMap(mapA map[ObjMetadata]struct{}) ObjMetadataSet {
+	setA := make(ObjMetadataSet, 0, len(mapA))
+	for f := range mapA {
+		setA = append(setA, f)
+	}
+	return setA
+}
+
 // Equal returns true if the two sets contain equivalent objects. Duplicates are
 // ignored.
 // This function satisfies the cmp.Equal interface from github.com/google/go-cmp
@@ -62,6 +71,28 @@ func (setA ObjMetadataSet) Remove(obj ObjMetadata) ObjMetadataSet {
 		}
 	}
 	return setA
+}
+
+// Intersection returns the set of unique objects in both set A and set B.
+func (setA ObjMetadataSet) Intersection(setB ObjMetadataSet) ObjMetadataSet {
+	var maxlen int
+	if len(setA) > len(setB) {
+		maxlen = len(setA)
+	} else {
+		maxlen = len(setB)
+	}
+	mapI := make(map[ObjMetadata]struct{}, maxlen)
+	mapB := setB.ToMap()
+	for _, a := range setA {
+		if _, ok := mapB[a]; ok {
+			mapI[a] = struct{}{}
+		}
+	}
+	intersection := make(ObjMetadataSet, 0, len(mapI))
+	for o := range mapI {
+		intersection = append(intersection, o)
+	}
+	return intersection
 }
 
 // Union returns the set of unique objects from the merging of set A and set B.
@@ -127,6 +158,15 @@ func calcHash(objs []string) (uint32, error) {
 		}
 	}
 	return h.Sum32(), nil
+}
+
+// ToMap returns the set as a map, with objMeta keys and empty struct values.
+func (setA ObjMetadataSet) ToMap() map[ObjMetadata]struct{} {
+	m := make(map[ObjMetadata]struct{}, len(setA))
+	for _, objMeta := range setA {
+		m[objMeta] = struct{}{}
+	}
+	return m
 }
 
 // ToStringMap returns the set as a serializable map, with objMeta keys and


### PR DESCRIPTION
- Added SkippedApplies and SkippedDeletes to the TaskContext
- Modified tasks to use the new skipped tracking, replacing usage
  of failure tracking, where skipped is more accurate.
- Renamed some TaskContext methods for consistency
- Added ObjMetadataSetFromMap for use by TaskContext
- Added ObjectMetadataSet.Intersection for use by InvSetTask
- Cleaned up InvSetTask to be more readable with comments explaining
  intended behavior, including handling of skips.
- Added apply and prune tests for skipped, failure, and abandoned

Fixes: #452