### PR TITLE
Avoid waiting for failed resources

### DIFF
--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -160,6 +160,7 @@ const (
 	Reconciled
 	ReconcileSkipped // Skipped
 	ReconcileTimeout // Timeout
+	ReconcileFailed  // Failed
 )
 
 type WaitEvent struct {

--- a/pkg/apply/event/waiteventoperation_string.go
+++ b/pkg/apply/event/waiteventoperation_string.go
@@ -12,11 +12,12 @@ func _() {
 	_ = x[Reconciled-1]
 	_ = x[ReconcileSkipped-2]
 	_ = x[ReconcileTimeout-3]
+	_ = x[ReconcileFailed-4]
 }
 
-const _WaitEventOperation_name = "PendingReconciledSkippedTimeout"
+const _WaitEventOperation_name = "PendingReconciledSkippedTimeoutFailed"
 
-var _WaitEventOperation_index = [...]uint8{0, 7, 17, 24, 31}
+var _WaitEventOperation_index = [...]uint8{0, 7, 17, 24, 31, 37}
 
 func (i WaitEventOperation) String() string {
 	if i < 0 || i >= WaitEventOperation(len(_WaitEventOperation_index)-1) {


### PR DESCRIPTION
This updates the WaitTask to handle resources that are reported as `Failed`. It prevents the library from waiting the full length of the wait timeout for resources that we know are unlikely to successfully reconcile.

The behavior is:
* If a resource is reported as `Failed`, the library will remove it from the set of resources we are waiting to be reconciled, add it to a set of failed resources, and send a `WaitEvent` with the `ReconciledFailed` operation.
* Any failed resources will not prevent a WaitTask from being completed if the other resources in the task have become `Current`. So a resource becoming `Failed` does not terminate a WaitTask, it just makes sure we don't end up waiting for the timeout to expire when we know resources are unlikely to successfully reconcile.
* If a resource becomes `Failed`, but happens to become unblocked before all other resources in the task has completed, it can transition out of the `Failed` state. It can move either into `Current` or `InProgress`.