### PR TITLE
fix: Remove support for multiple inventory objects with the same inventory id

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -99,7 +99,7 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 
 	// Based on the inventory template manifest we look up the inventory
 	// from the live state using the inventory client.
-	identifiers, err := invClient.GetClusterObjs(inv, common.DryRunNone)
+	identifiers, err := invClient.GetClusterObjs(inv)
 	if err != nil {
 		return err
 	}

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -195,7 +195,7 @@ func (p *Pruner) GetPruneObjs(
 	opts Options,
 ) (object.UnstructuredSet, error) {
 	ids := object.UnstructuredSetToObjMetadataSet(objs)
-	invIDs, err := p.InvClient.GetClusterObjs(inv, opts.DryRunStrategy)
+	invIDs, err := p.InvClient.GetClusterObjs(inv)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -118,11 +118,11 @@ func (t *TaskQueueBuilder) AppendInvAddTask(inv inventory.InventoryInfo, applyOb
 	return t
 }
 
-// AppendInvAddTask appends an inventory set task to the task queue.
+// AppendInvSetTask appends an inventory set task to the task queue.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo, dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding inventory set task")
-	prevInvIds, _ := t.InvClient.GetClusterObjs(inv, dryRun)
+	prevInvIds, _ := t.InvClient.GetClusterObjs(inv)
 	t.tasks = append(t.tasks, &task.InvSetTask{
 		TaskName:      fmt.Sprintf("inventory-set-%d", t.invSetCounter),
 		InvClient:     t.InvClient,
@@ -134,7 +134,7 @@ func (t *TaskQueueBuilder) AppendInvSetTask(inv inventory.InventoryInfo, dryRun 
 	return t
 }
 
-// AppendInvAddTask appends to the task queue a task to delete the inventory object.
+// AppendDeleteInvTask appends to the task queue a task to delete the inventory object.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo, dryRun common.DryRunStrategy) *TaskQueueBuilder {
 	klog.V(2).Infoln("adding delete inventory task")
@@ -148,7 +148,7 @@ func (t *TaskQueueBuilder) AppendDeleteInvTask(inv inventory.InventoryInfo, dryR
 	return t
 }
 
-// AppendInvAddTask appends a task to the task queue to apply the passed objects
+// AppendApplyTask appends a task to the task queue to apply the passed objects
 // to the cluster. Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendApplyTask(applyObjs object.UnstructuredSet,
 	applyFilters []filter.ValidationFilter, applyMutators []mutator.Interface, o Options) *TaskQueueBuilder {
@@ -168,7 +168,7 @@ func (t *TaskQueueBuilder) AppendApplyTask(applyObjs object.UnstructuredSet,
 	return t
 }
 
-// AppendInvAddTask appends a task to wait on the passed objects to the task queue.
+// AppendWaitTask appends a task to wait on the passed objects to the task queue.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendWaitTask(waitIds object.ObjMetadataSet, condition taskrunner.Condition,
 	waitTimeout time.Duration) *TaskQueueBuilder {
@@ -184,7 +184,7 @@ func (t *TaskQueueBuilder) AppendWaitTask(waitIds object.ObjMetadataSet, conditi
 	return t
 }
 
-// AppendInvAddTask appends a task to delete objects from the cluster to the task queue.
+// AppendPruneTask appends a task to delete objects from the cluster to the task queue.
 // Returns a pointer to the Builder to chain function calls.
 func (t *TaskQueueBuilder) AppendPruneTask(pruneObjs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter, o Options) *TaskQueueBuilder {

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -130,7 +130,7 @@ func TestInvAddTask(t *testing.T) {
 			if result.Err != nil {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
-			actual, _ := client.GetClusterObjs(nil, common.DryRunNone)
+			actual, _ := client.GetClusterObjs(nil)
 			if !tc.expectedObjs.Equal(actual) {
 				t.Errorf("expected merged inventory (%s), got (%s)", tc.expectedObjs, actual)
 			}

--- a/pkg/apply/task/inv_set_task_test.go
+++ b/pkg/apply/task/inv_set_task_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
-	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/testutil"
@@ -231,7 +230,7 @@ func TestInvSetTask(t *testing.T) {
 			if result.Err != nil {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
-			actual, _ := client.GetClusterObjs(nil, common.DryRunNone)
+			actual, _ := client.GetClusterObjs(nil)
 			testutil.AssertEqual(t, tc.expectedObjs, actual,
 				"Actual cluster objects (%d) do not match expected cluster objects (%d)",
 				len(actual), len(tc.expectedObjs))

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -23,7 +23,7 @@ var (
 
 type FakeInventoryClientFactory object.ObjMetadataSet
 
-func (f FakeInventoryClientFactory) NewInventoryClient(factory cmdutil.Factory) (InventoryClient, error) {
+func (f FakeInventoryClientFactory) NewInventoryClient(cmdutil.Factory) (InventoryClient, error) {
 	return NewFakeInventoryClient(object.ObjMetadataSet(f)), nil
 }
 
@@ -36,7 +36,7 @@ func NewFakeInventoryClient(initObjs object.ObjMetadataSet) *FakeInventoryClient
 }
 
 // GetClusterObjs returns currently stored set of objects.
-func (fic *FakeInventoryClient) GetClusterObjs(InventoryInfo, common.DryRunStrategy) (object.ObjMetadataSet, error) {
+func (fic *FakeInventoryClient) GetClusterObjs(InventoryInfo) (object.ObjMetadataSet, error) {
 	if fic.Err != nil {
 		return object.ObjMetadataSet{}, fic.Err
 	}
@@ -91,7 +91,7 @@ func (fic *FakeInventoryClient) ClearError() {
 	fic.Err = nil
 }
 
-func (fic *FakeInventoryClient) GetClusterInventoryInfo(InventoryInfo, common.DryRunStrategy) (*unstructured.Unstructured, error) {
+func (fic *FakeInventoryClient) GetClusterInventoryInfo(InventoryInfo) (*unstructured.Unstructured, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This removes support for having multiple inventory objects with the same inventory id. Having multiple inventory objects with the same id was part of the original design, but we switched to using a single inventory object well over 12 months ago. We kept support for reading and merging multiple inventories, but I think it is time we consider this situation an error. It removes some complex code from the InventoryClient and also cleans up the `InventoryClient` interface by no longer updating the live state in functions that seems like they should be read only. This also allows us to remove the `dry-run` flag from those functions.