### PR TITLE
More flexible resource type to StatusReader mapping

### DIFF
--- a/pkg/kstatus/polling/engine/engine_test.go
+++ b/pkg/kstatus/polling/engine/engine_test.go
@@ -111,7 +111,7 @@ func TestStatusPollerRunner(t *testing.T) {
 			engine := PollerEngine{
 				Mapper:              fakeMapper,
 				DefaultStatusReader: tc.defaultStatusReader,
-				StatusReaders:       map[schema.GroupKind]StatusReader{},
+				StatusReaders:       []StatusReader{},
 			}
 
 			options := Options{
@@ -214,6 +214,10 @@ func TestNewStatusPollerRunnerIdentifierValidation(t *testing.T) {
 type fakeStatusReader struct {
 	resourceStatuses    map[schema.GroupKind][]status.Status
 	resourceStatusCount map[schema.GroupKind]int
+}
+
+func (f *fakeStatusReader) Supports(schema.GroupKind) bool {
+	return true
 }
 
 func (f *fakeStatusReader) ReadStatus(_ context.Context, _ ClusterReader, identifier object.ObjMetadata) *event.ResourceStatus {

--- a/pkg/kstatus/polling/engine/status_reader.go
+++ b/pkg/kstatus/polling/engine/status_reader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -18,6 +19,10 @@ import (
 // how to identify these generated resources and how to compute status for
 // these generated resources.
 type StatusReader interface {
+	// Supports tells the caller whether the StatusReader can compute status for
+	// the provided GroupKind.
+	Supports(schema.GroupKind) bool
+
 	// ReadStatus will fetch the resource identified by the given identifier
 	// from the cluster and return an ResourceStatus that will contain
 	// information about the latest state of the resource, its computed status

--- a/pkg/kstatus/polling/statusreaders/common.go
+++ b/pkg/kstatus/polling/statusreaders/common.go
@@ -44,7 +44,12 @@ type baseStatusReader struct {
 // resourceTypeStatusReader is an interface that can be implemented differently
 // for each resource type.
 type resourceTypeStatusReader interface {
+	Supports(gk schema.GroupKind) bool
 	ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, object *unstructured.Unstructured) *event.ResourceStatus
+}
+
+func (b *baseStatusReader) Supports(gk schema.GroupKind) bool {
+	return b.resourceStatusReader.Supports(gk)
 }
 
 // ReadStatus reads the object identified by the passed-in identifier and computes it's status. It reads

--- a/pkg/kstatus/polling/statusreaders/deployment.go
+++ b/pkg/kstatus/polling/statusreaders/deployment.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -37,6 +38,10 @@ type deploymentResourceReader struct {
 }
 
 var _ resourceTypeStatusReader = &deploymentResourceReader{}
+
+func (d *deploymentResourceReader) Supports(gk schema.GroupKind) bool {
+	return gk == appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()
+}
 
 func (d *deploymentResourceReader) ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, deployment *unstructured.Unstructured) *event.ResourceStatus {
 	identifier := object.UnstructuredToObjMetaOrDie(deployment)

--- a/pkg/kstatus/polling/statusreaders/generic.go
+++ b/pkg/kstatus/polling/statusreaders/generic.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -42,6 +43,10 @@ type genericStatusReader struct {
 }
 
 var _ resourceTypeStatusReader = &genericStatusReader{}
+
+func (g *genericStatusReader) Supports(schema.GroupKind) bool {
+	return true
+}
 
 func (g *genericStatusReader) ReadStatusForObject(_ context.Context, _ engine.ClusterReader, resource *unstructured.Unstructured) *event.ResourceStatus {
 	identifier := object.UnstructuredToObjMetaOrDie(resource)

--- a/pkg/kstatus/polling/statusreaders/replicaset.go
+++ b/pkg/kstatus/polling/statusreaders/replicaset.go
@@ -6,8 +6,10 @@ package statusreaders
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 )
@@ -32,6 +34,10 @@ type replicaSetStatusReader struct {
 }
 
 var _ resourceTypeStatusReader = &replicaSetStatusReader{}
+
+func (r *replicaSetStatusReader) Supports(gk schema.GroupKind) bool {
+	return gk == appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind()
+}
 
 func (r *replicaSetStatusReader) ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, rs *unstructured.Unstructured) *event.ResourceStatus {
 	return newPodControllerStatusReader(r.mapper, r.podStatusReader).readStatus(ctx, reader, rs)

--- a/pkg/kstatus/polling/statusreaders/statefulset.go
+++ b/pkg/kstatus/polling/statusreaders/statefulset.go
@@ -6,8 +6,10 @@ package statusreaders
 import (
 	"context"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 )
@@ -32,6 +34,10 @@ type statefulSetResourceReader struct {
 }
 
 var _ resourceTypeStatusReader = &statefulSetResourceReader{}
+
+func (s *statefulSetResourceReader) Supports(gk schema.GroupKind) bool {
+	return gk == appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind()
+}
 
 func (s *statefulSetResourceReader) ReadStatusForObject(ctx context.Context, reader engine.ClusterReader, statefulSet *unstructured.Unstructured) *event.ResourceStatus {
 	return newPodControllerStatusReader(s.mapper, s.podResourceReader).readStatus(ctx, reader, statefulSet)

--- a/pkg/kstatus/polling/statusreaders/testing.go
+++ b/pkg/kstatus/polling/statusreaders/testing.go
@@ -43,6 +43,10 @@ func (f *fakeClusterReader) ListNamespaceScoped(_ context.Context, list *unstruc
 
 type fakeStatusReader struct{}
 
+func (f *fakeStatusReader) Supports(schema.GroupKind) bool {
+	return true
+}
+
 func (f *fakeStatusReader) ReadStatus(_ context.Context, _ engine.ClusterReader, _ object.ObjMetadata) *event.ResourceStatus {
 	return nil
 }

--- a/pkg/util/factory/statuspoller.go
+++ b/pkg/util/factory/statuspoller.go
@@ -6,7 +6,6 @@ package factory
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
@@ -32,5 +31,5 @@ func NewStatusPoller(f cmdutil.Factory) (*polling.StatusPoller, error) {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
-	return polling.NewStatusPoller(c, mapper, map[schema.GroupKind]engine.StatusReader{}), nil
+	return polling.NewStatusPoller(c, mapper, []engine.StatusReader{}), nil
 }


### PR DESCRIPTION
Currently all StatusReaders must be provided for a specific GroupKind. This is awkward when all resources in a group follow the same pattern and therefore can leverage a single StatusReader.
This change allows each StatusReader to decide whether it can compute status for a resource with a specific GroupKind.