### PR TITLE
Fix missing action value in table output

### DIFF
--- a/pkg/printers/table/collector.go
+++ b/pkg/printers/table/collector.go
@@ -19,6 +19,11 @@ func newResourceStateCollector(resourceGroups []event.ActionGroup) *ResourceStat
 	resourceInfos := make(map[object.ObjMetadata]*ResourceInfo)
 	for _, group := range resourceGroups {
 		action := group.Action
+		// Keep the action that describes the operation for the resource
+		// rather than that we will wait for it.
+		if action == event.WaitAction {
+			continue
+		}
 		for _, identifier := range group.Identifiers {
 			resourceInfos[identifier] = &ResourceInfo{
 				identifier: identifier,


### PR DESCRIPTION
The table output currently doesn't show any value in the `Action` column. The reason is that we use the value of the ResourceAction to determine whether a resource will be applied or pruned/deleted. With the introduction of the `WaitEvent`, we end up setting the ResourceAction of all resource to `Wait`.