### PR TITLE
chore: Remove redundant object sorting

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -6,7 +6,6 @@ package apply
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -28,7 +27,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/object/validation"
-	"sigs.k8s.io/cli-utils/pkg/ordering"
 )
 
 const defaultPollInterval = 2 * time.Second
@@ -93,7 +91,6 @@ func (a *Applier) prepareObjects(localInv inventory.InventoryInfo, localObjs obj
 	if err != nil {
 		return nil, nil, err
 	}
-	sort.Sort(ordering.SortableUnstructureds(localObjs))
 	return localObjs, pruneObjs, nil
 }
 

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -13,7 +13,6 @@ package prune
 
 import (
 	"context"
-	"sort"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -27,7 +26,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
-	"sigs.k8s.io/cli-utils/pkg/ordering"
 )
 
 // Pruner implements GetPruneObjs to calculate which objects to prune and Prune
@@ -233,7 +231,6 @@ func (p *Pruner) GetPruneObjs(
 		}
 		objs = append(objs, pruneObj)
 	}
-	sort.Sort(sort.Reverse(ordering.SortableUnstructureds(objs)))
 	return objs, nil
 }
 


### PR DESCRIPTION
- The Solver Graph performs sorting.
  So the applier & destroyer don't need to.