### PR TITLE
fix: Update ObjMetadataSet.Hash to not error

### DIFF
--- a/pkg/object/objmetadata_set.go
+++ b/pkg/object/objmetadata_set.go
@@ -132,32 +132,19 @@ func (setA ObjMetadataSet) Diff(setB ObjMetadataSet) ObjMetadataSet {
 
 // Hash the objects in the set by serializing, sorting, concatonating, and
 // hashing the result with the 32-bit FNV-1a algorithm.
-func (setA ObjMetadataSet) Hash() (string, error) {
+func (setA ObjMetadataSet) Hash() string {
 	objStrs := make([]string, 0, len(setA))
 	for _, obj := range setA {
 		objStrs = append(objStrs, obj.String())
 	}
-	hashInt, err := calcHash(objStrs)
-	if err != nil {
-		return "", err
-	}
-	return strconv.FormatUint(uint64(hashInt), 16), nil
-}
-
-// calcHash returns an unsigned int32 representing the hash
-// of the obj metadata strings. If there is an error writing bytes to
-// the hash, then the error is returned; nil is returned otherwise.
-// Used to quickly identify the set of resources in the inventory object.
-func calcHash(objs []string) (uint32, error) {
-	sort.Strings(objs)
+	sort.Strings(objStrs)
 	h := fnv.New32a()
-	for _, obj := range objs {
-		_, err := h.Write([]byte(obj))
-		if err != nil {
-			return uint32(0), err
-		}
+	for _, obj := range objStrs {
+		// Hash32.Write never returns an error
+		// https://pkg.go.dev/hash#pkg-types
+		_, _ = h.Write([]byte(obj))
 	}
-	return h.Sum32(), nil
+	return strconv.FormatUint(uint64(h.Sum32()), 16)
 }
 
 // ToMap returns the set as a map, with objMeta keys and empty struct values.

--- a/pkg/object/objmetadata_set_test.go
+++ b/pkg/object/objmetadata_set_test.go
@@ -6,6 +6,7 @@ package object
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -214,13 +215,8 @@ func TestObjMetadataSetHash(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual, err := tc.objs.Hash()
-			if err != nil {
-				t.Fatalf("Received unexpected error: %s", err)
-			}
-			if tc.expected != actual {
-				t.Errorf("Hash expected (%s), got (%s)", tc.expected, actual)
-			}
+			actual := tc.objs.Hash()
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
Hash32.Write never returns an error: https://pkg.go.dev/hash#pkg-types

Hash functions should never return errors in general, because they're commonly used in String() and Equals() funcs, which don't error.