### PR TITLE
fix: Clean up object.FieldPath

### DIFF
--- a/pkg/object/field_test.go
+++ b/pkg/object/field_test.go
@@ -78,6 +78,15 @@ func TestFieldPath(t *testing.T) {
 			fieldPath: []interface{}{"spec", "abc\n123"},
 			expected:  `.spec["abc\n123"]`,
 		},
+		// result from invalid input doesn't matter, as long as it doesn't panic
+		"invalid type: float": {
+			fieldPath: []interface{}{"spec", float64(-1.0)},
+			expected:  `.spec[-1]`,
+		},
+		"invalid type: struct": {
+			fieldPath: []interface{}{"spec", struct{ Field string }{Field: "value"}},
+			expected:  `.spec[struct { Field string }{Field:"value"}]`,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
- Use string.Builder to be slightly more efficient
- Format invalid types with Go syntax, wrapped with brackets
- Test that invalid types don't panic