### PR TITLE
capture the apply/reconcile status in the inventory object

### DIFF
--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -126,7 +126,7 @@ func createInventoryInfo(children ...*unstructured.Unstructured) inventory.Info 
 	inventoryObjCopy := inventoryObj.DeepCopy()
 	wrappedInv := inventory.WrapInventoryObj(inventoryObjCopy)
 	objs := object.UnstructuredSetToObjMetadataSet(children)
-	if err := wrappedInv.Store(objs); err != nil {
+	if err := wrappedInv.Store(objs, nil); err != nil {
 		return nil
 	}
 	obj, err := wrappedInv.GetObject()

--- a/pkg/apply/task/inv_set_task.go
+++ b/pkg/apply/task/inv_set_task.go
@@ -114,8 +114,11 @@ func (i *InvSetTask) Start(taskContext *taskrunner.TaskContext) {
 		klog.V(4).Infof("keep in inventory %d invalid objects", len(invalidObjects))
 		invObjs = invObjs.Union(invalidObjects)
 
+		klog.V(4).Infof("get the apply status for %d objects", len(invObjs))
+		objStatus := taskContext.InventoryManager().Inventory().Status.Objects
+
 		klog.V(4).Infof("set inventory %d total objects", len(invObjs))
-		err := i.InvClient.Replace(i.InvInfo, invObjs, i.DryRun)
+		err := i.InvClient.Replace(i.InvInfo, invObjs, objStatus, i.DryRun)
 
 		klog.V(2).Infof("inventory set task completing (name: %q)", i.Name())
 		taskContext.TaskChannel() <- taskrunner.TaskResult{Err: err}

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -6,14 +6,16 @@ package inventory
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
 // FakeClient is a testing implementation of the Client interface.
 type FakeClient struct {
-	Objs object.ObjMetadataSet
-	Err  error
+	Objs   object.ObjMetadataSet
+	Status []actuation.ObjectStatus
+	Err    error
 }
 
 var (
@@ -57,12 +59,13 @@ func (fic *FakeClient) Merge(_ Info, objs object.ObjMetadataSet, _ common.DryRun
 
 // Replace the stored cluster inventory objs with the passed obj, or an
 // error if one is set up.
-
-func (fic *FakeClient) Replace(_ Info, objs object.ObjMetadataSet, _ common.DryRunStrategy) error {
+func (fic *FakeClient) Replace(_ Info, objs object.ObjMetadataSet, status []actuation.ObjectStatus,
+	_ common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
 	}
 	fic.Objs = objs
+	fic.Status = status
 	return nil
 }
 

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -17,6 +17,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -31,7 +32,7 @@ type Storage interface {
 	// Load retrieves the set of object metadata from the inventory object
 	Load() (object.ObjMetadataSet, error)
 	// Store the set of object metadata in the inventory object
-	Store(objs object.ObjMetadataSet) error
+	Store(objs object.ObjMetadataSet, status []actuation.ObjectStatus) error
 	// GetObject returns the object that stores the inventory
 	GetObject() (*unstructured.Unstructured, error)
 }

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -420,10 +420,3 @@ func copyInventory() Info {
 	u := inventoryObj.DeepCopy()
 	return WrapInventoryInfoObj(u)
 }
-
-func storeObjsInInventory(info Info, objs object.ObjMetadataSet) *unstructured.Unstructured {
-	wrapped := WrapInventoryObj(InvInfoToConfigMap(info))
-	_ = wrapped.Store(objs)
-	inv, _ := wrapped.GetObject()
-	return inv
-}

--- a/pkg/inventory/inventorycm_test.go
+++ b/pkg/inventory/inventorycm_test.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package inventory
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestBuildObjMap(t *testing.T) {
+	obj1 := actuation.ObjectReference{
+		Group:     "group1",
+		Kind:      "Kind",
+		Namespace: "ns",
+		Name:      "na",
+	}
+	obj2 := actuation.ObjectReference{
+		Group:     "group2",
+		Kind:      "Kind",
+		Namespace: "ns",
+		Name:      "na",
+	}
+
+	tests := map[string]struct {
+		objSet    object.ObjMetadataSet
+		objStatus []actuation.ObjectStatus
+		expected  map[string]string
+		hasError  bool
+	}{
+		"objMetadata matches the status": {
+			objSet: object.ObjMetadataSet{ObjMetadataFromObjectReference(obj1), ObjMetadataFromObjectReference(obj2)},
+			objStatus: []actuation.ObjectStatus{
+				{
+					ObjectReference: obj1,
+					Strategy:        actuation.ActuationStrategyApply,
+					Actuation:       actuation.ActuationSucceeded,
+					Reconcile:       actuation.ReconcilePending,
+				},
+				{
+					ObjectReference: obj2,
+					Strategy:        actuation.ActuationStrategyDelete,
+					Actuation:       actuation.ActuationSkipped,
+					Reconcile:       actuation.ReconcileSucceeded,
+				},
+			},
+			expected: map[string]string{
+				"ns_na_group1_Kind": `{"actuation":"Succeeded","reconcile":"Pending","strategy":"Apply"}`,
+				"ns_na_group2_Kind": `{"actuation":"Skipped","reconcile":"Succeeded","strategy":"Delete"}`,
+			},
+		},
+		"empty object status list": {
+			objSet:   object.ObjMetadataSet{ObjMetadataFromObjectReference(obj1), ObjMetadataFromObjectReference(obj2)},
+			hasError: true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := buildObjMap(tc.objSet, tc.objStatus)
+			if tc.hasError {
+				if err == nil {
+					t.Fatalf("expected erroe, but not happened")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(actual, tc.expected); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -156,7 +157,7 @@ func (i InventoryCustomType) Load() (object.ObjMetadataSet, error) {
 	return inv, nil
 }
 
-func (i InventoryCustomType) Store(objs object.ObjMetadataSet) error {
+func (i InventoryCustomType) Store(objs object.ObjMetadataSet, _ []actuation.ObjectStatus) error {
 	var inv []interface{}
 	for _, obj := range objs {
 		inv = append(inv, map[string]interface{}{


### PR DESCRIPTION
Capture the apply status for individual resources after each apply.
If the inventory object supports status field, it is updated
after setting the inventory list at then of one apply process.

BREAKING CHANGE: Update the inventory client and inventory interfaces
to pass the apply/reconcile status.