### PR TITLE
Avoid goroutine being blocked forever in WaitTask

### DIFF
--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -60,8 +60,10 @@ func TestWaitTask_TimeoutCancelled(t *testing.T) {
 	timer := time.NewTimer(3 * time.Second)
 
 	select {
+	case res := <-taskContext.EventChannel():
+		t.Errorf("didn't expect error on eventChannel, but got %v", res)
 	case res := <-taskContext.TaskChannel():
-		t.Errorf("didn't expect timeout error, but got %v", res.Err)
+		t.Errorf("didn't expect event on taskChannel, but got %v", res)
 	case <-timer.C:
 		return
 	}


### PR DESCRIPTION
This addresses an issue where cancelling a WaitTask will cause the goroutine to block forever. With this change, we use a context instead of a timer so that the blocking goroutine will be released when the context is cancelled.

This has already been fixed as part of a larger refactor on the master branch.