### PR TITLE
Run `make all`

### DIFF
--- a/pkg/apply/event/type_string.go
+++ b/pkg/apply/event/type_string.go
@@ -15,11 +15,12 @@ func _() {
 	_ = x[StatusType-4]
 	_ = x[PruneType-5]
 	_ = x[DeleteType-6]
+	_ = x[WaitType-7]
 }
 
-const _Type_name = "InitTypeErrorTypeActionGroupTypeApplyTypeStatusTypePruneTypeDeleteType"
+const _Type_name = "InitTypeErrorTypeActionGroupTypeApplyTypeStatusTypePruneTypeDeleteTypeWaitType"
 
-var _Type_index = [...]uint8{0, 8, 17, 32, 41, 51, 60, 70}
+var _Type_index = [...]uint8{0, 8, 17, 32, 41, 51, 60, 70, 78}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
This includes the diff generated by `make all` except for the copyright diff:
```
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
```