### PR TITLE
[WIP] Removes inventory object from applier Run signature

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -128,12 +128,6 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	invObj, objs, err := inventory.SplitUnstructureds(objs)
-	if err != nil {
-		return err
-	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
-
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
@@ -154,7 +148,7 @@ func (r *ApplyRunner) RunE(cmd *cobra.Command, args []string) error {
 		r.printStatusEvents = true
 	}
 
-	ch := a.Run(ctx, inv, objs, apply.ApplierOptions{
+	ch := a.Run(ctx, objs, apply.ApplierOptions{
 		ServerSideOptions: r.serverSideOptions,
 		PollInterval:      r.period,
 		ReconcileTimeout:  r.reconcileTimeout,

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -108,12 +108,6 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	invObj, _, err := inventory.SplitUnstructureds(objs)
-	if err != nil {
-		return err
-	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
-
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
@@ -130,7 +124,7 @@ func (r *DestroyRunner) RunE(cmd *cobra.Command, args []string) error {
 
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	ch := d.Run(ctx, inv, apply.DestroyerOptions{
+	ch := d.Run(ctx, objs, apply.DestroyerOptions{
 		DeleteTimeout:           r.deleteTimeout,
 		DeletePropagationPolicy: deletePropPolicy,
 		InventoryPolicy:         inventoryPolicy,

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -120,12 +120,6 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	invObj, objs, err := inventory.SplitUnstructureds(objs)
-	if err != nil {
-		return err
-	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
-
 	invClient, err := r.invFactory.NewInventoryClient(r.factory)
 	if err != nil {
 		return err
@@ -148,7 +142,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 
 		// Run the applier. It will return a channel where we can receive updates
 		// to keep track of progress and any issues.
-		ch = a.Run(ctx, inv, objs, apply.ApplierOptions{
+		ch = a.Run(ctx, objs, apply.ApplierOptions{
 			EmitStatusEvents:  false,
 			NoPrune:           noPrune,
 			DryRunStrategy:    drs,
@@ -160,7 +154,7 @@ func (r *PreviewRunner) RunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		ch = d.Run(ctx, inv, apply.DestroyerOptions{
+		ch = d.Run(ctx, objs, apply.DestroyerOptions{
 			InventoryPolicy: inventoryPolicy,
 			DryRunStrategy:  drs,
 		})

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -1447,7 +1447,10 @@ func TestApplier(t *testing.T) {
 			testCtx, testCancel := context.WithTimeout(context.Background(), testTimeout)
 			defer testCancel() // cleanup
 
-			eventChannel := applier.Run(runCtx, tc.invInfo.toWrapped(), tc.resources, tc.options)
+			invObj := tc.invInfo.toUnstructured()
+			objs := tc.resources
+			objs = append(objs, invObj)
+			eventChannel := applier.Run(runCtx, objs, tc.options)
 
 			// only start sending events once
 			var once sync.Once
@@ -1887,7 +1890,10 @@ func TestApplierCancel(t *testing.T) {
 			testCtx, testCancel := context.WithTimeout(context.Background(), tc.testTimeout)
 			defer testCancel() // cleanup
 
-			eventChannel := applier.Run(runCtx, tc.invInfo.toWrapped(), tc.resources, tc.options)
+			invObj := tc.invInfo.toUnstructured()
+			objs := tc.resources
+			objs = append(objs, invObj)
+			eventChannel := applier.Run(runCtx, objs, tc.options)
 
 			// only start sending events once
 			var once sync.Once

--- a/pkg/apply/destroyer_test.go
+++ b/pkg/apply/destroyer_test.go
@@ -329,7 +329,10 @@ func TestDestroyerCancel(t *testing.T) {
 			testCtx, testCancel := context.WithTimeout(context.Background(), tc.testTimeout)
 			defer testCancel() // cleanup
 
-			eventChannel := destroyer.Run(runCtx, invInfo, tc.options)
+			invObj := tc.invInfo.toUnstructured()
+			objs := tc.clusterObjs
+			objs = append(objs, invObj)
+			eventChannel := destroyer.Run(runCtx, objs, tc.options)
 
 			// only start poller once per run
 			var once sync.Once

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -23,16 +23,17 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig Invento
 	By("apply an invalid CRD")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 
 	invalidCrdObj := manifestToUnstructured(invalidCrd)
 	pod1Obj := withNamespace(manifestToUnstructured(pod1), namespaceName)
 	resources := []*unstructured.Unstructured{
+		inv,
 		invalidCrdObj,
 		pod1Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{}))
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{}))
 
 	expEvents := []testutil.ExpEvent{
 		{

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -24,17 +24,18 @@ func crdTest(ctx context.Context, _ client.Client, invConfig InventoryConfig, in
 	By("apply a set of resources that includes both a crd and a cr")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 
 	crdObj := manifestToUnstructured(crd)
 	crObj := manifestToUnstructured(cr)
 
 	resources := []*unstructured.Unstructured{
+		inv,
 		crObj,
 		crdObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: false,
 	}))
@@ -215,7 +216,7 @@ func crdTest(ctx context.Context, _ client.Client, invConfig InventoryConfig, in
 	By("destroy the resources, including the crd")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(ctx, inv, options))
+	destroyerEvents := runCollect(destroyer.Run(ctx, resources, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -22,7 +22,7 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig InventoryConf
 	By("apply resources in order based on depends-on annotation")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 
 	pod1Obj := withDependsOn(withNamespace(manifestToUnstructured(pod1), namespaceName), fmt.Sprintf("/namespaces/%s/Pod/pod3", namespaceName))
 	pod2Obj := withNamespace(manifestToUnstructured(pod2), namespaceName)
@@ -31,12 +31,13 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig InventoryConf
 	// Dependency order: pod1 -> pod3 -> pod2
 	// Apply order: pod2, pod3, pod1
 	resources := []*unstructured.Unstructured{
+		inv,
 		pod1Obj,
 		pod2Obj,
 		pod3Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -301,7 +302,7 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig InventoryConf
 	By("destroy resources in opposite order")
 	destroyer := invConfig.DestroyerFactoryFunc()
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(ctx, inv, options))
+	destroyerEvents := runCollect(destroyer.Run(ctx, resources, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/exit_early_test.go
+++ b/test/e2e/exit_early_test.go
@@ -23,7 +23,7 @@ func exitEarlyTest(ctx context.Context, c client.Client, invConfig InventoryConf
 	By("exit early on invalid object")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 
 	fields := struct{ Namespace string }{Namespace: namespaceName}
 	// valid pod
@@ -35,12 +35,13 @@ func exitEarlyTest(ctx context.Context, c client.Client, invConfig InventoryConf
 	invalidPodObj := templateToUnstructured(invalidPodTemplate, fields)
 
 	resources := []*unstructured.Unstructured{
+		inv,
 		pod1Obj,
 		deployment1Obj,
 		invalidPodObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 		ValidationPolicy: validation.ExitEarly,
 	}))

--- a/test/e2e/inventory_policy_test.go
+++ b/test/e2e/inventory_policy_test.go
@@ -25,26 +25,28 @@ func inventoryPolicyMustMatchTest(ctx context.Context, c client.Client, invConfi
 	applier := invConfig.ApplierFactoryFunc()
 
 	firstInvName := randomString("first-inv-")
-	firstInv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(firstInvName, namespaceName, firstInvName))
+	firstInv := invConfig.InventoryFactoryFunc(firstInvName, namespaceName, firstInvName)
 	deployment1Obj := withNamespace(manifestToUnstructured(deployment1), namespaceName)
 	firstResources := []*unstructured.Unstructured{
+		firstInv,
 		deployment1Obj,
 	}
 
-	runWithNoErr(applier.Run(ctx, firstInv, firstResources, apply.ApplierOptions{
+	runWithNoErr(applier.Run(ctx, firstResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 	}))
 
 	By("Apply second set of resources")
 	secondInvName := randomString("second-inv-")
-	secondInv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(secondInvName, namespaceName, secondInvName))
+	secondInv := invConfig.InventoryFactoryFunc(secondInvName, namespaceName, secondInvName)
 	deployment1Obj = withNamespace(manifestToUnstructured(deployment1), namespaceName)
 	secondResources := []*unstructured.Unstructured{
+		secondInv,
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, secondInv, secondResources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, secondResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		InventoryPolicy:  inventory.InventoryPolicyMustMatch,
@@ -196,13 +198,14 @@ func inventoryPolicyAdoptIfNoInventoryTest(ctx context.Context, c client.Client,
 	applier := invConfig.ApplierFactoryFunc()
 
 	invName := randomString("test-inv-")
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(invName, namespaceName, invName))
+	inv := invConfig.InventoryFactoryFunc(invName, namespaceName, invName)
 	deployment1Obj = withNamespace(manifestToUnstructured(deployment1), namespaceName)
 	resources := []*unstructured.Unstructured{
+		inv,
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		InventoryPolicy:  inventory.AdoptIfNoInventory,
@@ -365,26 +368,28 @@ func inventoryPolicyAdoptAllTest(ctx context.Context, c client.Client, invConfig
 	applier := invConfig.ApplierFactoryFunc()
 
 	firstInvName := randomString("first-inv-")
-	firstInv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(firstInvName, namespaceName, firstInvName))
+	firstInv := invConfig.InventoryFactoryFunc(firstInvName, namespaceName, firstInvName)
 	deployment1Obj := withNamespace(manifestToUnstructured(deployment1), namespaceName)
 	firstResources := []*unstructured.Unstructured{
+		firstInv,
 		deployment1Obj,
 	}
 
-	runWithNoErr(applier.Run(ctx, firstInv, firstResources, apply.ApplierOptions{
+	runWithNoErr(applier.Run(ctx, firstResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 	}))
 
 	By("Apply resources")
 	secondInvName := randomString("test-inv-")
-	secondInv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(secondInvName, namespaceName, secondInvName))
+	secondInv := invConfig.InventoryFactoryFunc(secondInvName, namespaceName, secondInvName)
 	deployment1Obj = withNamespace(manifestToUnstructured(deployment1), namespaceName)
 	secondResources := []*unstructured.Unstructured{
+		secondInv,
 		withReplicas(deployment1Obj, 6),
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, secondInv, secondResources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, secondResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		InventoryPolicy:  inventory.AdoptAll,

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -28,10 +28,11 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig Inve
 
 	pod1Obj := withNamespace(manifestToUnstructured(pod1), namespaceName)
 	resource1 := []*unstructured.Unstructured{
+		inv,
 		pod1Obj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resource1, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resource1, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -162,10 +163,11 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig Inve
 	By("apply a different resource, and validate the inventory accurately reflects only this object")
 	pod2Obj := withNamespace(manifestToUnstructured(pod2), namespaceName)
 	resource2 := []*unstructured.Unstructured{
+		inv,
 		pod2Obj,
 	}
 
-	applierEvents2 := runCollect(applier.Run(ctx, inv, resource2, apply.ApplierOptions{
+	applierEvents2 := runCollect(applier.Run(ctx, resource2, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -297,7 +299,7 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig Inve
 	destroyer := invConfig.DestroyerFactoryFunc()
 
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.AdoptIfNoInventory}
-	destroyerEvents := runCollect(destroyer.Run(ctx, inv, options))
+	destroyerEvents := runCollect(destroyer.Run(ctx, resource2, options))
 
 	expEvents3 := []testutil.ExpEvent{
 		{

--- a/test/e2e/reconcile_failed_timeout_test.go
+++ b/test/e2e/reconcile_failed_timeout_test.go
@@ -22,14 +22,15 @@ func reconciliationFailed(ctx context.Context, invConfig InventoryConfig, invent
 	applier := invConfig.ApplierFactoryFunc()
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryObj := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 
 	podObj := withNodeSelector(withNamespace(manifestToUnstructured(pod1), namespaceName), "foo", "bar")
 	resources := []*unstructured.Unstructured{
+		inventoryObj,
 		podObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: false,
 	}))
@@ -45,14 +46,15 @@ func reconciliationTimeout(ctx context.Context, invConfig InventoryConfig, inven
 	applier := invConfig.ApplierFactoryFunc()
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryObj := createInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
 
 	podObj := podWithImage(withNamespace(manifestToUnstructured(pod1), namespaceName), "kubernetes-pause", "does-not-exist")
 	resources := []*unstructured.Unstructured{
+		inventoryObj,
 		podObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		ReconcileTimeout: 30 * time.Second,
 		EmitStatusEvents: false,
 	}))

--- a/test/e2e/serverside_apply_test.go
+++ b/test/e2e/serverside_apply_test.go
@@ -21,13 +21,14 @@ func serversideApplyTest(ctx context.Context, c client.Client, invConfig Invento
 	By("Apply a Deployment and an APIService by server-side apply")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 	firstResources := []*unstructured.Unstructured{
+		inv,
 		withNamespace(manifestToUnstructured(deployment1), namespaceName),
 		manifestToUnstructured(apiservice1),
 	}
 
-	runWithNoErr(applier.Run(ctx, inv, firstResources, apply.ApplierOptions{
+	runWithNoErr(applier.Run(ctx, firstResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		ServerSideOptions: common.ServerSideOptions{

--- a/test/e2e/skip_invalid_test.go
+++ b/test/e2e/skip_invalid_test.go
@@ -28,7 +28,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig InventoryCo
 	By("apply valid objects and skip invalid objects")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test"))
+	inv := invConfig.InventoryFactoryFunc(inventoryName, namespaceName, "test")
 
 	fields := struct{ Namespace string }{Namespace: namespaceName}
 	// valid pod
@@ -47,6 +47,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig InventoryCo
 	invalidPodObj := templateToUnstructured(invalidPodTemplate, fields)
 
 	resources := []*unstructured.Unstructured{
+		inv,
 		pod1Obj,
 		deployment1Obj,
 		pod3Obj,
@@ -55,7 +56,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig InventoryCo
 		invalidPodObj,
 	}
 
-	applierEvents := runCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := runCollect(applier.Run(ctx, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 		ValidationPolicy: validation.SkipInvalid,
 	}))
@@ -344,7 +345,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig InventoryCo
 
 	By("destroy valid objects and skip invalid objects")
 	destroyer := invConfig.DestroyerFactoryFunc()
-	destroyerEvents := runCollect(destroyer.Run(ctx, inv, apply.DestroyerOptions{
+	destroyerEvents := runCollect(destroyer.Run(ctx, resources, apply.DestroyerOptions{
 		InventoryPolicy:  inventory.AdoptIfNoInventory,
 		ValidationPolicy: validation.SkipInvalid,
 	}))


### PR DESCRIPTION
* Removes the inventory object from the applier `Run` function signature.
* Supports `cli-utils` clients that do not want to use the pruning functionality.
* Moves the identification of the inventory object from outside `Run` to inside.
* In a future PR, the inventory add and set tasks will become dependent on if an inventory object is detected among the passed objects to apply.

BREAKING CHANGE: the `applier.Run()` function signature is changed to remove the inventory object. The `destroyer.Run()` function signature is changed to take all objects to delete instead of the inventory object.