### PR TITLE
fix: TimeoutError only returns objs that timed out

### DIFF
--- a/pkg/apply/event/type_string.go
+++ b/pkg/apply/event/type_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[StatusType-4]
 	_ = x[PruneType-5]
 	_ = x[DeleteType-6]
+	_ = x[WaitType-7]
 }
 
-const _Type_name = "InitTypeErrorTypeActionGroupTypeApplyTypeStatusTypePruneTypeDeleteType"
+const _Type_name = "InitTypeErrorTypeActionGroupTypeApplyTypeStatusTypePruneTypeDeleteTypeWaitType"
 
-var _Type_index = [...]uint8{0, 8, 17, 32, 41, 51, 60, 70}
+var _Type_index = [...]uint8{0, 8, 17, 32, 41, 51, 60, 70, 78}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -123,7 +123,7 @@ func TestBaseRunner(t *testing.T) {
 					Message:    "resource not cached",
 				},
 			},
-			expectedTimeoutErrorMsg: "timeout after 2 seconds waiting for 2 resources ([default_cm__ConfigMap default_dep_apps_Deployment]) to reach condition AllCurrent",
+			expectedTimeoutErrorMsg: "timeout after 2 seconds waiting for 1 resources ([default_dep_apps_Deployment]) to reach condition AllCurrent",
 		},
 		"wait task times out eventually (InProgress)": {
 			tasks: []Task{
@@ -160,7 +160,7 @@ func TestBaseRunner(t *testing.T) {
 					Status:     status.InProgressStatus,
 				},
 			},
-			expectedTimeoutErrorMsg: "timeout after 2 seconds waiting for 2 resources ([default_cm__ConfigMap default_dep_apps_Deployment]) to reach condition AllCurrent",
+			expectedTimeoutErrorMsg: "timeout after 2 seconds waiting for 1 resources ([default_dep_apps_Deployment]) to reach condition AllCurrent",
 		},
 		"tasks run in order": {
 			tasks: []Task{

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -4,20 +4,40 @@
 package taskrunner
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
 )
 
+var testDeploymentYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  namespace: default
+  uid: dep-uid
+  generation: 1
+spec:
+  replicas: 1
+`
+
 func TestWaitTask_TimeoutTriggered(t *testing.T) {
+	testDeploymentID := testutil.ToIdentifier(t, testDeploymentYAML)
 	taskName := "wait"
-	task := NewWaitTask(taskName, object.ObjMetadataSet{}, AllCurrent,
-		2*time.Second, testutil.NewFakeRESTMapper())
+	ids := object.ObjMetadataSet{
+		testDeploymentID,
+	}
+	waitTimeout := 2 * time.Second
+	task := NewWaitTask(taskName, ids, AllCurrent,
+		waitTimeout, testutil.NewFakeRESTMapper())
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
@@ -26,29 +46,48 @@ func TestWaitTask_TimeoutTriggered(t *testing.T) {
 
 	task.Start(taskContext)
 
-	timer := time.NewTimer(3 * time.Second)
+	receivedTaskResults, receivedEvents, err := consumeUntilTimeout(taskContext, 5*time.Second)
 
-	select {
-	case e := <-taskContext.EventChannel():
-		if e.Type != event.WaitType {
-			t.Errorf("expected a WaitType event, but got a %v event", e.Type)
-		}
-		if e.WaitEvent.GroupName != taskName {
-			t.Errorf("expected WaitEvent.GroupName = %q, but got %q", taskName, e.WaitEvent.GroupName)
-		}
-		err := e.WaitEvent.Error
-		if _, ok := IsTimeoutError(err); !ok {
-			t.Errorf("expected timeout error, but got %v", err)
-		}
-		return
-	case <-timer.C:
-		t.Errorf("expected timeout to trigger, but it didn't")
+	expectedEvents := []event.Event{
+		{
+			Type: event.WaitType,
+			WaitEvent: event.WaitEvent{
+				GroupName: taskName,
+				Error: &TimeoutError{
+					Identifiers: ids,
+					Timeout:     waitTimeout,
+					Condition:   AllCurrent,
+					TimedOutResources: []TimedOutResource{
+						{
+							Identifier: testDeploymentID,
+							Status:     status.UnknownStatus,
+							Message:    "resource not cached",
+						},
+					},
+				},
+			},
+		},
 	}
+	assert.Equal(t, expectedEvents, receivedEvents)
+
+	expectedTaskResults := []TaskResult{
+		{}, // empty == completed/cancelled
+	}
+	testutil.AssertEqual(t, expectedTaskResults, receivedTaskResults)
+
+	// Expect timeout, because channels are not closed by the WaitTask
+	assert.Equal(t, context.DeadlineExceeded, err)
 }
 
 func TestWaitTask_TimeoutCancelled(t *testing.T) {
-	task := NewWaitTask("wait", object.ObjMetadataSet{}, AllCurrent,
-		2*time.Second, testutil.NewFakeRESTMapper())
+	testDeploymentID := testutil.ToIdentifier(t, testDeploymentYAML)
+	taskName := "wait"
+	ids := object.ObjMetadataSet{
+		testDeploymentID,
+	}
+	waitTimeout := 2 * time.Second
+	task := NewWaitTask(taskName, ids, AllCurrent,
+		waitTimeout, testutil.NewFakeRESTMapper())
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
@@ -57,14 +96,17 @@ func TestWaitTask_TimeoutCancelled(t *testing.T) {
 
 	task.Start(taskContext)
 	task.ClearTimeout()
-	timer := time.NewTimer(3 * time.Second)
 
-	select {
-	case res := <-taskContext.TaskChannel():
-		t.Errorf("didn't expect timeout error, but got %v", res.Err)
-	case <-timer.C:
-		return
-	}
+	receivedTaskResults, receivedEvents, err := consumeUntilTimeout(taskContext, 5*time.Second)
+
+	expectedEvents := []event.Event{}
+	testutil.AssertEqual(t, expectedEvents, receivedEvents)
+
+	expectedTaskResults := []TaskResult{}
+	testutil.AssertEqual(t, expectedTaskResults, receivedTaskResults)
+
+	// Expect timeout, because channels are not closed by the WaitTask
+	assert.Equal(t, context.DeadlineExceeded, err)
 }
 
 func TestWaitTask_SingleTaskResult(t *testing.T) {
@@ -74,11 +116,11 @@ func TestWaitTask_SingleTaskResult(t *testing.T) {
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
 	taskContext := NewTaskContext(eventChannel, resourceCache)
-	taskContext.taskChannel = make(chan TaskResult, 10)
 	defer close(eventChannel)
 
-	var completeWg sync.WaitGroup
+	task.Start(taskContext)
 
+	var completeWg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		completeWg.Add(1)
 		go func() {
@@ -88,14 +130,49 @@ func TestWaitTask_SingleTaskResult(t *testing.T) {
 	}
 	completeWg.Wait()
 
-	<-taskContext.TaskChannel()
+	receivedTaskResults, receivedEvents, err := consumeUntilTimeout(taskContext, 5*time.Second)
 
-	timer := time.NewTimer(4 * time.Second)
+	expectedEvents := []event.Event{}
+	testutil.AssertEqual(t, expectedEvents, receivedEvents)
 
-	select {
-	case <-taskContext.TaskChannel():
-		t.Errorf("expected only one result on taskChannel, but got more")
-	case <-timer.C:
-		return
+	expectedTaskResults := []TaskResult{
+		{}, // empty == completed/cancelled
+	}
+	testutil.AssertEqual(t, expectedTaskResults, receivedTaskResults)
+
+	// Expect timeout, because channels are not closed by the WaitTask
+	assert.Equal(t, context.DeadlineExceeded, err)
+}
+
+func consumeUntilTimeout(taskContext *TaskContext, timeout time.Duration) ([]TaskResult, []event.Event, error) {
+	taskResults := []TaskResult{}
+	taskChClosed := false
+	events := []event.Event{}
+	eventChClosed := false
+	timer := time.NewTimer(timeout)
+	for {
+		select {
+		case tr, ok := <-taskContext.TaskChannel():
+			if !ok {
+				taskChClosed = true
+				if eventChClosed {
+					timer.Stop()
+					return taskResults, events, nil
+				}
+			}
+			taskResults = append(taskResults, tr)
+		case e, ok := <-taskContext.EventChannel():
+			if !ok {
+				eventChClosed = true
+				if taskChClosed {
+					timer.Stop()
+					return taskResults, events, nil
+				}
+			}
+			events = append(events, e)
+		case <-timer.C:
+			// timed out
+			return taskResults, events, context.DeadlineExceeded
+		}
 	}
 }


### PR DESCRIPTION
- Previous behavior returned all objects being waited on
- Updated WaitTask tests to wait for all TaskResults and Events

Fixes an old bug and cleans up some tech debt from https://github.com/kubernetes-sigs/cli-utils/pull/451

This change is probably mutually exclusive to https://github.com/kubernetes-sigs/cli-utils/pull/463, because with this change uses a single bulk WaitEvent and that change replaces it with individual WaitEvents.