### PR TITLE
fix: Add context & timeouts to e2e tests

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -56,18 +56,18 @@ func withDependsOn(obj *unstructured.Unstructured, dep string) *unstructured.Uns
 	return obj
 }
 
-func deleteUnstructuredAndWait(c client.Client, obj *unstructured.Unstructured) {
+func deleteUnstructuredAndWait(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {
 	ref := mutation.NewResourceReference(obj)
 
-	err := c.Delete(context.TODO(), obj,
+	err := c.Delete(ctx, obj,
 		client.PropagationPolicy(metav1.DeletePropagationForeground))
 	Expect(err).NotTo(HaveOccurred(),
 		"expected DELETE to not error (%s): %s", ref, err)
 
-	waitForDeletion(c, obj)
+	waitForDeletion(ctx, c, obj)
 }
 
-func waitForDeletion(c client.Client, obj *unstructured.Unstructured) {
+func waitForDeletion(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {
 	ref := mutation.NewResourceReference(obj)
 	resultObj := ref.Unstructured()
 
@@ -84,7 +84,7 @@ func waitForDeletion(c client.Client, obj *unstructured.Unstructured) {
 			Fail("timed out waiting for resource to be fully deleted")
 			return
 		case <-s.C:
-			err := c.Get(context.TODO(), types.NamespacedName{
+			err := c.Get(ctx, types.NamespacedName{
 				Namespace: obj.GetNamespace(),
 				Name:      obj.GetName(),
 			}, resultObj)
@@ -98,7 +98,17 @@ func waitForDeletion(c client.Client, obj *unstructured.Unstructured) {
 	}
 }
 
-func waitForCreation(c client.Client, obj *unstructured.Unstructured) {
+func createUnstructuredAndWait(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {
+	ref := mutation.NewResourceReference(obj)
+
+	err := c.Create(ctx, obj)
+	Expect(err).NotTo(HaveOccurred(),
+		"expected CREATE to not error (%s): %s", ref, err)
+
+	waitForCreation(ctx, c, obj)
+}
+
+func waitForCreation(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {
 	ref := mutation.NewResourceReference(obj)
 	resultObj := ref.Unstructured()
 
@@ -115,7 +125,7 @@ func waitForCreation(c client.Client, obj *unstructured.Unstructured) {
 			Fail("timed out waiting for resource to be fully created")
 			return
 		case <-s.C:
-			err := c.Get(context.TODO(), types.NamespacedName{
+			err := c.Get(ctx, types.NamespacedName{
 				Namespace: obj.GetNamespace(),
 				Name:      obj.GetName(),
 			}, resultObj)
@@ -130,11 +140,11 @@ func waitForCreation(c client.Client, obj *unstructured.Unstructured) {
 	}
 }
 
-func assertUnstructuredExists(c client.Client, obj *unstructured.Unstructured) *unstructured.Unstructured {
+func assertUnstructuredExists(ctx context.Context, c client.Client, obj *unstructured.Unstructured) *unstructured.Unstructured {
 	ref := mutation.NewResourceReference(obj)
 	resultObj := ref.Unstructured()
 
-	err := c.Get(context.TODO(), types.NamespacedName{
+	err := c.Get(ctx, types.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}, resultObj)
@@ -143,11 +153,11 @@ func assertUnstructuredExists(c client.Client, obj *unstructured.Unstructured) *
 	return resultObj
 }
 
-func assertUnstructuredDoesNotExist(c client.Client, obj *unstructured.Unstructured) {
+func assertUnstructuredDoesNotExist(ctx context.Context, c client.Client, obj *unstructured.Unstructured) {
 	ref := mutation.NewResourceReference(obj)
 	resultObj := ref.Unstructured()
 
-	err := c.Get(context.TODO(), types.NamespacedName{
+	err := c.Get(ctx, types.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	}, resultObj)

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
+func continueOnErrorTest(ctx context.Context, c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
 	By("apply an invalid CRD")
 	applier := invConfig.ApplierFactoryFunc()
 
@@ -30,7 +30,7 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 		withNamespace(manifestToUnstructured(pod1), namespaceName),
 	}
 
-	applierEvents := runCollect(applier.Run(context.TODO(), inv, resources, apply.Options{}))
+	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{}))
 
 	expEvents := []testutil.ExpEvent{
 		{
@@ -140,8 +140,8 @@ func continueOnErrorTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	Expect(receivedEvents).To(testutil.Equal(expEvents))
 
 	By("Verify pod1 created")
-	assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod1), namespaceName))
+	assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod1), namespaceName))
 
 	By("Verify CRD not created")
-	assertUnstructuredDoesNotExist(c, manifestToUnstructured(invalidCrd))
+	assertUnstructuredDoesNotExist(ctx, c, manifestToUnstructured(invalidCrd))
 }

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 //nolint:dupl // expEvents similar to mutation tests
-func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
+func crdTest(ctx context.Context, _ client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
 	By("apply a set of resources that includes both a crd and a cr")
 	applier := invConfig.ApplierFactoryFunc()
 
@@ -34,7 +34,7 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 		crdObj,
 	}
 
-	applierEvents := runCollect(applier.Run(context.TODO(), inv, resources, apply.Options{
+	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: false,
 	}))
@@ -215,7 +215,7 @@ func crdTest(_ client.Client, invConfig InventoryConfig, inventoryName, namespac
 	By("destroy the resources, including the crd")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(context.TODO(), inv, options))
+	destroyerEvents := runCollect(destroyer.Run(ctx, inv, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/deletion_prevention_test.go
+++ b/test/e2e/deletion_prevention_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func deletionPreventionTest(c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
+func deletionPreventionTest(ctx context.Context, c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply resources")
 	applier := invConfig.ApplierFactoryFunc()
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
@@ -30,68 +30,68 @@ func deletionPreventionTest(c client.Client, invConfig InventoryConfig, inventor
 		withAnnotation(withNamespace(manifestToUnstructured(pod2), namespaceName), common.LifecycleDeleteAnnotation, common.PreventDeletion),
 	}
 
-	runCollect(applier.Run(context.TODO(), inventoryInfo, resources, apply.Options{
+	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 	}))
 
 	By("Verify deployment created")
-	obj := assertUnstructuredExists(c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
+	obj := assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify pod1 created")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod1), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify pod2 created")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod2), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod2), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify the inventory size is 3")
-	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 3)
+	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 3)
 
 	resources = []*unstructured.Unstructured{
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
 
-	runCollect(applier.Run(context.TODO(), inventoryInfo, resources, apply.Options{
+	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		DryRunStrategy:   common.DryRunClient,
 	}))
 	By("Verify deployment still exists and has the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify pod1 still exits and does not have the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod1), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify pod2 still exits and does not have the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod2), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod2), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify the inventory size is still 3")
-	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 3)
+	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 3)
 
 	resources = []*unstructured.Unstructured{
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 	}
 
-	runCollect(applier.Run(context.TODO(), inventoryInfo, resources, apply.Options{
+	runCollect(applier.Run(ctx, inventoryInfo, resources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 	}))
 
 	By("Verify deployment still exists and has the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.ID()))
 
 	By("Verify pod1 still exits and does not have the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod1), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod1), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(""))
 
 	By("Verify pod2 still exits and does not have the config.k8s.io/owning-inventory annotation")
-	obj = assertUnstructuredExists(c, withNamespace(manifestToUnstructured(pod2), namespaceName))
+	obj = assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(pod2), namespaceName))
 	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(""))
 
 	By("Verify the inventory size is 1")
-	invConfig.InvSizeVerifyFunc(c, inventoryName, namespaceName, inventoryID, 1)
+	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 1)
 }

--- a/test/e2e/serverside_apply_test.go
+++ b/test/e2e/serverside_apply_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func serversideApplyTest(c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
+func serversideApplyTest(ctx context.Context, c client.Client, invConfig InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply a Deployment and an APIService by server-side apply")
 	applier := invConfig.ApplierFactoryFunc()
 
@@ -27,7 +27,7 @@ func serversideApplyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 		manifestToUnstructured(apiservice1),
 	}
 
-	runWithNoErr(applier.Run(context.TODO(), inv, firstResources, apply.Options{
+	runWithNoErr(applier.Run(ctx, inv, firstResources, apply.Options{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		ServerSideOptions: common.ServerSideOptions{
@@ -38,7 +38,7 @@ func serversideApplyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	}))
 
 	By("Verify deployment is server-side applied")
-	result := assertUnstructuredExists(c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
+	result := assertUnstructuredExists(ctx, c, withNamespace(manifestToUnstructured(deployment1), namespaceName))
 
 	// LastAppliedConfigAnnotation annotation is only set for client-side apply and we've server-side applied here.
 	_, found, err := testutil.NestedField(result.Object, "metadata", "annotations", v1.LastAppliedConfigAnnotation)
@@ -51,7 +51,7 @@ func serversideApplyTest(c client.Client, invConfig InventoryConfig, inventoryNa
 	Expect(manager).To(Equal("test"))
 
 	By("Verify APIService is server-side applied")
-	result = assertUnstructuredExists(c, manifestToUnstructured(apiservice1))
+	result = assertUnstructuredExists(ctx, c, manifestToUnstructured(apiservice1))
 
 	// LastAppliedConfigAnnotation annotation is only set for client-side apply and we've server-side applied here.
 	_, found, err = testutil.NestedField(result.Object, "metadata", "annotations", v1.LastAppliedConfigAnnotation)


### PR DESCRIPTION
Tests will now each have a context that is cancelled on timeout.
BeforeEach and AfterEach blocks have their own timeouts, to allow
bounded setup and cleanup.

- Test Timeout: 5m
- Before Test Timeout: 30s
- After Test Timeout: 30s