### PR TITLE
No need to lowercase namespaces

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,12 +308,11 @@ func handleError(eventChannel chan event.Event, err error) {
 func localNamespaces(localInv inventory.InventoryInfo, localObjs []object.ObjMetadata) sets.String {
 	namespaces := sets.NewString()
 	for _, obj := range localObjs {
-		namespace := strings.ToLower(obj.Namespace)
-		if namespace != "" {
-			namespaces.Insert(namespace)
+		if obj.Namespace != "" {
+			namespaces.Insert(obj.Namespace)
 		}
 	}
-	invNamespace := strings.ToLower(localInv.Namespace())
+	invNamespace := localInv.Namespace()
 	if invNamespace != "" {
 		namespaces.Insert(invNamespace)
 	}


### PR DESCRIPTION
They are lowercase and that's enforced by Kubernetes. We [don't lowercase](https://github.com/kubernetes-sigs/cli-utils/blob/8da78378653820d12a12b9a92103ab302e4591b9/pkg/apply/filter/local-namespaces-filter.go#L38) the namespaces' names when we perform the check anyway.