### PR TITLE
Avoid printing out all the events

### DIFF
--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -252,9 +252,6 @@ func TestBaseRunner(t *testing.T) {
 				t.Errorf("expected no error, but got %v", err)
 			}
 
-			for _, event := range events {
-				t.Log(event)
-			}
 			if want, got := len(tc.expectedEventTypes), len(events); want != got {
 				t.Errorf("expected %d events, but got %d", want, got)
 			}


### PR DESCRIPTION
The printing logic was added by accident in https://github.com/kubernetes-sigs/cli-utils/pull/451/files#diff-dee0be9aff370837ed01dcd5dc8f8a414369adc7b3d846453f800c8639fb8d37R255