### PR TITLE
Use discovery client to check if inventory objects has subresource status

### DIFF
--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -232,7 +232,7 @@ func TestCreateInventory(t *testing.T) {
 			if inv != nil {
 				inv = storeObjsInInventory(tc.inv, tc.localObjs)
 			}
-			err = invClient.createInventoryObj(inv, common.DryRunNone)
+			_, err = invClient.createInventoryObj(inv, common.DryRunNone)
 			if tc.error != "" {
 				assert.EqualError(t, err, tc.error)
 			} else {


### PR DESCRIPTION
Use the function `DiscoveryClient.ServerResourcesForGroupVersion`
to list all the resources in a group. Then check if the subresource
status is contained in the list.