### PR TITLE
feat: Return a specific error type from the printers when resources fail to apply/delete/reconcile

### DIFF
--- a/pkg/print/common/errors.go
+++ b/pkg/print/common/errors.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/cli-utils/pkg/print/stats"
+)
+
+// ResultErrorFromStats takes a stats object and returns either a ResultError or
+// nil depending on whether the stats reports that resources failed apply/prune/delete
+// or reconciliation.
+func ResultErrorFromStats(s stats.Stats) error {
+	if s.FailedActuationSum() > 0 || s.FailedReconciliationSum() > 0 {
+		return &ResultError{
+			Stats: s,
+		}
+	}
+	return nil
+}
+
+// ResultError is returned from printers when the apply/destroy operations completed, but one or
+// more resources either failed apply/prune/delete, or failed to reconcile.
+type ResultError struct {
+	Stats stats.Stats
+}
+
+func (a *ResultError) Error() string {
+	switch {
+	case a.Stats.FailedActuationSum() > 0 && a.Stats.FailedReconciliationSum() > 0:
+		return fmt.Sprintf("%d resources failed, %d resources failed to reconcile before timeout",
+			a.Stats.FailedActuationSum(), a.Stats.FailedReconciliationSum())
+	case a.Stats.FailedActuationSum() > 0:
+		return fmt.Sprintf("%d resources failed", a.Stats.FailedActuationSum())
+	case a.Stats.FailedReconciliationSum() > 0:
+		return fmt.Sprintf("%d resources failed to reconcile before timeout",
+			a.Stats.FailedReconciliationSum())
+	default:
+		// Should not happen as this error is only used when at least one resource
+		// either failed to apply/prune/delete or reconcile.
+		return "unknown error"
+	}
+}

--- a/pkg/print/list/base_test.go
+++ b/pkg/print/list/base_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package list
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/print/stats"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
+	printertesting "sigs.k8s.io/cli-utils/pkg/printers/testutil"
+)
+
+func TestPrint(t *testing.T) {
+	printertesting.PrintResultErrorTest(t, func() printer.Printer {
+		return &BaseListPrinter{
+			FormatterFactory: func(previewStrategy common.DryRunStrategy) Formatter {
+				return newCountingFormatter()
+			},
+		}
+	})
+}
+
+func newCountingFormatter() *countingFormatter {
+	return &countingFormatter{}
+}
+
+type countingFormatter struct {
+	applyEvents      []event.ApplyEvent
+	statusEvents     []event.StatusEvent
+	pruneEvents      []event.PruneEvent
+	deleteEvents     []event.DeleteEvent
+	waitEvents       []event.WaitEvent
+	errorEvent       event.ErrorEvent
+	actionGroupEvent []event.ActionGroupEvent
+}
+
+func (c *countingFormatter) FormatApplyEvent(e event.ApplyEvent) error {
+	c.applyEvents = append(c.applyEvents, e)
+	return nil
+}
+
+func (c *countingFormatter) FormatStatusEvent(e event.StatusEvent) error {
+	c.statusEvents = append(c.statusEvents, e)
+	return nil
+}
+
+func (c *countingFormatter) FormatPruneEvent(e event.PruneEvent) error {
+	c.pruneEvents = append(c.pruneEvents, e)
+	return nil
+}
+
+func (c *countingFormatter) FormatDeleteEvent(e event.DeleteEvent) error {
+	c.deleteEvents = append(c.deleteEvents, e)
+	return nil
+}
+
+func (c *countingFormatter) FormatWaitEvent(e event.WaitEvent) error {
+	c.waitEvents = append(c.waitEvents, e)
+	return nil
+}
+
+func (c *countingFormatter) FormatErrorEvent(e event.ErrorEvent) error {
+	c.errorEvent = e
+	return nil
+}
+
+func (c *countingFormatter) FormatActionGroupEvent(e event.ActionGroupEvent, _ []event.ActionGroup, _ stats.Stats,
+	_ Collector) error {
+	c.actionGroupEvent = append(c.actionGroupEvent, e)
+	return nil
+}

--- a/pkg/print/stats/stats.go
+++ b/pkg/print/stats/stats.go
@@ -1,0 +1,147 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package stats
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+)
+
+// Stats captures the summarized numbers from apply/prune/delete and
+// reconciliation of resources.
+type Stats struct {
+	ApplyStats  ApplyStats
+	PruneStats  PruneStats
+	DeleteStats DeleteStats
+	WaitStats   WaitStats
+}
+
+// FailedActuationSum returns the number of resources that failed actuation.
+func (s *Stats) FailedActuationSum() int {
+	return s.ApplyStats.Failed + s.PruneStats.Failed + s.DeleteStats.Failed
+}
+
+// FailedReconciliationSum returns the number of resources that failed reconciliation.
+func (s *Stats) FailedReconciliationSum() int {
+	return s.WaitStats.Failed + s.WaitStats.Timeout
+}
+
+// Handle updates the stats based on an event.
+func (s *Stats) Handle(e event.Event) {
+	switch e.Type {
+	case event.ApplyType:
+		if e.ApplyEvent.Error != nil {
+			s.ApplyStats.IncFailed()
+			return
+		}
+		s.ApplyStats.Inc(e.ApplyEvent.Operation)
+	case event.PruneType:
+		if e.PruneEvent.Error != nil {
+			s.PruneStats.IncFailed()
+			return
+		}
+		s.PruneStats.Inc(e.PruneEvent.Operation)
+	case event.DeleteType:
+		if e.DeleteEvent.Error != nil {
+			s.DeleteStats.IncFailed()
+			return
+		}
+		s.DeleteStats.Inc(e.DeleteEvent.Operation)
+	case event.WaitType:
+		s.WaitStats.Inc(e.WaitEvent.Operation)
+	}
+}
+
+type ApplyStats struct {
+	ServersideApplied int
+	Created           int
+	Unchanged         int
+	Configured        int
+	Failed            int
+}
+
+func (a *ApplyStats) Inc(op event.ApplyEventOperation) {
+	switch op {
+	case event.ApplyUnspecified:
+	case event.ServersideApplied:
+		a.ServersideApplied++
+	case event.Created:
+		a.Created++
+	case event.Unchanged:
+		a.Unchanged++
+	case event.Configured:
+		a.Configured++
+	default:
+		panic(fmt.Errorf("unknown apply operation %s", op.String()))
+	}
+}
+
+func (a *ApplyStats) IncFailed() {
+	a.Failed++
+}
+
+func (a *ApplyStats) Sum() int {
+	return a.ServersideApplied + a.Configured + a.Unchanged + a.Created + a.Failed
+}
+
+type PruneStats struct {
+	Pruned  int
+	Skipped int
+	Failed  int
+}
+
+func (p *PruneStats) Inc(op event.PruneEventOperation) {
+	switch op {
+	case event.PruneUnspecified:
+	case event.Pruned:
+		p.Pruned++
+	case event.PruneSkipped:
+		p.Skipped++
+	}
+}
+
+func (p *PruneStats) IncFailed() {
+	p.Failed++
+}
+
+type DeleteStats struct {
+	Deleted int
+	Skipped int
+	Failed  int
+}
+
+func (d *DeleteStats) Inc(op event.DeleteEventOperation) {
+	switch op {
+	case event.DeleteUnspecified:
+	case event.Deleted:
+		d.Deleted++
+	case event.DeleteSkipped:
+		d.Skipped++
+	}
+}
+
+func (d *DeleteStats) IncFailed() {
+	d.Failed++
+}
+
+type WaitStats struct {
+	Reconciled int
+	Timeout    int
+	Failed     int
+	Skipped    int
+}
+
+func (w *WaitStats) Inc(op event.WaitEventOperation) {
+	switch op {
+	case event.Reconciled:
+		w.Reconciled++
+	case event.ReconcileSkipped:
+		w.Skipped++
+	case event.ReconcileTimeout:
+		w.Timeout++
+	case event.ReconcileFailed:
+		w.Failed++
+	}
+}

--- a/pkg/printers/events/formatter_test.go
+++ b/pkg/printers/events/formatter_test.go
@@ -24,7 +24,6 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.ApplyEvent
-		applyStats      *list.ApplyStats
 		statusCollector list.Collector
 		expected        string
 	}{
@@ -125,7 +124,6 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.PruneEvent
-		pruneStats      *list.PruneStats
 		expected        string
 	}{
 		"resource pruned without no dryrun": {
@@ -170,7 +168,6 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.DeleteEvent
-		deleteStats     *list.DeleteStats
 		statusCollector list.Collector
 		expected        string
 	}{
@@ -219,7 +216,6 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.WaitEvent
-		waitStats       *list.WaitStats
 		statusCollector list.Collector
 		expected        string
 	}{

--- a/pkg/printers/json/formatter.go
+++ b/pkg/printers/json/formatter.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
+	"sigs.k8s.io/cli-utils/pkg/print/stats"
 )
 
 func NewFormatter(ioStreams genericclioptions.IOStreams,
@@ -82,14 +83,12 @@ func (jf *formatter) FormatErrorEvent(ee event.ErrorEvent) error {
 func (jf *formatter) FormatActionGroupEvent(
 	age event.ActionGroupEvent,
 	ags []event.ActionGroup,
-	as *list.ApplyStats,
-	ps *list.PruneStats,
-	ds *list.DeleteStats,
-	ws *list.WaitStats,
+	s stats.Stats,
 	_ list.Collector,
 ) error {
 	if age.Action == event.ApplyAction && age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {
+		as := s.ApplyStats
 		if err := jf.printEvent("apply", "completed", map[string]interface{}{
 			"count":           as.Sum(),
 			"createdCount":    as.Created,
@@ -104,22 +103,27 @@ func (jf *formatter) FormatActionGroupEvent(
 
 	if age.Action == event.PruneAction && age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {
+		ps := s.PruneStats
 		return jf.printEvent("prune", "completed", map[string]interface{}{
 			"pruned":  ps.Pruned,
 			"skipped": ps.Skipped,
+			"failed":  ps.Failed,
 		})
 	}
 
 	if age.Action == event.DeleteAction && age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {
+		ds := s.DeleteStats
 		return jf.printEvent("delete", "completed", map[string]interface{}{
 			"deleted": ds.Deleted,
 			"skipped": ds.Skipped,
+			"failed":  ds.Failed,
 		})
 	}
 
 	if age.Action == event.WaitAction && age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {
+		ws := s.WaitStats
 		return jf.printEvent("wait", "completed", map[string]interface{}{
 			"reconciled": ws.Reconciled,
 			"skipped":    ws.Skipped,

--- a/pkg/printers/table/printer_test.go
+++ b/pkg/printers/table/printer_test.go
@@ -7,8 +7,11 @@ import (
 	"bytes"
 	"testing"
 
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/print/table"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
+	printertesting "sigs.k8s.io/cli-utils/pkg/printers/testutil"
 )
 
 var (
@@ -71,4 +74,13 @@ func TestActionColumnDef(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrint(t *testing.T) {
+	printertesting.PrintResultErrorTest(t, func() printer.Printer {
+		ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+		return &Printer{
+			IOStreams: ioStreams,
+		}
+	})
 }

--- a/pkg/printers/testutil/common.go
+++ b/pkg/printers/testutil/common.go
@@ -1,0 +1,205 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package testutil
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	printcommon "sigs.k8s.io/cli-utils/pkg/print/common"
+	"sigs.k8s.io/cli-utils/pkg/print/stats"
+	"sigs.k8s.io/cli-utils/pkg/printers/printer"
+)
+
+type PrinterFactoryFunc func() printer.Printer
+
+func PrintResultErrorTest(t *testing.T, f PrinterFactoryFunc) {
+	deploymentIdentifier := object.ObjMetadata{
+		GroupKind: schema.GroupKind{
+			Group: "apps",
+			Kind:  "Deployment",
+		},
+		Name:      "foo",
+		Namespace: "bar",
+	}
+
+	testCases := map[string]struct {
+		events      []event.Event
+		expectedErr error
+	}{
+		"successful apply, prune and reconcile": {
+			events: []event.Event{
+				{
+					Type: event.InitType,
+					InitEvent: event.InitEvent{
+						ActionGroups: event.ActionGroupList{
+							{
+								Name:   "apply-1",
+								Action: event.ApplyAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+							{
+								Name:   "wait-1",
+								Action: event.WaitAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: event.ApplyType,
+					ApplyEvent: event.ApplyEvent{
+						Operation:  event.Created,
+						Identifier: deploymentIdentifier,
+					},
+				},
+				{
+					Type: event.WaitType,
+					WaitEvent: event.WaitEvent{
+						Operation:  event.Reconciled,
+						Identifier: deploymentIdentifier,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		"successful apply, failed reconcile": {
+			events: []event.Event{
+				{
+					Type: event.InitType,
+					InitEvent: event.InitEvent{
+						ActionGroups: event.ActionGroupList{
+							{
+								Name:   "apply-1",
+								Action: event.ApplyAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+							{
+								Name:   "wait-1",
+								Action: event.WaitAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: event.ApplyType,
+					ApplyEvent: event.ApplyEvent{
+						Operation:  event.Created,
+						Identifier: deploymentIdentifier,
+					},
+				},
+				{
+					Type: event.WaitType,
+					WaitEvent: event.WaitEvent{
+						Operation:  event.ReconcileFailed,
+						Identifier: deploymentIdentifier,
+					},
+				},
+			},
+			expectedErr: &printcommon.ResultError{
+				Stats: stats.Stats{
+					ApplyStats: stats.ApplyStats{
+						Created: 1,
+					},
+					WaitStats: stats.WaitStats{
+						Failed: 1,
+					},
+				},
+			},
+		},
+		"failed apply": {
+			events: []event.Event{
+				{
+					Type: event.InitType,
+					InitEvent: event.InitEvent{
+						ActionGroups: event.ActionGroupList{
+							{
+								Name:   "apply-1",
+								Action: event.ApplyAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+							{
+								Name:   "wait-1",
+								Action: event.WaitAction,
+								Identifiers: []object.ObjMetadata{
+									deploymentIdentifier,
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: event.ApplyType,
+					ApplyEvent: event.ApplyEvent{
+						Operation:  event.ApplyUnspecified,
+						Identifier: deploymentIdentifier,
+						Error:      fmt.Errorf("apply failed"),
+					},
+				},
+				{
+					Type: event.WaitType,
+					WaitEvent: event.WaitEvent{
+						Operation:  event.ReconcileSkipped,
+						Identifier: deploymentIdentifier,
+					},
+				},
+			},
+			expectedErr: &printcommon.ResultError{
+				Stats: stats.Stats{
+					ApplyStats: stats.ApplyStats{
+						Failed: 1,
+					},
+					WaitStats: stats.WaitStats{
+						Skipped: 1,
+					},
+				},
+			},
+		},
+	}
+
+	for tn := range testCases {
+		tc := testCases[tn]
+		t.Run(tn, func(t *testing.T) {
+			p := f()
+
+			eventChannel := make(chan event.Event)
+
+			var wg sync.WaitGroup
+			var err error
+
+			wg.Add(1)
+			go func() {
+				err = p.Print(eventChannel, common.DryRunNone, false)
+				wg.Done()
+			}()
+
+			for i := range tc.events {
+				e := tc.events[i]
+				eventChannel <- e
+			}
+			close(eventChannel)
+
+			wg.Wait()
+
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Instead of returning a generic error from the printer when one or more resource fails to apply/prune/delete or reconcile, it will return a specific type that includes the counts. This allows clients to more easily distinguish these type of errors from more fatal errors.
An example where this is useful, is to be able to use a different exit codes in a cli when resources fail to apply/prune/delete or reconcile, rather than the operation failing due to other reasons.