### PR TITLE
Expose ClusterReader options in the API

### DIFF
--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/aggregator"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/collector"
-	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
@@ -153,9 +152,8 @@ func (r *StatusRunner) runE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unknown value for pollUntil: %q", r.pollUntil)
 	}
 
-	eventChannel := statusPoller.Poll(ctx, identifiers, polling.Options{
+	eventChannel := statusPoller.Poll(ctx, identifiers, polling.PollOptions{
 		PollInterval: r.period,
-		UseCache:     true,
 	})
 
 	return printer.Print(eventChannel, identifiers, cancelFunc)
@@ -193,5 +191,5 @@ func allKnownNotifierFunc(cancelFunc context.CancelFunc) collector.ObserverFunc 
 }
 
 func pollerFactoryFunc(f cmdutil.Factory) (poller.Poller, error) {
-	return polling.NewStatusPollerFromFactory(f, []engine.StatusReader{})
+	return polling.NewStatusPollerFromFactory(f, polling.Options{})
 }

--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -261,7 +261,7 @@ type fakePoller struct {
 }
 
 func (f *fakePoller) Poll(ctx context.Context, _ object.ObjMetadataSet,
-	_ polling.Options) <-chan pollevent.Event {
+	_ polling.PollOptions) <-chan pollevent.Event {
 	eventChannel := make(chan pollevent.Event)
 	go func() {
 		defer close(eventChannel)

--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -232,7 +232,6 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 		klog.V(4).Infoln("applier running TaskStatusRunner...")
 		err = runner.Run(ctx, taskContext, taskQueue.ToChannel(), taskrunner.Options{
 			PollInterval:     options.PollInterval,
-			UseCache:         true,
 			EmitStatusEvents: options.EmitStatusEvents,
 		})
 		if err != nil {

--- a/pkg/apply/applier_builder.go
+++ b/pkg/apply/applier_builder.go
@@ -114,7 +114,7 @@ func (b *ApplierBuilder) finalize() (*ApplierBuilder, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error creating client: %v", err)
 		}
-		bx.statusPoller = polling.NewStatusPoller(c, bx.mapper, nil)
+		bx.statusPoller = polling.NewStatusPoller(c, bx.mapper, polling.Options{})
 	}
 	return &bx, nil
 }

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -362,7 +362,7 @@ func (f *fakePoller) Start() {
 	close(f.start)
 }
 
-func (f *fakePoller) Poll(ctx context.Context, _ object.ObjMetadataSet, _ polling.Options) <-chan pollevent.Event {
+func (f *fakePoller) Poll(ctx context.Context, _ object.ObjMetadataSet, _ polling.PollOptions) <-chan pollevent.Event {
 	eventChannel := make(chan pollevent.Event)
 	go func() {
 		defer close(eventChannel)

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
-	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/object/validation"
 )
@@ -38,7 +37,7 @@ func NewDestroyer(factory cmdutil.Factory, invClient inventory.InventoryClient) 
 	if err != nil {
 		return nil, fmt.Errorf("error setting up PruneOptions: %w", err)
 	}
-	statusPoller, err := polling.NewStatusPollerFromFactory(factory, []engine.StatusReader{})
+	statusPoller, err := polling.NewStatusPollerFromFactory(factory, polling.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +208,6 @@ func (d *Destroyer) Run(ctx context.Context, inv inventory.InventoryInfo, option
 		runner := taskrunner.NewTaskStatusRunner(deleteIds, d.StatusPoller)
 		klog.V(4).Infoln("destroyer running TaskStatusRunner...")
 		err = runner.Run(ctx, taskContext, taskQueue.ToChannel(), taskrunner.Options{
-			UseCache:         true,
 			PollInterval:     options.PollInterval,
 			EmitStatusEvents: options.EmitStatusEvents,
 		})

--- a/pkg/apply/poller/poller.go
+++ b/pkg/apply/poller/poller.go
@@ -18,5 +18,5 @@ import (
 // The options allows callers to override some of the settings of the poller,
 // like the polling frequency and the caching strategy.
 type Poller interface {
-	Poll(ctx context.Context, identifiers object.ObjMetadataSet, options polling.Options) <-chan pollevent.Event
+	Poll(ctx context.Context, identifiers object.ObjMetadataSet, options polling.PollOptions) <-chan pollevent.Event
 }

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -36,7 +36,6 @@ type taskStatusRunner struct {
 // the statusPoller.
 type Options struct {
 	PollInterval     time.Duration
-	UseCache         bool
 	EmitStatusEvents bool
 }
 
@@ -60,9 +59,8 @@ func (tsr *taskStatusRunner) Run(
 	// If taskStatusRunner.Run is cancelled, baseRunner.run will exit early,
 	// causing the poller to be cancelled.
 	statusCtx, cancelFunc := context.WithCancel(context.Background())
-	statusChannel := tsr.statusPoller.Poll(statusCtx, tsr.identifiers, polling.Options{
+	statusChannel := tsr.statusPoller.Poll(statusCtx, tsr.identifiers, polling.PollOptions{
 		PollInterval: opts.PollInterval,
-		UseCache:     opts.UseCache,
 	})
 
 	// complete stops the statusPoller, drains the statusChannel, and returns

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -557,7 +557,7 @@ func (f *fakePoller) Start() {
 	close(f.start)
 }
 
-func (f *fakePoller) Poll(ctx context.Context, _ object.ObjMetadataSet, _ polling.Options) <-chan pollevent.Event {
+func (f *fakePoller) Poll(ctx context.Context, _ object.ObjMetadataSet, _ polling.PollOptions) <-chan pollevent.Event {
 	eventChannel := make(chan pollevent.Event)
 	go func() {
 		defer close(eventChannel)

--- a/pkg/kstatus/polling/clusterreader/caching_reader.go
+++ b/pkg/kstatus/polling/clusterreader/caching_reader.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,7 +50,7 @@ var genGroupKinds = map[schema.GroupKind][]schema.GroupKind{
 // identifiers is needed so the ClusterReader can figure out which GroupKind
 // and namespace combinations it needs to cache when the Sync function is called.
 // We only want to fetch the resources that are actually needed.
-func NewCachingClusterReader(reader client.Reader, mapper meta.RESTMapper, identifiers object.ObjMetadataSet) (*CachingClusterReader, error) {
+func NewCachingClusterReader(reader client.Reader, mapper meta.RESTMapper, identifiers object.ObjMetadataSet) (engine.ClusterReader, error) {
 	gvkNamespaceSet := newGnSet()
 	for _, id := range identifiers {
 		// For every identifier, add the GroupVersionKind and namespace combination to the gvkNamespaceSet and

--- a/pkg/kstatus/polling/clusterreader/caching_reader_test.go
+++ b/pkg/kstatus/polling/clusterreader/caching_reader_test.go
@@ -88,7 +88,7 @@ func TestSync(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			fakeReader := &fakeReader{}
 
-			clusterReader, err := NewCachingClusterReader(fakeReader, fakeMapper, tc.identifiers)
+			clusterReader, err := newCachingClusterReader(fakeReader, fakeMapper, tc.identifiers)
 			require.NoError(t, err)
 
 			err = clusterReader.Sync(context.Background())
@@ -166,7 +166,7 @@ func TestSync_Errors(t *testing.T) {
 				err: tc.readerError,
 			}
 
-			clusterReader, err := NewCachingClusterReader(fakeReader, tc.mapper, identifiers)
+			clusterReader, err := newCachingClusterReader(fakeReader, tc.mapper, identifiers)
 			require.NoError(t, err)
 
 			err = clusterReader.Sync(context.Background())
@@ -186,6 +186,16 @@ func TestSync_Errors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newCachingClusterReader creates a new CachingClusterReader and returns it as the concrete
+// type instead of engine.ClusterReader.
+func newCachingClusterReader(reader client.Reader, mapper meta.RESTMapper, identifiers object.ObjMetadataSet) (*CachingClusterReader, error) {
+	r, err := NewCachingClusterReader(reader, mapper, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	return r.(*CachingClusterReader), nil
 }
 
 func sortGVKNamespaces(gvkNamespaces []gkNamespace) {

--- a/pkg/kstatus/polling/clusterreader/direct_reader.go
+++ b/pkg/kstatus/polling/clusterreader/direct_reader.go
@@ -6,10 +6,21 @@ package clusterreader
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
+	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// NewDirectClusterReader creates a new implementation of the engine.ClusterReader interface that makes
+// calls directly to the cluster without any caching.
+func NewDirectClusterReader(reader client.Reader, _ meta.RESTMapper, _ object.ObjMetadataSet) (engine.ClusterReader, error) {
+	return &DirectClusterReader{
+		Reader: reader,
+	}, nil
+}
 
 // DirectClusterReader is an implementation of the ClusterReader that just delegates all calls directly to
 // the underlying clusterreader. No caching.

--- a/pkg/kstatus/polling/doc.go
+++ b/pkg/kstatus/polling/doc.go
@@ -34,7 +34,7 @@
 //   }
 //
 //   poller := polling.NewStatusPoller(reader, mapper, true)
-//   eventsChan := poller.Poll(context.Background(), identifiers, polling.Options{})
+//   eventsChan := poller.Poll(context.Background(), identifiers, polling.PollOptions{})
 //   for e := range eventsChan {
 //      // Handle event
 //   }

--- a/pkg/kstatus/polling/engine/engine_test.go
+++ b/pkg/kstatus/polling/engine/engine_test.go
@@ -112,14 +112,13 @@ func TestStatusPollerRunner(t *testing.T) {
 				Mapper:              fakeMapper,
 				DefaultStatusReader: tc.defaultStatusReader,
 				StatusReaders:       []StatusReader{},
+				ClusterReaderFactory: ClusterReaderFactoryFunc(func(client.Reader, meta.RESTMapper, object.ObjMetadataSet) (ClusterReader, error) {
+					return testutil.NewNoopClusterReader(), nil
+				}),
 			}
 
 			options := Options{
 				PollInterval: 2 * time.Second,
-				ClusterReaderFactoryFunc: func(_ client.Reader, _ meta.RESTMapper, _ object.ObjMetadataSet) (
-					ClusterReader, error) {
-					return testutil.NewNoopClusterReader(), nil
-				},
 			}
 
 			eventChannel := engine.Poll(ctx, identifiers, options)
@@ -145,14 +144,14 @@ func TestNewStatusPollerRunnerCancellation(t *testing.T) {
 
 	timer := time.NewTimer(5 * time.Second)
 
-	engine := PollerEngine{}
+	engine := PollerEngine{
+		ClusterReaderFactory: ClusterReaderFactoryFunc(func(client.Reader, meta.RESTMapper, object.ObjMetadataSet) (ClusterReader, error) {
+			return testutil.NewNoopClusterReader(), nil
+		}),
+	}
 
 	options := Options{
 		PollInterval: 2 * time.Second,
-		ClusterReaderFactoryFunc: func(_ client.Reader, _ meta.RESTMapper, _ object.ObjMetadataSet) (
-			ClusterReader, error) {
-			return testutil.NewNoopClusterReader(), nil
-		},
 	}
 
 	eventChannel := engine.Poll(ctx, identifiers, options)
@@ -184,14 +183,12 @@ func TestNewStatusPollerRunnerIdentifierValidation(t *testing.T) {
 		Mapper: fakemapper.NewFakeRESTMapper(
 			appsv1.SchemeGroupVersion.WithKind("Deployment"),
 		),
+		ClusterReaderFactory: ClusterReaderFactoryFunc(func(client.Reader, meta.RESTMapper, object.ObjMetadataSet) (ClusterReader, error) {
+			return testutil.NewNoopClusterReader(), nil
+		}),
 	}
 
-	eventChannel := engine.Poll(context.Background(), identifiers, Options{
-		ClusterReaderFactoryFunc: func(_ client.Reader, _ meta.RESTMapper, _ object.ObjMetadataSet) (
-			ClusterReader, error) {
-			return testutil.NewNoopClusterReader(), nil
-		},
-	})
+	eventChannel := engine.Poll(context.Background(), identifiers, Options{})
 
 	timer := time.NewTimer(3 * time.Second)
 	defer timer.Stop()


### PR DESCRIPTION
This change allows clients to provide custom implementations of the `ClusterReader` interface for polling. The StatusPoller.Poll function currently allows users to choose between two different implementations using the `UseCache` option. With this change, the ClusterReader implementation is instead provided when the `StatusPoller` is created and allows for any implementation of the interface. This allows users to provide custom implementations for ApplyDestroy by providing a custom instance of the StatusPoller (this is currently a bit awkward, but should be addressed by https://github.com/kubernetes-sigs/cli-utils/pull/485)