### PR TITLE
fix: Make UnknownTypesError error more readable

### DIFF
--- a/pkg/manifestreader/common.go
+++ b/pkg/manifestreader/common.go
@@ -25,11 +25,12 @@ type UnknownTypesError struct {
 }
 
 func (e *UnknownTypesError) Error() string {
-	var gks []string
-	for _, gk := range e.GroupVersionKinds {
-		gks = append(gks, gk.String())
+	var gvks []string
+	for _, gvk := range e.GroupVersionKinds {
+		gvks = append(gvks, fmt.Sprintf("%s/%s/%s",
+			gvk.Group, gvk.Version, gvk.Kind))
 	}
-	return fmt.Sprintf("unknown resource types: %s", strings.Join(gks, ","))
+	return fmt.Sprintf("unknown resource types: %s", strings.Join(gvks, ","))
 }
 
 // NamespaceMismatchError is returned if all resources must be in a specific


### PR DESCRIPTION
- Fix regression from switch to GroupVersionKind from GroupKind
- New error string format: G/V/K, G/V/K
- Avoid K.G/V, which looks like but isn't R.G/V

Fixes: https://github.com/kubernetes-sigs/cli-utils/pull/430#issuecomment-966737188