### PR TITLE
fix: race condition in BuildInfo

### DIFF
--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -102,6 +102,9 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			// Set the client and mapping fields on the provided
 			// info so they can be applied to the cluster.
 			info, err := a.InfoHelper.BuildInfo(obj)
+			// BuildInfo strips path annotations.
+			// Use modified object for filters, mutations, and events.
+			obj = info.Object.(*unstructured.Unstructured)
 			id := object.UnstructuredToObjMetaOrDie(obj)
 			if err != nil {
 				if klog.V(4).Enabled() {

--- a/pkg/object/infos.go
+++ b/pkg/object/infos.go
@@ -44,6 +44,9 @@ func InfoToUnstructured(info *resource.Info) *unstructured.Unstructured {
 // UnstructuredToInfo transforms the passed Unstructured object into Info format,
 // or an error if one occurs.
 func UnstructuredToInfo(obj *unstructured.Unstructured) (*resource.Info, error) {
+	// make a copy of the input object to avoid modifying the input
+	obj = obj.DeepCopy()
+
 	annos := obj.GetAnnotations()
 
 	source := "unstructured"


### PR DESCRIPTION
Historically, the objects in ApplyTask were being modified in the
Start func by BuildInfo to remove the path annotation, but this can
cause a race condition in the task runner if it tried to read the
task objects.

Now a DeepCopy is made in BuildInfo instead. This avoids the race
condition but broke mutation, which executes after BuildInfo on the
original object. So we now extract the object from the into after
BuildInfo and use that instead for mutations, filters, and events.