### PR TITLE
[WIP] fix: Require src namespace in apply-time-mutation

### DIFF
--- a/pkg/apply/mutator/apply_time_mutator.go
+++ b/pkg/apply/mutator/apply_time_mutator.go
@@ -57,7 +57,7 @@ func (atm *ApplyTimeMutator) Mutate(ctx context.Context, obj *unstructured.Unstr
 		return mutated, reason, fmt.Errorf("failed to read annotation in resource (%s): %w", targetRef, err)
 	}
 
-	klog.V(4).Infof("target resource (%s):\n%s", targetRef, object.YamlStringer{O: obj})
+	klog.V(7).Infof("target resource (%s):\n%s", targetRef, object.YamlStringer{O: obj})
 
 	// validate no self-references
 	// Early validation to avoid GETs, but won't catch sources with implicit namespace.
@@ -78,7 +78,7 @@ func (atm *ApplyTimeMutator) Mutate(ctx context.Context, obj *unstructured.Unstr
 
 		// Default source namespace to target namesapce, if namespace-scoped
 		if sourceRef.Namespace == "" && sourceMapping.Scope.Name() == meta.RESTScopeNameNamespace {
-			sourceRef.Namespace = targetRef.Namespace
+			return mutated, reason, fmt.Errorf("invalid source reference (%s): missing required namespace", sourceRef)
 		}
 
 		// validate no self-references
@@ -93,7 +93,7 @@ func (atm *ApplyTimeMutator) Mutate(ctx context.Context, obj *unstructured.Unstr
 			return mutated, reason, fmt.Errorf("failed to get source resource (%s): %w", sourceRef, err)
 		}
 
-		klog.V(4).Infof("source resource (%s):\n%s", sourceRef, object.YamlStringer{O: sourceObj})
+		klog.V(7).Infof("source resource (%s):\n%s", sourceRef, object.YamlStringer{O: sourceObj})
 
 		// lookup target field in target resource
 		targetValue, _, err := readFieldValue(obj, sub.TargetPath)
@@ -145,7 +145,7 @@ func (atm *ApplyTimeMutator) Mutate(ctx context.Context, obj *unstructured.Unstr
 	}
 
 	if mutated {
-		klog.V(4).Infof("mutated target resource (%s):\n%s", targetRef, object.YamlStringer{O: obj})
+		klog.V(7).Infof("mutated target resource (%s):\n%s", targetRef, object.YamlStringer{O: obj})
 	}
 
 	return mutated, reason, nil

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -150,7 +150,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			err = a.mutate(ctx, obj)
 			if err != nil {
 				if klog.V(5).Enabled() {
-					klog.Errorf("error mutating: %w", err)
+					klog.Errorf("error mutating: %v", err)
 				}
 				taskContext.SendEvent(a.createApplyFailedEvent(id, err))
 				taskContext.AddFailedApply(id)

--- a/pkg/object/mutation/annotation.go
+++ b/pkg/object/mutation/annotation.go
@@ -35,13 +35,13 @@ func ReadAnnotation(obj *unstructured.Unstructured) (ApplyTimeMutation, error) {
 	if !found {
 		return mutation, nil
 	}
-	if klog.V(5).Enabled() {
-		klog.Infof("resource (%v) has apply-time-mutation annotation:\n%s", NewResourceReference(obj), mutationYaml)
-	}
+	objRef := NewResourceReference(obj)
+	klog.V(5).Infof("parsing annotation %q on object %q", Annotation, objRef)
 
 	err := yaml.Unmarshal([]byte(mutationYaml), &mutation)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse apply-time-mutation annotation: %q: %v", mutationYaml, err)
+		return nil, fmt.Errorf("failed to parse annotation %q on object %q: %v",
+			Annotation, objRef, err)
 	}
 	return mutation, nil
 }
@@ -57,7 +57,9 @@ func WriteAnnotation(obj *unstructured.Unstructured, mutation ApplyTimeMutation)
 	}
 	yamlBytes, err := yaml.Marshal(mutation)
 	if err != nil {
-		return fmt.Errorf("failed to format apply-time-mutation annotation: %#v: %v", mutation, err)
+		objRef := NewResourceReference(obj)
+		return fmt.Errorf("failed to format annotation %q on object %q: %v",
+			Annotation, objRef, err)
 	}
 	a := obj.GetAnnotations()
 	if a == nil {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -95,23 +95,25 @@ spec:
     image: k8s.gcr.io/pause:2.0
 `))
 
-var podA = []byte(strings.TrimSpace(`
+var podATemplate = strings.TrimSpace(`
 kind: Pod
 apiVersion: v1
 metadata:
   name: pod-a
-  namespace: test
+  namespace: {{.Namespace}}
   annotations:
     config.kubernetes.io/apply-time-mutation: |
       - sourceRef:
           kind: Pod
           name: pod-b
+          namespace: {{.Namespace}}
         sourcePath: $.status.podIP
         targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
         token: ${pob-b-ip}
       - sourceRef:
           kind: Pod
           name: pod-b
+          namespace: {{.Namespace}}
         sourcePath: $.spec.containers[?(@.name=="nginx")].ports[?(@.name=="tcp")].containerPort
         targetPath: $.spec.containers[?(@.name=="nginx")].env[?(@.name=="SERVICE_HOST")].value
         token: ${pob-b-port}
@@ -125,7 +127,7 @@ spec:
     env:
     - name: SERVICE_HOST
       value: "${pob-b-ip}:${pob-b-port}"
-`))
+`)
 
 var podB = []byte(strings.TrimSpace(`
 kind: Pod

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -4,8 +4,10 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"html/template"
 	"strings"
 	"time"
 
@@ -244,9 +246,22 @@ func manifestToUnstructured(manifest []byte) *unstructured.Unstructured {
 	u := make(map[string]interface{})
 	err := yaml.Unmarshal(manifest, &u)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to parse manifest yaml: %w", err))
 	}
 	return &unstructured.Unstructured{
 		Object: u,
 	}
+}
+
+func templateToUnstructured(tmpl string, data interface{}) *unstructured.Unstructured {
+	t, err := template.New("manifest").Parse(tmpl)
+	if err != nil {
+		panic(fmt.Errorf("failed to parse manifest go-template: %w", err))
+	}
+	var buffer bytes.Buffer
+	err = t.Execute(&buffer, data)
+	if err != nil {
+		panic(fmt.Errorf("failed to execute manifest go-template: %w", err))
+	}
+	return manifestToUnstructured(buffer.Bytes())
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Applier", func() {
 						withNamespace(manifestToUnstructured(pod1), namespace.GetName()),
 						withNamespace(manifestToUnstructured(pod2), namespace.GetName()),
 						withNamespace(manifestToUnstructured(pod3), namespace.GetName()),
-						withNamespace(manifestToUnstructured(podA), namespace.GetName()),
+						templateToUnstructured(podATemplate, struct{ Namespace string }{Namespace: namespace.GetName()}),
 						withNamespace(manifestToUnstructured(podB), namespace.GetName()),
 						withNamespace(manifestToUnstructured(deployment1), namespace.GetName()),
 						manifestToUnstructured(apiservice1),

--- a/test/e2e/mutation_test.go
+++ b/test/e2e/mutation_test.go
@@ -38,7 +38,7 @@ func mutationTest(ctx context.Context, c client.Client, invConfig InventoryConfi
 
 	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
 
-	podAObj := withNamespace(manifestToUnstructured(podA), namespaceName)
+	podAObj := templateToUnstructured(podATemplate, struct{ Namespace string }{Namespace: namespaceName})
 	podBObj := withNamespace(manifestToUnstructured(podB), namespaceName)
 
 	// Dependency order: podA -> podB


### PR DESCRIPTION
- This change dissables implicit namespace resolution for
  apply-time-mutation sourceRefs. This feature has been partially
  broken since it was implimented and fixing it is not currently
  possible. The sorting never worked properly because the namespace
  was being infered at apply time, while sorting was being done
  much earlier, before the tasks were scheduled.
- Unfortunately, this makes testing and usage harder when the
  namespace is not known in advance, requiring yaml templating.
- Avoid logging yaml at log lvl 5 (use lvl 7)
- Improve error messages when annotation read/write fails
- Warn if dependencies cannot be sorted
- Warn if dependency not in resource set

Fixes: https://github.com/kubernetes-sigs/cli-utils/issues/481