### PR TITLE
Removed unused command PreProcess function

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -73,7 +73,6 @@ func ApplyCommand(f cmdutil.Factory, invFactory inventory.InventoryClientFactory
 
 type ApplyRunner struct {
 	Command    *cobra.Command
-	PreProcess func(info inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error)
 	ioStreams  genericclioptions.IOStreams
 	factory    cmdutil.Factory
 	invFactory inventory.InventoryClientFactory
@@ -137,13 +136,6 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
-
-	if r.PreProcess != nil {
-		inventoryPolicy, err = r.PreProcess(inv, common.DryRunNone)
-		if err != nil {
-			return err
-		}
-	}
 
 	statusPoller, err := factory.NewStatusPoller(r.factory)
 	if err != nil {

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -63,7 +63,6 @@ func DestroyCommand(f cmdutil.Factory, invFactory inventory.InventoryClientFacto
 // DestroyRunner encapsulates data necessary to run the destroy command.
 type DestroyRunner struct {
 	Command    *cobra.Command
-	PreProcess func(info inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error)
 	ioStreams  genericclioptions.IOStreams
 	factory    cmdutil.Factory
 	invFactory inventory.InventoryClientFactory
@@ -107,13 +106,6 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
-
-	if r.PreProcess != nil {
-		inventoryPolicy, err = r.PreProcess(inv, common.DryRunNone)
-		if err != nil {
-			return err
-		}
-	}
 
 	statusPoller, err := factory.NewStatusPoller(r.factory)
 	if err != nil {

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -74,7 +74,6 @@ func PreviewCommand(f cmdutil.Factory, invFactory inventory.InventoryClientFacto
 // PreviewRunner encapsulates data necessary to run the preview command.
 type PreviewRunner struct {
 	Command    *cobra.Command
-	PreProcess func(info inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error)
 	factory    cmdutil.Factory
 	invFactory inventory.InventoryClientFactory
 	loader     manifestreader.ManifestLoader
@@ -122,13 +121,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
-
-	if r.PreProcess != nil {
-		inventoryPolicy, err = r.PreProcess(inv, drs)
-		if err != nil {
-			return err
-		}
-	}
 
 	statusPoller, err := factory.NewStatusPoller(r.factory)
 	if err != nil {


### PR DESCRIPTION
* Removes unused `PreProcess` function for `InventoryPolicy`, which is also not exported since it is under `cmd`.