### PR TITLE
chore: Move AdoptAll logic out of the Applier

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -150,14 +150,13 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.InventoryInfo, obje
 			InventoryPolicy:        options.InventoryPolicy,
 		}
 		// Build list of apply validation filters.
-		var applyFilters []filter.ValidationFilter
-		if options.InventoryPolicy != inventory.AdoptAll {
-			applyFilters = append(applyFilters, filter.InventoryPolicyApplyFilter{
+		applyFilters := []filter.ValidationFilter{
+			filter.InventoryPolicyApplyFilter{
 				Client:    a.client,
 				Mapper:    a.mapper,
 				Inv:       invInfo,
 				InvPolicy: options.InventoryPolicy,
-			})
+			},
 		}
 
 		// Build list of prune validation filters.

--- a/pkg/apply/filter/inventory-policy-apply-filter.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter.go
@@ -38,6 +38,9 @@ func (ipaf InventoryPolicyApplyFilter) Filter(obj *unstructured.Unstructured) (b
 	if obj == nil {
 		return true, "missing object", nil
 	}
+	if ipaf.InvPolicy == inventory.AdoptAll {
+		return false, "", nil
+	}
 	// Object must be retrieved from the cluster to get the inventory id.
 	clusterObj, err := ipaf.getObject(object.UnstructuredToObjMetadata(obj))
 	if err != nil {


### PR DESCRIPTION
Just a minor change to simplify the applier code by removing code branches.