### PR TITLE
fix: Use the dynamic client in the InventoryClient

### DIFF
--- a/pkg/object/infos.go
+++ b/pkg/object/infos.go
@@ -56,12 +56,8 @@ func UnstructuredToInfo(obj *unstructured.Unstructured) (*resource.Info, error) 
 	path, ok := annos[kioutil.PathAnnotation]
 	if ok {
 		source = path
-		// kyaml adds both annotations for the time being, so we need to remove them both
-		// before apply.
-		delete(annos, kioutil.PathAnnotation)
-		delete(annos, kioutil.LegacyPathAnnotation) //nolint:staticcheck
-		obj.SetAnnotations(annos)
 	}
+	StripKyamlAnnotations(obj)
 
 	return &resource.Info{
 		Name:      obj.GetName(),

--- a/pkg/object/unstructured.go
+++ b/pkg/object/unstructured.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 )
 
 var (
@@ -188,4 +189,15 @@ func crdDefinesVersion(crd *unstructured.Unstructured, version string) (bool, er
 		}
 	}
 	return false, nil
+}
+
+// StripKyamlAnnotations removes any path and index annotations from the
+// unstructured resource.
+func StripKyamlAnnotations(u *unstructured.Unstructured) {
+	annos := u.GetAnnotations()
+	delete(annos, kioutil.PathAnnotation)
+	delete(annos, kioutil.LegacyPathAnnotation) //nolint:staticcheck
+	delete(annos, kioutil.IndexAnnotation)
+	delete(annos, kioutil.LegacyIndexAnnotation) //nolint:staticcheck
+	u.SetAnnotations(annos)
 }


### PR DESCRIPTION
This updates the InventoryClient implementation to use the dynamic client, rather than the builder and info functionality. It means we don't have to use the `resource.Info` types, which removes the need for the `InfoHelper` in the InventoryClient. The dynamic client is also easier to work with and comes with a `FakeDynamicClient` implementation that is easier to use than stubbing out the REST api through the TestFactory.