### PR TITLE
fix: Colorize example tests

### DIFF
--- a/examples/alphaTestExamples/init.md
+++ b/examples/alphaTestExamples/init.md
@@ -25,11 +25,18 @@ BASE=$DEMO_HOME/base
 mkdir -p $BASE
 OUTPUT=$DEMO_HOME/output
 mkdir -p $OUTPUT
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
 
 function expectedOutputLine() {
-  test 1 == \
-  $(grep "$@" $OUTPUT/status | wc -l); \
-  echo $?
+  if ! grep -q "$@" "$OUTPUT/status"; then
+    echo -e "${RED}Error: output line not found${NC}"
+    echo -e "${RED}Expected: $@${NC}"
+    exit 1
+  else
+    echo -e "${GREEN}Success: output line found${NC}"
+  fi
 }
 ```
 
@@ -93,7 +100,7 @@ Use the kapply init command to generate the inventory template. This contains
 the namespace and inventory id used by apply to create inventory objects. 
 <!-- @createInventoryTemplate @testE2EAgainstLatestRelease-->
 ```
-kapply init $BASE > $OUTPUT/status
+kapply init $BASE | tee $OUTPUT/status
 expectedOutputLine "namespace: test-namespace is used for inventory object"
 ```
 
@@ -116,7 +123,7 @@ EOF
 # Remove the initial inventory template.
 rm -f $BASE/inventory-template.yaml
 
-kapply init $BASE > $OUTPUT/status
+kapply init $BASE | tee $OUTPUT/status
 expectedOutputLine "namespace: default is used for inventory object"
 ```
 
@@ -150,7 +157,7 @@ rules:
   verbs: ["get", "watch", "list"]
 EOF
 
-kapply init $BASE > $OUTPUT/status
+kapply init $BASE | tee $OUTPUT/status
 expectedOutputLine "namespace: test-namespace is used for inventory object"
 ```
 

--- a/hack/testExamplesE2EAgainstKapply.sh
+++ b/hack/testExamplesE2EAgainstKapply.sh
@@ -7,7 +7,39 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-mdrip -alsologtostderr -v 10 --blockTimeOut 6m0s --mode test \
-    --label testE2EAgainstLatestRelease examples/alphaTestExamples
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
 
-echo "Example e2e tests passed against ."
+succeeded=0
+failed=0
+
+function run_test() {
+    mdrip -alsologtostderr -v 10 --blockTimeOut 6m0s --mode test \
+        --label testE2EAgainstLatestRelease "${1}"
+}
+
+for path in examples/alphaTestExamples/*.md; do
+    test_name="$(basename "${path}")"
+    echo "-----------------------------------"
+    echo "Example Test: ${test_name}"
+    echo "-----------------------------------"
+    if run_test "${path}"; then
+        echo
+        echo -e "${GREEN}Example Test Succeeded: ${test_name}${NC}"
+        let "succeeded+=1"
+    else
+        echo
+        echo -e "${RED}Example Test Failed: ${test_name}${NC}"
+        let "failed+=1"
+    fi
+  echo
+done
+
+if [[ ${failed} -gt 0 ]]; then
+    echo -e "${RED}Example Tests Complete (succeeded: ${succeeded}, failed: ${failed})${NC}"
+    exit 1
+else
+    echo -e "${GREEN}Example Tests Complete (succeeded: ${succeeded}, failed: ${failed})${NC}"
+    exit 0
+fi


### PR DESCRIPTION
Makes the `expectedOutputLine` and `expectedNotFound` tests succeed green and fail red, with re-printed expectation on failure, to make it easier to see problems at a glance when running locally.