### PR TITLE
Fixes the error returned from running `make verify-kapply-e2e` locally

### DIFF
--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -171,7 +171,7 @@ expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured,
 
 # Verify that preview didn't create any resources.
 kubectl get all -n hellospace > $OUTPUT/status 2>&1
-expectedOutputLine "No resources found in hellospace namespace."
+expectedOutputLine "No resources found."
 ```
 
 Use the `kapply` binary in `MYGOBIN` to apply a deployment and verify it is successful.


### PR DESCRIPTION
Running `make verify-kapply-e2e` locally on kind v0.11.1 go1.16.7 linux/amd64 failed because
`kubectl get all -n hellospace` returns `No resources found.` instead of
`No resources found in hellospace namespace.`