### PR TITLE
feat: Add apply/destroy --status-events flag

### DIFF
--- a/examples/alphaTestExamples/MultipleServices.md
+++ b/examples/alphaTestExamples/MultipleServices.md
@@ -74,7 +74,7 @@ kind create cluster
 Let's apply the mysql service
 <!-- @RunMysql @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE/mysql --reconcile-timeout=120s > $OUTPUT/status;
+kapply apply $BASE/mysql --reconcile-timeout=120s --status-events > $OUTPUT/status;
 
 expectedOutputLine "deployment.apps/mysql is Current: Deployment is available. Replicas: 1"
 
@@ -94,7 +94,7 @@ expectedOutputLine "0"
 And the apply the wordpress service
 <!-- @RunWordpress @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE/wordpress --reconcile-timeout=120s > $OUTPUT/status;
+kapply apply $BASE/wordpress --reconcile-timeout=120s --status-events > $OUTPUT/status;
 
 expectedOutputLine "service/wordpress is Current: Service is ready"
 

--- a/examples/alphaTestExamples/crds.md
+++ b/examples/alphaTestExamples/crds.md
@@ -122,7 +122,7 @@ expectedOutputLine "inventory-template.yaml"
 Use the `kapply` binary in `MYGOBIN` to apply both the CRD and the CR.
 <!-- @runApply @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
+kapply apply $BASE --reconcile-timeout=1m --status-events> $OUTPUT/status
 
 expectedOutputLine "foo.custom.io/example-foo is Current: Resource is current"
 

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -177,7 +177,7 @@ expectedOutputLine "No resources found in hellospace namespace."
 Use the `kapply` binary in `MYGOBIN` to apply a deployment and verify it is successful.
 <!-- @runHelloApp @testE2EAgainstLatestRelease -->
 ```
-kapply apply $BASE --reconcile-timeout=1m > $OUTPUT/status
+kapply apply $BASE --reconcile-timeout=1m --status-events > $OUTPUT/status
 
 expectedOutputLine "deployment.apps/the-deployment is Current: Deployment is available. Replicas: 3"
 
@@ -207,7 +207,7 @@ EOF
 
 rm $BASE/configMap.yaml
 
-kapply apply $BASE --reconcile-timeout=120s > $OUTPUT/status;
+kapply apply $BASE --reconcile-timeout=120s --status-events > $OUTPUT/status;
 
 expectedOutputLine "configmap/the-map2 is Current: Resource is always ready"
 


### PR DESCRIPTION
- Status events disabled by default
- Status events always enabled for table output

The table output has a status column which doesn't work when status events are disabled. So they either need to be enabled or a way added to remove the column. I opted for the simpler solution.

The current "enable only if timeout is set" doesn't make any sense, because it defaults to a 1m timeout and we want to make it wait forever anyway. So I just removed that bit and disabled the status events by default.