### PR TITLE
Removes inventory from manifestloader

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -132,10 +132,11 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, objs, err := r.loader.InventoryInfo(objs)
+	invObj, objs, err := inventory.SplitUnstructureds(objs)
 	if err != nil {
 		return err
 	}
+	inv := inventory.WrapInventoryInfoObj(invObj)
 
 	if r.PreProcess != nil {
 		inventoryPolicy, err = r.PreProcess(inv, common.DryRunNone)
@@ -143,6 +144,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
 	statusPoller, err := factory.NewStatusPoller(r.factory)
 	if err != nil {
 		return err

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -102,10 +102,11 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inv, _, err := r.loader.InventoryInfo(objs)
+	invObj, _, err := inventory.SplitUnstructureds(objs)
 	if err != nil {
 		return err
 	}
+	inv := inventory.WrapInventoryInfoObj(invObj)
 
 	if r.PreProcess != nil {
 		inventoryPolicy, err = r.PreProcess(inv, common.DryRunNone)

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -117,10 +117,11 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, objs, err := r.loader.InventoryInfo(objs)
+	invObj, objs, err := inventory.SplitUnstructureds(objs)
 	if err != nil {
 		return err
 	}
+	inv := inventory.WrapInventoryInfoObj(invObj)
 
 	if r.PreProcess != nil {
 		inventoryPolicy, err = r.PreProcess(inv, drs)

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -86,10 +86,11 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inv, _, err := r.loader.InventoryInfo(objs)
+	invObj, _, err := inventory.SplitUnstructureds(objs)
 	if err != nil {
 		return err
 	}
+	inv := inventory.WrapInventoryInfoObj(invObj)
 
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {

--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -64,10 +64,6 @@ func TestStatusCommand(t *testing.T) {
 		expectedErrMsg string
 		expectedOutput string
 	}{
-		"no inventory template": {
-			input:          "",
-			expectedErrMsg: "Package uninitialized. Please run \"init\" command.",
-		},
 		"no inventory in live state": {
 			input:          inventoryTemplate,
 			expectedOutput: "no resources found in the inventory\n",

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -98,7 +98,9 @@ func ValidateNoInventory(objs object.UnstructuredSet) error {
 
 // splitUnstructureds takes a set of unstructured.Unstructured objects and
 // splits it into one set that contains the inventory object templates and
-// another one that contains the remaining resources.
+// another one that contains the remaining resources. If there is no inventory
+// object the first return value is nil. Returns an error if there are
+// more than one inventory objects.
 func SplitUnstructureds(objs object.UnstructuredSet) (*unstructured.Unstructured, object.UnstructuredSet, error) {
 	invs := make(object.UnstructuredSet, 0)
 	resources := make(object.UnstructuredSet, 0)
@@ -109,14 +111,16 @@ func SplitUnstructureds(objs object.UnstructuredSet) (*unstructured.Unstructured
 			resources = append(resources, obj)
 		}
 	}
-	if len(invs) == 0 {
-		return nil, resources, NoInventoryObjError{}
+	var inv *unstructured.Unstructured
+	var err error
+	if len(invs) == 1 {
+		inv = invs[0]
 	} else if len(invs) > 1 {
-		return nil, resources, MultipleInventoryObjError{
+		err = MultipleInventoryObjError{
 			InventoryObjectTemplates: invs,
 		}
 	}
-	return invs[0], resources, nil
+	return inv, resources, err
 }
 
 // addSuffixToName adds the passed suffix (usually a hash) as a suffix

--- a/pkg/manifestreader/manifestloader.go
+++ b/pkg/manifestreader/manifestloader.go
@@ -6,20 +6,16 @@ package manifestreader
 import (
 	"io"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
 
 // ManifestLoader is an interface for reading
-// and parsing the resources and inventory info.
+// and parsing the resources
 type ManifestLoader interface {
-	InventoryInfo([]*unstructured.Unstructured) (inventory.InventoryInfo, []*unstructured.Unstructured, error)
 	ManifestReader(reader io.Reader, path string) (ManifestReader, error)
 }
 
 // manifestLoader implements the ManifestLoader interface
-// for ConfigMap as the inventory object.
 type manifestLoader struct {
 	factory util.Factory
 }
@@ -29,12 +25,6 @@ func NewManifestLoader(f util.Factory) ManifestLoader {
 	return &manifestLoader{
 		factory: f,
 	}
-}
-
-// InventoryInfo returns the InventoryInfo from a list of Unstructured objects.
-func (f *manifestLoader) InventoryInfo(objs []*unstructured.Unstructured) (inventory.InventoryInfo, []*unstructured.Unstructured, error) {
-	invObj, objs, err := inventory.SplitUnstructureds(objs)
-	return inventory.WrapInventoryInfoObj(invObj), objs, err
 }
 
 func (f *manifestLoader) ManifestReader(reader io.Reader, path string) (ManifestReader, error) {


### PR DESCRIPTION
* Removes `InventoryInfo` from `ManifestLoader` interface
* Removes `NoInventoryObjError` from `inventory.SplitUnstructureds`

This is part of the ongoing effort to remove incorrect assumption that pruning functionality must be used when using the apply library. If clients want to make a missing inventory object an error, they will have to validate themselves now.