### PR TITLE
[WIP] Separate out collection of stats from the printer

### DIFF
--- a/pkg/print/list/base.go
+++ b/pkg/print/list/base.go
@@ -4,11 +4,10 @@
 package list
 
 import (
-	"fmt"
-
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/stats"
 )
 
 type Formatter interface {
@@ -21,10 +20,7 @@ type Formatter interface {
 	FormatActionGroupEvent(
 		age event.ActionGroupEvent,
 		ags []event.ActionGroup,
-		as *ApplyStats,
-		ps *PruneStats,
-		ds *DeleteStats,
-		ws *WaitStats,
+		stats stats.Stats,
 		c Collector,
 	) error
 }
@@ -33,97 +29,6 @@ type FormatterFactory func(previewStrategy common.DryRunStrategy) Formatter
 
 type BaseListPrinter struct {
 	FormatterFactory FormatterFactory
-}
-
-type ApplyStats struct {
-	ServersideApplied int
-	Created           int
-	Unchanged         int
-	Configured        int
-	Failed            int
-}
-
-func (a *ApplyStats) inc(op event.ApplyEventOperation) {
-	switch op {
-	case event.ApplyUnspecified:
-	case event.ServersideApplied:
-		a.ServersideApplied++
-	case event.Created:
-		a.Created++
-	case event.Unchanged:
-		a.Unchanged++
-	case event.Configured:
-		a.Configured++
-	default:
-		panic(fmt.Errorf("unknown apply operation %s", op.String()))
-	}
-}
-
-func (a *ApplyStats) incFailed() {
-	a.Failed++
-}
-
-func (a *ApplyStats) Sum() int {
-	return a.ServersideApplied + a.Configured + a.Unchanged + a.Created + a.Failed
-}
-
-type PruneStats struct {
-	Pruned  int
-	Skipped int
-	Failed  int
-}
-
-func (p *PruneStats) incPruned() {
-	p.Pruned++
-}
-
-func (p *PruneStats) incSkipped() {
-	p.Skipped++
-}
-
-func (p *PruneStats) incFailed() {
-	p.Failed++
-}
-
-type DeleteStats struct {
-	Deleted int
-	Skipped int
-	Failed  int
-}
-
-func (d *DeleteStats) incDeleted() {
-	d.Deleted++
-}
-
-func (d *DeleteStats) incSkipped() {
-	d.Skipped++
-}
-
-func (d *DeleteStats) incFailed() {
-	d.Failed++
-}
-
-type WaitStats struct {
-	Reconciled int
-	Timeout    int
-	Failed     int
-	Skipped    int
-}
-
-func (w *WaitStats) incReconciled() {
-	w.Reconciled++
-}
-
-func (w *WaitStats) incTimeout() {
-	w.Timeout++
-}
-
-func (w *WaitStats) incFailed() {
-	w.Failed++
-}
-
-func (w *WaitStats) incSkipped() {
-	w.Skipped++
 }
 
 type Collector interface {
@@ -149,15 +54,13 @@ func (sc *StatusCollector) LatestStatus() map[object.ObjMetadata]event.StatusEve
 //nolint:gocyclo
 func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy, printStatus bool) error {
 	var actionGroups []event.ActionGroup
-	applyStats := &ApplyStats{}
-	pruneStats := &PruneStats{}
-	deleteStats := &DeleteStats{}
-	waitStats := &WaitStats{}
+	var statsCollector stats.Stats
 	statusCollector := &StatusCollector{
 		latestStatus: make(map[object.ObjMetadata]event.StatusEvent),
 	}
 	formatter := b.FormatterFactory(previewStrategy)
 	for e := range ch {
+		statsCollector.Handle(e)
 		switch e.Type {
 		case event.InitType:
 			actionGroups = e.InitEvent.ActionGroups
@@ -165,10 +68,6 @@ func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.Dr
 			_ = formatter.FormatErrorEvent(e.ErrorEvent)
 			return e.ErrorEvent.Err
 		case event.ApplyType:
-			applyStats.inc(e.ApplyEvent.Operation)
-			if e.ApplyEvent.Error != nil {
-				applyStats.incFailed()
-			}
 			if err := formatter.FormatApplyEvent(e.ApplyEvent); err != nil {
 				return err
 			}
@@ -180,42 +79,14 @@ func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.Dr
 				}
 			}
 		case event.PruneType:
-			switch e.PruneEvent.Operation {
-			case event.Pruned:
-				pruneStats.incPruned()
-			case event.PruneSkipped:
-				pruneStats.incSkipped()
-			}
-			if e.PruneEvent.Error != nil {
-				pruneStats.incFailed()
-			}
 			if err := formatter.FormatPruneEvent(e.PruneEvent); err != nil {
 				return err
 			}
 		case event.DeleteType:
-			switch e.DeleteEvent.Operation {
-			case event.Deleted:
-				deleteStats.incDeleted()
-			case event.DeleteSkipped:
-				deleteStats.incSkipped()
-			}
-			if e.DeleteEvent.Error != nil {
-				deleteStats.incFailed()
-			}
 			if err := formatter.FormatDeleteEvent(e.DeleteEvent); err != nil {
 				return err
 			}
 		case event.WaitType:
-			switch e.WaitEvent.Operation {
-			case event.Reconciled:
-				waitStats.incReconciled()
-			case event.ReconcileSkipped:
-				waitStats.incSkipped()
-			case event.ReconcileTimeout:
-				waitStats.incTimeout()
-			case event.ReconcileFailed:
-				waitStats.incFailed()
-			}
 			if err := formatter.FormatWaitEvent(e.WaitEvent); err != nil {
 				return err
 			}
@@ -223,30 +94,14 @@ func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.Dr
 			if err := formatter.FormatActionGroupEvent(
 				e.ActionGroupEvent,
 				actionGroups,
-				applyStats,
-				pruneStats,
-				deleteStats,
-				waitStats,
+				statsCollector,
 				statusCollector,
 			); err != nil {
 				return err
 			}
 		}
 	}
-	failedActuateSum := applyStats.Failed + pruneStats.Failed + deleteStats.Failed
-	failedReconcileSum := waitStats.Timeout + waitStats.Failed
-	switch {
-	case failedActuateSum > 0 && failedReconcileSum > 0:
-		return fmt.Errorf("%d resources failed, %d resources failed to reconcile before timeout",
-			failedActuateSum, failedReconcileSum)
-	case failedActuateSum > 0:
-		return fmt.Errorf("%d resources failed", failedActuateSum)
-	case failedReconcileSum > 0:
-		return fmt.Errorf("%d resources failed to reconcile before timeout",
-			failedReconcileSum)
-	default:
-		return nil
-	}
+	return nil
 }
 
 func ActionGroupByName(name string, ags []event.ActionGroup) (event.ActionGroup, bool) {

--- a/pkg/printers/events/formatter_test.go
+++ b/pkg/printers/events/formatter_test.go
@@ -24,7 +24,6 @@ func TestFormatter_FormatApplyEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.ApplyEvent
-		applyStats      *list.ApplyStats
 		statusCollector list.Collector
 		expected        string
 	}{
@@ -125,7 +124,6 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.PruneEvent
-		pruneStats      *list.PruneStats
 		expected        string
 	}{
 		"resource pruned without no dryrun": {
@@ -170,7 +168,6 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.DeleteEvent
-		deleteStats     *list.DeleteStats
 		statusCollector list.Collector
 		expected        string
 	}{
@@ -219,7 +216,6 @@ func TestFormatter_FormatWaitEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.WaitEvent
-		waitStats       *list.WaitStats
 		statusCollector list.Collector
 		expected        string
 	}{

--- a/pkg/printers/json/formatter.go
+++ b/pkg/printers/json/formatter.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/print/list"
+	"sigs.k8s.io/cli-utils/pkg/stats"
 )
 
 func NewFormatter(ioStreams genericclioptions.IOStreams,
@@ -84,20 +85,17 @@ func (jf *formatter) FormatErrorEvent(ee event.ErrorEvent) error {
 func (jf *formatter) FormatActionGroupEvent(
 	age event.ActionGroupEvent,
 	ags []event.ActionGroup,
-	as *list.ApplyStats,
-	ps *list.PruneStats,
-	ds *list.DeleteStats,
-	ws *list.WaitStats,
+	s stats.Stats,
 	c list.Collector,
 ) error {
 	if age.Action == event.ApplyAction && age.Type == event.Finished {
 		if err := jf.printEvent("apply", "completed", map[string]interface{}{
-			"count":           as.Sum(),
-			"createdCount":    as.Created,
-			"unchangedCount":  as.Unchanged,
-			"configuredCount": as.Configured,
-			"serverSideCount": as.ServersideApplied,
-			"failedCount":     as.Failed,
+			"count":           s.ApplyStats.Sum(),
+			"createdCount":    s.ApplyStats.Created,
+			"unchangedCount":  s.ApplyStats.Unchanged,
+			"configuredCount": s.ApplyStats.Configured,
+			"serverSideCount": s.ApplyStats.ServersideApplied,
+			"failedCount":     s.ApplyStats.Failed,
 		}); err != nil {
 			return err
 		}
@@ -105,24 +103,26 @@ func (jf *formatter) FormatActionGroupEvent(
 
 	if age.Action == event.PruneAction && age.Type == event.Finished {
 		return jf.printEvent("prune", "completed", map[string]interface{}{
-			"pruned":  ps.Pruned,
-			"skipped": ps.Skipped,
+			"pruned":  s.PruneStats.Pruned,
+			"skipped": s.PruneStats.Skipped,
+			"failed":  s.PruneStats.Failed,
 		})
 	}
 
 	if age.Action == event.DeleteAction && age.Type == event.Finished {
 		return jf.printEvent("delete", "completed", map[string]interface{}{
-			"deleted": ds.Deleted,
-			"skipped": ds.Skipped,
+			"deleted": s.DeleteStats.Deleted,
+			"skipped": s.DeleteStats.Skipped,
+			"failed":  s.DeleteStats.Failed,
 		})
 	}
 
 	if age.Action == event.WaitAction && age.Type == event.Finished {
 		return jf.printEvent("wait", "completed", map[string]interface{}{
-			"reconciled": ws.Reconciled,
-			"skipped":    ws.Skipped,
-			"timeout":    ws.Timeout,
-			"failed":     ws.Failed,
+			"reconciled": s.WaitStats.Reconciled,
+			"skipped":    s.WaitStats.Skipped,
+			"timeout":    s.WaitStats.Timeout,
+			"failed":     s.WaitStats.Failed,
 		})
 	}
 

--- a/pkg/printers/json/formatter_test.go
+++ b/pkg/printers/json/formatter_test.go
@@ -183,7 +183,6 @@ func TestFormatter_FormatPruneEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.PruneEvent
-		pruneStats      *list.PruneStats
 		expected        map[string]interface{}
 	}{
 		"resource pruned without dryrun": {
@@ -255,7 +254,6 @@ func TestFormatter_FormatDeleteEvent(t *testing.T) {
 	testCases := map[string]struct {
 		previewStrategy common.DryRunStrategy
 		event           event.DeleteEvent
-		deleteStats     *list.DeleteStats
 		statusCollector list.Collector
 		expected        map[string]interface{}
 	}{

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,0 +1,161 @@
+// Copyright 2022 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package stats
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+)
+
+type Collector struct {
+	Stats Stats
+}
+
+func NewCollector() *Collector {
+	return &Collector{}
+}
+
+func (n *Collector) Collect(eventChannel <-chan event.Event) <-chan event.Event {
+	outChannel := make(chan event.Event)
+	var stats Stats
+	go func() {
+		defer close(outChannel)
+		for ev := range eventChannel {
+			stats.Handle(ev)
+			outChannel <- ev
+		}
+	}()
+	return outChannel
+}
+
+type Stats struct {
+	ApplyStats  ApplyStats
+	PruneStats  PruneStats
+	DeleteStats DeleteStats
+	WaitStats   WaitStats
+}
+
+func (s *Stats) FailedActuationSum() int {
+	return s.ApplyStats.Failed + s.PruneStats.Failed + s.DeleteStats.Failed
+}
+
+func (s *Stats) FailedReconciliationSum() int {
+	return s.WaitStats.Failed + s.WaitStats.Timeout
+}
+
+func (s *Stats) Handle(e event.Event) {
+	switch e.Type {
+	case event.ApplyType:
+		if e.ApplyEvent.Error != nil {
+			s.ApplyStats.incFailed()
+			return
+		}
+		s.ApplyStats.inc(e.ApplyEvent.Operation)
+	case event.PruneType:
+		if e.PruneEvent.Error != nil {
+			s.PruneStats.incFailed()
+			return
+		}
+		s.PruneStats.inc(e.PruneEvent.Operation)
+	case event.DeleteType:
+		if e.DeleteEvent.Error != nil {
+			s.DeleteStats.incFailed()
+			return
+		}
+		s.DeleteStats.inc(e.DeleteEvent.Operation)
+	case event.WaitType:
+		s.WaitStats.inc(e.WaitEvent.Operation)
+	}
+}
+
+type ApplyStats struct {
+	ServersideApplied int
+	Created           int
+	Unchanged         int
+	Configured        int
+	Failed            int
+}
+
+func (a *ApplyStats) inc(op event.ApplyEventOperation) {
+	switch op {
+	case event.ApplyUnspecified:
+	case event.ServersideApplied:
+		a.ServersideApplied++
+	case event.Created:
+		a.Created++
+	case event.Unchanged:
+		a.Unchanged++
+	case event.Configured:
+		a.Configured++
+	default:
+		panic(fmt.Errorf("unknown apply operation %s", op.String()))
+	}
+}
+
+func (a *ApplyStats) incFailed() {
+	a.Failed++
+}
+
+func (a *ApplyStats) Sum() int {
+	return a.ServersideApplied + a.Configured + a.Unchanged + a.Created + a.Failed
+}
+
+type PruneStats struct {
+	Pruned  int
+	Skipped int
+	Failed  int
+}
+
+func (p *PruneStats) inc(op event.PruneEventOperation) {
+	switch op {
+	case event.Pruned:
+		p.Pruned++
+	case event.PruneSkipped:
+		p.Skipped++
+	}
+}
+
+func (p *PruneStats) incFailed() {
+	p.Failed++
+}
+
+type DeleteStats struct {
+	Deleted int
+	Skipped int
+	Failed  int
+}
+
+func (d *DeleteStats) inc(op event.DeleteEventOperation) {
+	switch op {
+	case event.Deleted:
+		d.Deleted++
+	case event.DeleteSkipped:
+		d.Skipped++
+	}
+}
+
+func (d *DeleteStats) incFailed() {
+	d.Failed++
+}
+
+type WaitStats struct {
+	Reconciled int
+	Timeout    int
+	Failed     int
+	Skipped    int
+}
+
+func (w *WaitStats) inc(op event.WaitEventOperation) {
+	switch op {
+	case event.Reconciled:
+		w.Reconciled++
+	case event.ReconcileSkipped:
+		w.Skipped++
+	case event.ReconcileTimeout:
+		w.Timeout++
+	case event.ReconcileFailed:
+		w.Failed++
+	}
+}


### PR DESCRIPTION
This is a POC for how we can separate collection of stats from an apply/destroy operation from the printers. It splits out the code used for this within the `BaseListPrinter` and make the `Stats` type available for other use-cases. 
It makes it available in the `stats.Collector`, which can be used as in this example:
```golang
eventChannel := a.Run(ctx, inv, objs, apply.Options{})

statsCollector := stats.NewCollector()
printer := printers.GetPrinter(r.output, r.ioStreams)
if err := printer.Print(statsCollector.Run(eventChannel), common.DryRunNone, r.printStatusEvents); err != nil {
  // handle err
}

s := statsCollector.Stats
```