### PR TITLE
Support ReconcileFailed status in printers

### DIFF
--- a/pkg/printers/events/formatter.go
+++ b/pkg/printers/events/formatter.go
@@ -95,6 +95,8 @@ func (ef *formatter) FormatWaitEvent(we event.WaitEvent) error {
 		ef.print("%s reconcile skipped", resourceIDToString(gk, name))
 	case event.ReconcileTimeout:
 		ef.print("%s reconcile timeout", resourceIDToString(gk, name))
+	case event.ReconcileFailed:
+		ef.print("%s reconcile failed", resourceIDToString(gk, name))
 	}
 	return nil
 }

--- a/pkg/printers/events/formatter_test.go
+++ b/pkg/printers/events/formatter_test.go
@@ -304,6 +304,15 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 			},
 			expected: "deployment.apps/my-dep reconcile skipped (preview-server)",
 		},
+		"resource reconcile failed": {
+			previewStrategy: common.DryRunNone,
+			event: event.WaitEvent{
+				GroupName:  "wait-1",
+				Operation:  event.ReconcileFailed,
+				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: "deployment.apps/my-dep reconcile failed",
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/pkg/printers/json/formatter.go
+++ b/pkg/printers/json/formatter.go
@@ -138,6 +138,7 @@ func (jf *formatter) FormatActionGroupEvent(
 			"reconciled": ws.Reconciled,
 			"skipped":    ws.Skipped,
 			"timeout":    ws.Timeout,
+			"failed":     ws.Failed,
 		})
 	}
 

--- a/pkg/printers/json/formatter_test.go
+++ b/pkg/printers/json/formatter_test.go
@@ -439,6 +439,24 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				"type":      "wait",
 			},
 		},
+		"resource reconcile failed": {
+			previewStrategy: common.DryRunNone,
+			event: event.WaitEvent{
+				GroupName:  "wait-1",
+				Operation:  event.ReconcileFailed,
+				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
+			},
+			expected: map[string]interface{}{
+				"eventType": "resourceReconciled",
+				"group":     "apps",
+				"kind":      "Deployment",
+				"name":      "my-dep",
+				"namespace": "default",
+				"operation": "Failed",
+				"timestamp": "",
+				"type":      "wait",
+			},
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
Updates the Printers to handle the `Failed` reconcile status. Follow-up from https://github.com/kubernetes-sigs/cli-utils/pull/486