### PR TITLE
Allow status readers to be reused between invocations

### DIFF
--- a/pkg/kstatus/polling/engine/status_reader.go
+++ b/pkg/kstatus/polling/engine/status_reader.go
@@ -22,9 +22,9 @@ type StatusReader interface {
 	// from the cluster and return an ResourceStatus that will contain
 	// information about the latest state of the resource, its computed status
 	// and information about any generated resources.
-	ReadStatus(ctx context.Context, resource object.ObjMetadata) *event.ResourceStatus
+	ReadStatus(ctx context.Context, reader ClusterReader, resource object.ObjMetadata) *event.ResourceStatus
 
 	// ReadStatusForObject is similar to ReadStatus, but instead of looking up the
 	// resource based on an identifier, it will use the passed-in resource.
-	ReadStatusForObject(ctx context.Context, object *unstructured.Unstructured) *event.ResourceStatus
+	ReadStatusForObject(ctx context.Context, reader ClusterReader, object *unstructured.Unstructured) *event.ResourceStatus
 }

--- a/pkg/kstatus/polling/statusreaders/common_test.go
+++ b/pkg/kstatus/polling/statusreaders/common_test.go
@@ -77,11 +77,10 @@ func TestLookupResource(t *testing.T) {
 			fakeMapper := fakemapper.NewFakeRESTMapper(deploymentGVK)
 
 			statusReader := &baseStatusReader{
-				reader: fakeReader,
 				mapper: fakeMapper,
 			}
 
-			u, err := statusReader.lookupResource(context.Background(), tc.identifier)
+			u, err := statusReader.lookupResource(context.Background(), fakeReader, tc.identifier)
 
 			if tc.expectErr {
 				if err == nil {

--- a/pkg/kstatus/polling/statusreaders/generic.go
+++ b/pkg/kstatus/polling/statusreaders/generic.go
@@ -19,12 +19,10 @@ import (
 // An example of a StatusFunc is status.Compute.
 type StatusFunc func(u *unstructured.Unstructured) (*status.Result, error)
 
-func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper, statusFunc StatusFunc) engine.StatusReader {
+func NewGenericStatusReader(mapper meta.RESTMapper, statusFunc StatusFunc) engine.StatusReader {
 	return &baseStatusReader{
-		reader: reader,
 		mapper: mapper,
 		resourceStatusReader: &genericStatusReader{
-			reader:     reader,
 			mapper:     mapper,
 			statusFunc: statusFunc,
 		},
@@ -38,7 +36,6 @@ func NewGenericStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper,
 // generated resources and where status can be computed only based on the
 // resource itself.
 type genericStatusReader struct {
-	reader engine.ClusterReader
 	mapper meta.RESTMapper
 
 	statusFunc StatusFunc
@@ -46,7 +43,7 @@ type genericStatusReader struct {
 
 var _ resourceTypeStatusReader = &genericStatusReader{}
 
-func (g *genericStatusReader) ReadStatusForObject(_ context.Context, resource *unstructured.Unstructured) *event.ResourceStatus {
+func (g *genericStatusReader) ReadStatusForObject(_ context.Context, _ engine.ClusterReader, resource *unstructured.Unstructured) *event.ResourceStatus {
 	identifier := object.UnstructuredToObjMetaOrDie(resource)
 
 	res, err := g.statusFunc(resource)

--- a/pkg/kstatus/polling/statusreaders/generic_test.go
+++ b/pkg/kstatus/polling/statusreaders/generic_test.go
@@ -62,7 +62,6 @@ func TestGenericStatusReader(t *testing.T) {
 			fakeReader := testutil.NewNoopClusterReader()
 			fakeMapper := fakemapper.NewFakeRESTMapper()
 			resourceStatusReader := &genericStatusReader{
-				reader: fakeReader,
 				mapper: fakeMapper,
 				statusFunc: func(u *unstructured.Unstructured) (*status.Result, error) {
 					return tc.result, tc.err
@@ -74,7 +73,7 @@ func TestGenericStatusReader(t *testing.T) {
 			o.SetName(name)
 			o.SetNamespace(namespace)
 
-			resourceStatus := resourceStatusReader.ReadStatusForObject(context.Background(), o)
+			resourceStatus := resourceStatusReader.ReadStatusForObject(context.Background(), fakeReader, o)
 
 			assert.Equal(t, tc.expectedIdentifier, resourceStatus.Identifier)
 			assert.Equal(t, tc.expectedStatus, resourceStatus.Status)

--- a/pkg/kstatus/polling/statusreaders/pod_controller.go
+++ b/pkg/kstatus/polling/statusreaders/pod_controller.go
@@ -16,9 +16,8 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
-func newPodControllerStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper, podStatusReader resourceTypeStatusReader) *podControllerStatusReader {
+func newPodControllerStatusReader(mapper meta.RESTMapper, podStatusReader resourceTypeStatusReader) *podControllerStatusReader {
 	return &podControllerStatusReader{
-		reader:          reader,
 		mapper:          mapper,
 		podStatusReader: podStatusReader,
 		groupKind: schema.GroupKind{
@@ -34,7 +33,6 @@ func newPodControllerStatusReader(reader engine.ClusterReader, mapper meta.RESTM
 // for resource types that act as controllers for pods. This is quite common, so
 // the logic is here instead of duplicated in each resource specific StatusReader.
 type podControllerStatusReader struct {
-	reader          engine.ClusterReader
 	mapper          meta.RESTMapper
 	podStatusReader resourceTypeStatusReader
 	groupKind       schema.GroupKind
@@ -44,10 +42,10 @@ type podControllerStatusReader struct {
 	statusForGenResourcesFunc statusForGenResourcesFunc
 }
 
-func (p *podControllerStatusReader) readStatus(ctx context.Context, obj *unstructured.Unstructured) *event.ResourceStatus {
+func (p *podControllerStatusReader) readStatus(ctx context.Context, reader engine.ClusterReader, obj *unstructured.Unstructured) *event.ResourceStatus {
 	identifier := object.UnstructuredToObjMetaOrDie(obj)
 
-	podResourceStatuses, err := p.statusForGenResourcesFunc(ctx, p.mapper, p.reader, p.podStatusReader, obj,
+	podResourceStatuses, err := p.statusForGenResourcesFunc(ctx, p.mapper, reader, p.podStatusReader, obj,
 		p.groupKind, "spec", "selector")
 	if err != nil {
 		return &event.ResourceStatus{

--- a/pkg/kstatus/polling/statusreaders/pod_controller_test.go
+++ b/pkg/kstatus/polling/statusreaders/pod_controller_test.go
@@ -81,7 +81,6 @@ func TestPodControllerStatusReader(t *testing.T) {
 			fakeReader := testutil.NewNoopClusterReader()
 			fakeMapper := fakemapper.NewFakeRESTMapper()
 			podControllerStatusReader := &podControllerStatusReader{
-				reader: fakeReader,
 				mapper: fakeMapper,
 				statusFunc: func(u *unstructured.Unstructured) (*status.Result, error) {
 					return tc.computeStatusResult, tc.computeStatusErr
@@ -94,7 +93,7 @@ func TestPodControllerStatusReader(t *testing.T) {
 			rs.SetName(name)
 			rs.SetNamespace(namespace)
 
-			resourceStatus := podControllerStatusReader.readStatus(context.Background(), rs)
+			resourceStatus := podControllerStatusReader.readStatus(context.Background(), fakeReader, rs)
 
 			assert.Equal(t, tc.expectedIdentifier, resourceStatus.Identifier)
 			assert.Equal(t, tc.expectedStatus, resourceStatus.Status)

--- a/pkg/kstatus/polling/statusreaders/replicaset.go
+++ b/pkg/kstatus/polling/statusreaders/replicaset.go
@@ -12,12 +12,10 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 )
 
-func NewReplicaSetStatusReader(reader engine.ClusterReader, mapper meta.RESTMapper, podStatusReader resourceTypeStatusReader) engine.StatusReader {
+func NewReplicaSetStatusReader(mapper meta.RESTMapper, podStatusReader resourceTypeStatusReader) engine.StatusReader {
 	return &baseStatusReader{
-		reader: reader,
 		mapper: mapper,
 		resourceStatusReader: &replicaSetStatusReader{
-			reader:          reader,
 			mapper:          mapper,
 			podStatusReader: podStatusReader,
 		},
@@ -28,7 +26,6 @@ func NewReplicaSetStatusReader(reader engine.ClusterReader, mapper meta.RESTMapp
 // from the cluster, knows how to find any Pods belonging to the ReplicaSet,
 // and compute status for the ReplicaSet.
 type replicaSetStatusReader struct {
-	reader engine.ClusterReader
 	mapper meta.RESTMapper
 
 	podStatusReader resourceTypeStatusReader
@@ -36,6 +33,6 @@ type replicaSetStatusReader struct {
 
 var _ resourceTypeStatusReader = &replicaSetStatusReader{}
 
-func (r *replicaSetStatusReader) ReadStatusForObject(ctx context.Context, rs *unstructured.Unstructured) *event.ResourceStatus {
-	return newPodControllerStatusReader(r.reader, r.mapper, r.podStatusReader).readStatus(ctx, rs)
+func (r *replicaSetStatusReader) ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, rs *unstructured.Unstructured) *event.ResourceStatus {
+	return newPodControllerStatusReader(r.mapper, r.podStatusReader).readStatus(ctx, reader, rs)
 }

--- a/pkg/kstatus/polling/statusreaders/statefulset.go
+++ b/pkg/kstatus/polling/statusreaders/statefulset.go
@@ -12,12 +12,10 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 )
 
-func NewStatefulSetResourceReader(reader engine.ClusterReader, mapper meta.RESTMapper, podResourceReader resourceTypeStatusReader) engine.StatusReader {
+func NewStatefulSetResourceReader(mapper meta.RESTMapper, podResourceReader resourceTypeStatusReader) engine.StatusReader {
 	return &baseStatusReader{
-		reader: reader,
 		mapper: mapper,
 		resourceStatusReader: &statefulSetResourceReader{
-			reader:            reader,
 			mapper:            mapper,
 			podResourceReader: podResourceReader,
 		},
@@ -28,7 +26,6 @@ func NewStatefulSetResourceReader(reader engine.ClusterReader, mapper meta.RESTM
 // that can fetch StatefulSet resources from the cluster, knows how to find any
 // Pods belonging to the StatefulSet, and compute status for the StatefulSet.
 type statefulSetResourceReader struct {
-	reader engine.ClusterReader
 	mapper meta.RESTMapper
 
 	podResourceReader resourceTypeStatusReader
@@ -36,6 +33,6 @@ type statefulSetResourceReader struct {
 
 var _ resourceTypeStatusReader = &statefulSetResourceReader{}
 
-func (s *statefulSetResourceReader) ReadStatusForObject(ctx context.Context, statefulSet *unstructured.Unstructured) *event.ResourceStatus {
-	return newPodControllerStatusReader(s.reader, s.mapper, s.podResourceReader).readStatus(ctx, statefulSet)
+func (s *statefulSetResourceReader) ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, statefulSet *unstructured.Unstructured) *event.ResourceStatus {
+	return newPodControllerStatusReader(s.mapper, s.podResourceReader).readStatus(ctx, reader, statefulSet)
 }

--- a/pkg/kstatus/polling/statusreaders/testing.go
+++ b/pkg/kstatus/polling/statusreaders/testing.go
@@ -43,11 +43,11 @@ func (f *fakeClusterReader) ListNamespaceScoped(_ context.Context, list *unstruc
 
 type fakeStatusReader struct{}
 
-func (f *fakeStatusReader) ReadStatus(_ context.Context, _ object.ObjMetadata) *event.ResourceStatus {
+func (f *fakeStatusReader) ReadStatus(_ context.Context, _ engine.ClusterReader, _ object.ObjMetadata) *event.ResourceStatus {
 	return nil
 }
 
-func (f *fakeStatusReader) ReadStatusForObject(_ context.Context, obj *unstructured.Unstructured) *event.ResourceStatus {
+func (f *fakeStatusReader) ReadStatusForObject(_ context.Context, _ engine.ClusterReader, obj *unstructured.Unstructured) *event.ResourceStatus {
 	identifier := object.UnstructuredToObjMetaOrDie(obj)
 	return &event.ResourceStatus{
 		Identifier: identifier,

--- a/pkg/util/factory/statuspoller.go
+++ b/pkg/util/factory/statuspoller.go
@@ -6,9 +6,11 @@ package factory
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,5 +32,5 @@ func NewStatusPoller(f cmdutil.Factory) (*polling.StatusPoller, error) {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
-	return polling.NewStatusPoller(c, mapper), nil
+	return polling.NewStatusPoller(c, mapper, map[schema.GroupKind]engine.StatusReader{}), nil
 }


### PR DESCRIPTION
Instead of having the `StatusPoller` create a new instance of every `StatusReader` each time it is invoked, this creates the `StatusReader` instances when the `StatusPoller` is created. In order to do this, the `StatusReader` interface is changed so the `ClusterReader` is passed in every time.