### PR TITLE
fix: Remove preview/dry-run type from events output

### DIFF
--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -163,6 +163,15 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	// Print the preview strategy unless the output format is json.
+	if r.output != printers.JSONPrinter {
+		if drs.ServerDryRun() {
+			fmt.Println("Preview strategy: server")
+		} else {
+			fmt.Println("Preview strategy: client")
+		}
+	}
+
 	// The printer will print updates from the channel. It will block
 	// until the channel is closed.
 	printer := printers.GetPrinter(r.output, r.ioStreams)

--- a/examples/alphaTestExamples/helloapp.md
+++ b/examples/alphaTestExamples/helloapp.md
@@ -174,11 +174,11 @@ Run preview to check which commands will be executed
 ```
 kapply preview $BASE | tee $OUTPUT/status
 
-expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured, 0 failed (preview)"
+expectedOutputLine "3 resource(s) applied. 3 created, 0 unchanged, 0 configured, 0 failed"
 
 kapply preview $BASE --server-side | tee $OUTPUT/status
 
-expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured, 0 failed, 3 serverside applied (preview-server)"
+expectedOutputLine "3 resource(s) applied. 0 created, 0 unchanged, 0 configured, 0 failed, 3 serverside applied"
 
 # Verify that preview didn't create any resources.
 kubectl get all -n hellospace 2>&1 | tee $OUTPUT/status
@@ -235,19 +235,19 @@ Clean-up the cluster
 ```
 kapply preview $BASE --destroy | tee $OUTPUT/status
 
-expectedOutputLine "deployment.apps/the-deployment deleted (preview)"
+expectedOutputLine "deployment.apps/the-deployment deleted"
 
-expectedOutputLine "configmap/the-map2 deleted (preview)"
+expectedOutputLine "configmap/the-map2 deleted"
 
-expectedOutputLine "service/the-service deleted (preview)"
+expectedOutputLine "service/the-service deleted"
 
 kapply preview $BASE --destroy --server-side | tee $OUTPUT/status
 
-expectedOutputLine "deployment.apps/the-deployment deleted (preview-server)"
+expectedOutputLine "deployment.apps/the-deployment deleted"
 
-expectedOutputLine "configmap/the-map2 deleted (preview-server)"
+expectedOutputLine "configmap/the-map2 deleted"
 
-expectedOutputLine "service/the-service deleted (preview-server)"
+expectedOutputLine "service/the-service deleted"
 
 # Verify that preview all resources are still there after running preview.
 kubectl get --no-headers all -n hellospace | wc -l | xargs | tee $OUTPUT/status

--- a/examples/alphaTestExamples/pruneAndDelete.md
+++ b/examples/alphaTestExamples/pruneAndDelete.md
@@ -142,11 +142,11 @@ command.
 ```
 kapply preview --destroy $BASE | tee $OUTPUT/status
 
-expectedOutputLine "configmap/firstmap deleted (preview)"
+expectedOutputLine "configmap/firstmap deleted"
 
-expectedOutputLine "configmap/secondmap delete skipped (preview)"
+expectedOutputLine "configmap/secondmap delete skipped"
 
-expectedOutputLine "configmap/thirdmap delete skipped (preview)"
+expectedOutputLine "configmap/thirdmap delete skipped"
 ```
 
 We run the destroy command and see that the resource without the annotations (firstmap)
@@ -193,9 +193,9 @@ will instead be skipped due to the lifecycle directive.
 ```
 kapply preview $BASE | tee $OUTPUT/status
 
-expectedOutputLine "configmap/secondmap prune skipped (preview)"
+expectedOutputLine "configmap/secondmap prune skipped"
 
-expectedOutputLine "configmap/thirdmap prune skipped (preview)"
+expectedOutputLine "configmap/thirdmap prune skipped"
 ```
 
 Run apply and verify that secondmap and thirdmap are still in the cluster.

--- a/pkg/printers/events/formatter_test.go
+++ b/pkg/printers/events/formatter_test.go
@@ -42,7 +42,7 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 				Operation:  event.Configured,
 				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep configured (preview)",
+			expected: "deployment.apps/my-dep configured",
 		},
 		"resource updated with server dryrun": {
 			previewStrategy: common.DryRunServer,
@@ -50,7 +50,7 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 				Operation:  event.Configured,
 				Identifier: createIdentifier("batch", "CronJob", "foo", "my-cron"),
 			},
-			expected: "cronjob.batch/my-cron configured (preview-server)",
+			expected: "cronjob.batch/my-cron configured",
 		},
 		"apply event with error should display the error": {
 			previewStrategy: common.DryRunServer,
@@ -58,7 +58,7 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 				Error:      fmt.Errorf("this is a test error"),
 			},
-			expected: "deployment.apps/my-dep apply failed: this is a test error (preview-server)",
+			expected: "deployment.apps/my-dep apply failed: this is a test error",
 		},
 	}
 
@@ -142,7 +142,7 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 				Operation:  event.PruneSkipped,
 				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep prune skipped (preview)",
+			expected: "deployment.apps/my-dep prune skipped",
 		},
 		"resource with prune error": {
 			previewStrategy: common.DryRunNone,
@@ -190,7 +190,7 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 				Object:     createObject("apps", "Deployment", "", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep delete skipped (preview)",
+			expected: "deployment.apps/my-dep delete skipped",
 		},
 		"resource with delete error": {
 			previewStrategy: common.DryRunServer,
@@ -199,7 +199,7 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 				Identifier: createIdentifier("apps", "Deployment", "", "my-dep"),
 				Error:      fmt.Errorf("this is a test"),
 			},
-			expected: "deployment.apps/my-dep deletion failed: this is a test (preview-server)",
+			expected: "deployment.apps/my-dep deletion failed: this is a test",
 		},
 	}
 
@@ -239,7 +239,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Operation:  event.Reconciled,
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep reconciled (preview)",
+			expected: "deployment.apps/my-dep reconciled",
 		},
 		"resource reconciled (server-side dry-run)": {
 			previewStrategy: common.DryRunServer,
@@ -248,7 +248,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Operation:  event.Reconciled,
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep reconciled (preview-server)",
+			expected: "deployment.apps/my-dep reconciled",
 		},
 		"resource reconcile timeout": {
 			previewStrategy: common.DryRunNone,
@@ -266,7 +266,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 				Operation:  event.ReconcileTimeout,
 			},
-			expected: "deployment.apps/my-dep reconcile timeout (preview)",
+			expected: "deployment.apps/my-dep reconcile timeout",
 		},
 		"resource reconcile timeout (server-side dry-run)": {
 			previewStrategy: common.DryRunServer,
@@ -275,7 +275,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 				Operation:  event.ReconcileTimeout,
 			},
-			expected: "deployment.apps/my-dep reconcile timeout (preview-server)",
+			expected: "deployment.apps/my-dep reconcile timeout",
 		},
 		"resource reconcile skipped": {
 			previewStrategy: common.DryRunNone,
@@ -293,7 +293,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Operation:  event.ReconcileSkipped,
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep reconcile skipped (preview)",
+			expected: "deployment.apps/my-dep reconcile skipped",
 		},
 		"resource reconcile skipped (server-side dry-run)": {
 			previewStrategy: common.DryRunServer,
@@ -302,7 +302,7 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 				Operation:  event.ReconcileSkipped,
 				Identifier: createIdentifier("apps", "Deployment", "default", "my-dep"),
 			},
-			expected: "deployment.apps/my-dep reconcile skipped (preview-server)",
+			expected: "deployment.apps/my-dep reconcile skipped",
 		},
 		"resource reconcile failed": {
 			previewStrategy: common.DryRunNone,

--- a/pkg/printers/json/formatter.go
+++ b/pkg/printers/json/formatter.go
@@ -16,16 +16,14 @@ import (
 )
 
 func NewFormatter(ioStreams genericclioptions.IOStreams,
-	previewStrategy common.DryRunStrategy) list.Formatter {
+	_ common.DryRunStrategy) list.Formatter {
 	return &formatter{
-		ioStreams:       ioStreams,
-		previewStrategy: previewStrategy,
+		ioStreams: ioStreams,
 	}
 }
 
 type formatter struct {
-	previewStrategy common.DryRunStrategy
-	ioStreams       genericclioptions.IOStreams
+	ioStreams genericclioptions.IOStreams
 }
 
 func (jf *formatter) FormatApplyEvent(ae event.ApplyEvent) error {
@@ -88,7 +86,7 @@ func (jf *formatter) FormatActionGroupEvent(
 	ps *list.PruneStats,
 	ds *list.DeleteStats,
 	ws *list.WaitStats,
-	c list.Collector,
+	_ list.Collector,
 ) error {
 	if age.Action == event.ApplyAction && age.Type == event.Finished &&
 		list.IsLastActionGroup(age, ags) {


### PR DESCRIPTION
The reasons for this change:
* The output is just repeating the preview/dry-run strategy that the user provided, and the value is the same for every line. Thus, it ends up being very verbose.
* We don't currently print it consistently for all printers. It is only used in the output for the events output format.
* We currently uses the term `preview`, rather than the more common term `dry-run` used in kubectl. Making is possible to customize the term here seems a bit overkill (https://github.com/kubernetes-sigs/cli-utils/pull/499).

Removing it seems like a good solution to keep the printers simple, but still allow users to build their own printers if they want to.