### PR TITLE
Allow customization of the dry-run output

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
 func GetApplyRunner(factory cmdutil.Factory, invFactory inventory.InventoryClientFactory,
@@ -167,6 +168,6 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, common.DryRunNone, r.printStatusEvents)
+	pr := printers.GetPrinter(r.output, r.ioStreams, printer.PreviewStringer{})
+	return pr.Print(ch, common.DryRunNone, r.printStatusEvents)
 }

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
 // GetDestroyRunner creates and returns the DestroyRunner which stores the cobra command.
@@ -139,6 +140,6 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, common.DryRunNone, r.printStatusEvents)
+	pr := printers.GetPrinter(r.output, r.ioStreams, printer.PreviewStringer{})
+	return pr.Print(ch, common.DryRunNone, r.printStatusEvents)
 }

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/printers"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
 var (
@@ -165,6 +166,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
-	printer := printers.GetPrinter(r.output, r.ioStreams)
-	return printer.Print(ch, drs, false) // Do not print status
+	pr := printers.GetPrinter(r.output, r.ioStreams, printer.PreviewStringer{})
+	return pr.Print(ch, drs, false) // Do not print status
 }

--- a/pkg/printers/events/formatter.go
+++ b/pkg/printers/events/formatter.go
@@ -14,12 +14,13 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
 func NewFormatter(ioStreams genericclioptions.IOStreams,
-	previewStrategy common.DryRunStrategy) list.Formatter {
+	previewStrategy common.DryRunStrategy, drs printer.DryRunStringer) list.Formatter {
 	return &formatter{
-		print: getPrintFunc(ioStreams.Out, previewStrategy),
+		print: getPrintFunc(ioStreams.Out, previewStrategy, drs),
 	}
 }
 
@@ -159,13 +160,9 @@ func resourceIDToString(gk schema.GroupKind, name string) string {
 
 type printFunc func(format string, a ...interface{})
 
-func getPrintFunc(w io.Writer, previewStrategy common.DryRunStrategy) printFunc {
+func getPrintFunc(w io.Writer, previewStrategy common.DryRunStrategy, drs printer.DryRunStringer) printFunc {
 	return func(format string, a ...interface{}) {
-		if previewStrategy.ClientDryRun() {
-			format += " (preview)"
-		} else if previewStrategy.ServerDryRun() {
-			format += " (preview-server)"
-		}
+		format += drs.String(previewStrategy)
 		fmt.Fprintf(w, format+"\n", a...)
 	}
 }

--- a/pkg/printers/events/printer.go
+++ b/pkg/printers/events/printer.go
@@ -10,10 +10,10 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
-func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
+func NewPrinter(ioStreams genericclioptions.IOStreams, drs printer.DryRunStringer) printer.Printer {
 	return &list.BaseListPrinter{
 		FormatterFactory: func(previewStrategy common.DryRunStrategy) list.Formatter {
-			return NewFormatter(ioStreams, previewStrategy)
+			return NewFormatter(ioStreams, previewStrategy, drs)
 		},
 	}
 }

--- a/pkg/printers/printer/printer.go
+++ b/pkg/printers/printer/printer.go
@@ -11,3 +11,20 @@ import (
 type Printer interface {
 	Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy, printStatus bool) error
 }
+
+type DryRunStringer interface {
+	String(strategy common.DryRunStrategy) string
+}
+
+type PreviewStringer struct{}
+
+func (p PreviewStringer) String(strategy common.DryRunStrategy) string {
+	switch {
+	case strategy.ClientDryRun():
+		return " (preview)"
+	case strategy.ServerDryRun():
+		return " (preview-server)"
+	default:
+		return ""
+	}
+}

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -5,8 +5,6 @@ package printers
 
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/cli-utils/pkg/common"
-	"sigs.k8s.io/cli-utils/pkg/print/list"
 	"sigs.k8s.io/cli-utils/pkg/printers/events"
 	"sigs.k8s.io/cli-utils/pkg/printers/json"
 	"sigs.k8s.io/cli-utils/pkg/printers/printer"
@@ -19,20 +17,14 @@ const (
 	JSONPrinter   = "json"
 )
 
-func GetPrinter(printerType string, ioStreams genericclioptions.IOStreams) printer.Printer {
+func GetPrinter(printerType string, ioStreams genericclioptions.IOStreams, drs printer.DryRunStringer) printer.Printer {
 	switch printerType { //nolint:gocritic
 	case TablePrinter:
-		return &table.Printer{
-			IOStreams: ioStreams,
-		}
+		return table.NewPrinter(ioStreams)
 	case JSONPrinter:
-		return &list.BaseListPrinter{
-			FormatterFactory: func(previewStrategy common.DryRunStrategy) list.Formatter {
-				return json.NewFormatter(ioStreams, previewStrategy)
-			},
-		}
+		return json.NewPrinter(ioStreams)
 	default:
-		return events.NewPrinter(ioStreams)
+		return events.NewPrinter(ioStreams, drs)
 	}
 }
 

--- a/pkg/printers/table/printer.go
+++ b/pkg/printers/table/printer.go
@@ -12,13 +12,20 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/print/table"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
 )
 
 type Printer struct {
 	IOStreams genericclioptions.IOStreams
 }
 
-func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy, printStatus bool) error {
+func NewPrinter(ioStreams genericclioptions.IOStreams) printer.Printer {
+	return &Printer{
+		IOStreams: ioStreams,
+	}
+}
+
+func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy, _ bool) error {
 	// Wait for the init event that will give us the set of
 	// resources.
 	var initEvent event.InitEvent


### PR DESCRIPTION
This allows users to customize the output added to the event output for preview/dry-run