### PR TITLE
Don't print status for all events for reach WaitEvent

### DIFF
--- a/pkg/printers/events/formatter.go
+++ b/pkg/printers/events/formatter.go
@@ -139,20 +139,6 @@ func (ef *formatter) FormatActionGroupEvent(
 		ef.print("%d resource(s) deleted, %d skipped", ds.Deleted, ds.Skipped)
 	}
 
-	if age.Action == event.WaitAction && age.Type == event.Started {
-		ag, found := list.ActionGroupByName(age.GroupName, ags)
-		if !found {
-			panic(fmt.Errorf("unknown action group name %q", age.GroupName))
-		}
-		for id, se := range c.LatestStatus() {
-			// Only print information about objects that we actually care about
-			// for this wait task.
-			if found := ag.Identifiers.Contains(id); found {
-				ef.printResourceStatus(id, se)
-			}
-		}
-	}
-
 	if age.Action == event.WaitAction &&
 		age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {

--- a/pkg/printers/json/formatter.go
+++ b/pkg/printers/json/formatter.go
@@ -117,22 +117,6 @@ func (jf *formatter) FormatActionGroupEvent(
 		})
 	}
 
-	if age.Action == event.WaitAction && age.Type == event.Started {
-		ag, found := list.ActionGroupByName(age.GroupName, ags)
-		if !found {
-			panic(fmt.Errorf("unknown action group name %q", age.GroupName))
-		}
-		for id, se := range c.LatestStatus() {
-			// Only print information about objects that we actually care about
-			// for this wait task.
-			if found := ag.Identifiers.Contains(id); found {
-				if err := jf.printResourceStatus(se); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
 	if age.Action == event.WaitAction && age.Type == event.Finished {
 		return jf.printEvent("wait", "completed", map[string]interface{}{
 			"reconciled": ws.Reconciled,


### PR DESCRIPTION
This is a leftover from previous behavior in the printers where we only printed status events during WaitTasks. Currently we instead print status events directly whenever they happen, which means that this is no longer needed and leads to printing of unnecessary status events.