### PR TITLE
fix: Make testutil.AssertEqual more like testify

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -1258,7 +1258,9 @@ func TestApplier(t *testing.T) {
 			sort.Sort(testutil.GroupedEventsByID(receivedEvents))
 
 			// Validate the rest of the events
-			testutil.AssertEqual(t, receivedEvents, tc.expectedEvents)
+			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents,
+				"Actual events (%d) do not match expected events (%d)",
+				len(receivedEvents), len(tc.expectedEvents))
 
 			// Validate that the expected timeout was the cause of the run completion.
 			// just in case something else cancelled the run
@@ -1690,7 +1692,9 @@ func TestApplierCancel(t *testing.T) {
 			}
 
 			// Validate the rest of the events
-			testutil.AssertEqual(t, receivedEvents, tc.expectedEvents)
+			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents,
+				"Actual events (%d) do not match expected events (%d)",
+				len(receivedEvents), len(tc.expectedEvents))
 
 			// Validate that the expected timeout was the cause of the run completion.
 			// just in case something else cancelled the run
@@ -1819,8 +1823,13 @@ func TestReadAndPrepareObjects(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			testutil.AssertEqual(t, tc.applyObjs, applyObjs)
-			testutil.AssertEqual(t, tc.pruneObjs, pruneObjs)
+			testutil.AssertEqual(t, applyObjs, tc.applyObjs,
+				"Actual applied objects (%d) do not match expected applied objects (%d)",
+				len(applyObjs), len(tc.applyObjs))
+
+			testutil.AssertEqual(t, pruneObjs, tc.pruneObjs,
+				"Actual pruned objects (%d) do not match expected pruned objects (%d)",
+				len(pruneObjs), len(tc.pruneObjs))
 		})
 	}
 }

--- a/pkg/apply/destroyer_test.go
+++ b/pkg/apply/destroyer_test.go
@@ -375,7 +375,9 @@ func TestDestroyerCancel(t *testing.T) {
 			}
 
 			// Validate the rest of the events
-			testutil.AssertEqual(t, receivedEvents, tc.expectedEvents)
+			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents,
+				"Actual events (%d) do not match expected events (%d)",
+				len(receivedEvents), len(tc.expectedEvents))
 
 			// Validate that the expected timeout was the cause of the run completion.
 			// just in case something else cancelled the run

--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -232,7 +232,9 @@ func TestInvSetTask(t *testing.T) {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
 			actual, _ := client.GetClusterObjs(nil, common.DryRunNone)
-			testutil.AssertEqual(t, actual, tc.expectedObjs)
+			testutil.AssertEqual(t, tc.expectedObjs, actual,
+				"Actual cluster objects (%d) do not match expected cluster objects (%d)",
+				len(actual), len(tc.expectedObjs))
 		})
 	}
 }

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -202,7 +202,9 @@ loop:
 			},
 		},
 	}
-	testutil.AssertEqual(t, receivedEvents, expectedEvents)
+	testutil.AssertEqual(t, expectedEvents, receivedEvents,
+		"Actual events (%d) do not match expected events (%d)",
+		len(receivedEvents), len(expectedEvents))
 }
 
 func TestWaitTask_Timeout(t *testing.T) {
@@ -327,7 +329,9 @@ loop:
 			},
 		},
 	}
-	testutil.AssertEqual(t, receivedEvents, expectedEvents)
+	testutil.AssertEqual(t, expectedEvents, receivedEvents,
+		"Actual events (%d) do not match expected events (%d)",
+		len(receivedEvents), len(expectedEvents))
 }
 
 func TestWaitTask_StartAndComplete(t *testing.T) {
@@ -390,7 +394,9 @@ loop:
 			},
 		},
 	}
-	testutil.AssertEqual(t, receivedEvents, expectedEvents)
+	testutil.AssertEqual(t, expectedEvents, receivedEvents,
+		"Actual events (%d) do not match expected events (%d)",
+		len(receivedEvents), len(expectedEvents))
 }
 
 func TestWaitTask_Cancel(t *testing.T) {
@@ -450,7 +456,9 @@ loop:
 			},
 		},
 	}
-	testutil.AssertEqual(t, receivedEvents, expectedEvents)
+	testutil.AssertEqual(t, expectedEvents, receivedEvents,
+		"Actual events (%d) do not match expected events (%d)",
+		len(receivedEvents), len(expectedEvents))
 }
 
 func TestWaitTask_SingleTaskResult(t *testing.T) {
@@ -531,7 +539,9 @@ loop:
 			},
 		},
 	}
-	testutil.AssertEqual(t, receivedEvents, expectedEvents)
+	testutil.AssertEqual(t, expectedEvents, receivedEvents,
+		"Actual events (%d) do not match expected events (%d)",
+		len(receivedEvents), len(expectedEvents))
 
 	expectedResults := []TaskResult{
 		{}, // Empty result means success


### PR DESCRIPTION
- Swap actual and expected arguments
- Add optional Sprintf arguments
- Add messages to existing usages