### PR TITLE
Exports Applier/Destroyer StatusPoller field

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
-	"sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 func GetApplyRunner(factory cmdutil.Factory, invFactory inventory.InventoryClientFactory,
@@ -137,10 +136,6 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
 
-	statusPoller, err := factory.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
@@ -148,7 +143,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// Run the applier. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	a, err := apply.NewApplier(r.factory, invClient, statusPoller)
+	a, err := apply.NewApplier(r.factory, invClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
-	"sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 // GetDestroyRunner creates and returns the DestroyRunner which stores the cobra command.
@@ -107,15 +106,11 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
 
-	statusPoller, err := factory.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
 	}
-	d, err := apply.NewDestroyer(r.factory, invClient, statusPoller)
+	d, err := apply.NewDestroyer(r.factory, invClient)
 	if err != nil {
 		return err
 	}

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
-	"sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 var (
@@ -122,11 +121,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 	}
 	inv := inventory.WrapInventoryInfoObj(invObj)
 
-	statusPoller, err := factory.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
-
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
@@ -139,7 +133,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		a, err := apply.NewApplier(r.factory, invClient, statusPoller)
+		a, err := apply.NewApplier(r.factory, invClient)
 		if err != nil {
 			return err
 		}
@@ -154,7 +148,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 			InventoryPolicy:   inventoryPolicy,
 		})
 	} else {
-		d, err := apply.NewDestroyer(r.factory, invClient, statusPoller)
+		d, err := apply.NewDestroyer(r.factory, invClient)
 		if err != nil {
 			return err
 		}

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -75,8 +75,9 @@ func newTestApplier(
 
 	invClient := newTestInventory(t, tf, infoHelper)
 
-	applier, err := NewApplier(tf, invClient, statusPoller)
+	applier, err := NewApplier(tf, invClient)
 	require.NoError(t, err)
+	applier.StatusPoller = statusPoller
 
 	// Inject the fakeInfoHelper to allow generating Info
 	// objects that use the FakeRESTClient as the UnstructuredClient.
@@ -100,8 +101,9 @@ func newTestDestroyer(
 
 	invClient := newTestInventory(t, tf, infoHelper)
 
-	destroyer, err := NewDestroyer(tf, invClient, statusPoller)
+	destroyer, err := NewDestroyer(tf, invClient)
 	require.NoError(t, err)
+	destroyer.StatusPoller = statusPoller
 
 	return destroyer
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -352,10 +352,8 @@ func newApplierFromInvFactory(invFactory inventory.InventoryClientFactory) *appl
 	f := newFactory()
 	invClient, err := invFactory.NewInventoryClient(f)
 	Expect(err).NotTo(HaveOccurred())
-	statusPoller, err := factory.NewStatusPoller(f)
-	Expect(err).NotTo(HaveOccurred())
 
-	a, err := apply.NewApplier(f, invClient, statusPoller)
+	a, err := apply.NewApplier(f, invClient)
 	Expect(err).NotTo(HaveOccurred())
 	return a
 }
@@ -364,10 +362,8 @@ func newDestroyerFromInvFactory(invFactory inventory.InventoryClientFactory) *ap
 	f := newFactory()
 	invClient, err := invFactory.NewInventoryClient(f)
 	Expect(err).NotTo(HaveOccurred())
-	statusPoller, err := factory.NewStatusPoller(f)
-	Expect(err).NotTo(HaveOccurred())
 
-	d, err := apply.NewDestroyer(f, invClient, statusPoller)
+	d, err := apply.NewDestroyer(f, invClient)
 	Expect(err).NotTo(HaveOccurred())
 	return d
 }


### PR DESCRIPTION
* Exports `StatusPoller` fields for `Applier` and `Destroyer` so they can be overwritten if necessary.
* Removes the status poller parameter from `NewApplier` and `NewDestroyer`, assigning the default status poller instead.
* The two known library clients use the default status poller, so this will result in only code removal.