### PR TITLE
Validate the value of the output flag

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -109,6 +109,10 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if found := printers.ValidatePrinterType(r.output); !found {
+		return fmt.Errorf("unknown output type %q", r.output)
+	}
+
 	// TODO: Fix DemandOneDirectory to no longer return FileNameFlags
 	// since we are no longer using them.
 	_, err = common.DemandOneDirectory(args)

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -94,6 +94,11 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if found := printers.ValidatePrinterType(r.output); !found {
+		return fmt.Errorf("unknown output type %q", r.output)
+	}
+
 	// Retrieve the inventory object.
 	reader, err := r.loader.ManifestReader(cmd.InOrStdin(), flagutils.PathFromArgs(args))
 	if err != nil {

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -110,6 +110,11 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if found := printers.ValidatePrinterType(r.output); !found {
+		return fmt.Errorf("unknown output type %q", r.output)
+	}
+
 	objs, err := reader.Read()
 	if err != nil {
 		return err

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -43,3 +43,12 @@ func SupportedPrinters() []string {
 func DefaultPrinter() string {
 	return EventsPrinter
 }
+
+func ValidatePrinterType(printerType string) bool {
+	for _, p := range SupportedPrinters() {
+		if printerType == p {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Make sure the value provided for the `output` flag corresponds to a supported printer