### PR TITLE
fix: Ensure WaitTask gets StatusUpdate

### DIFF
--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -201,8 +201,6 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 			}
 
 			id := statusEvent.Resource.Identifier
-			oldStatus := taskContext.ResourceCache().Get(id).Status
-			newStatus := statusEvent.Resource.Status
 
 			// Update the cache to track the latest resource spec & status.
 			// Status is computed from the resource on-demand.
@@ -215,7 +213,7 @@ func (b *baseRunner) run(ctx context.Context, taskQueue chan Task,
 
 			// send a status update to the running task, but only if the status
 			// has changed and the task is tracking the object.
-			if oldStatus != newStatus && currentTask.Identifiers().Contains(id) {
+			if currentTask.Identifiers().Contains(id) {
 				currentTask.StatusUpdate(taskContext, id)
 			}
 		// A message on the taskChannel means that the current task


### PR DESCRIPTION
This fixes a flakey test failure in the inventory policy test.

The failure was caused by the Deployment becoming reconciled
imediately after apply, before the WaitTask has started. Normally,
this should be fine, but the task runner was "de-duping" status
events without checking for generation changes. So when the status
went from NotFound (gen 1) to Current (gen 2), it was sent to the
still running ApplyTask. And when the status went from Current
(gen 2) to Current (gen 3), it was being de-duped and not sent to
the WaitTask.

Since the inventory test is the only e2e test performing an update,
it's the only one that was failing, and only sometimes.

The fix is to remove de-duping from the task runner, because the
status poller already performs its own deduping:
statusPollerRunner.isUpdatedResourceStatus.