### PR TITLE
chore: Log YAML to V7, instead of V4

### DIFF
--- a/pkg/apply/mutator/apply_time_mutator_test.go
+++ b/pkg/apply/mutator/apply_time_mutator_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var expectedReason = "resource contained annotation: config.kubernetes.io/apply-time-mutation"
+var expectedReason = "object contained annotation: config.kubernetes.io/apply-time-mutation"
 
 var pod1y = `
 apiVersion: v1
@@ -409,7 +409,7 @@ func TestMutate(t *testing.T) {
 			mutated: false,
 			reason:  "",
 			// exact error message isn't very important. Feel free to update if the error text changes.
-			errMsg: `failed to read annotation in resource (v1/namespaces/map-namespace/ConfigMap/map3-name): ` +
+			errMsg: `failed to read annotation in object (v1/namespaces/map-namespace/ConfigMap/map3-name): ` +
 				`invalid "config.kubernetes.io/apply-time-mutation" annotation: ` +
 				`error unmarshaling JSON: ` +
 				`while decoding JSON: ` +
@@ -427,8 +427,8 @@ func TestMutate(t *testing.T) {
 			mutated: false,
 			reason:  "",
 			// exact error message isn't very important. Feel free to update if the error text changes.
-			errMsg: `failed to get source resource (networking.k8s.io/namespaces/ingress-namespace/Ingress/ingress1-name): ` +
-				`resource not found: ` +
+			errMsg: `failed to get source object (networking.k8s.io/namespaces/ingress-namespace/Ingress/ingress1-name): ` +
+				`object not found: ` +
 				`ingresses.networking.k8s.io "ingress1-name" not found`,
 		},
 		"pod env var string from ingress port int": {

--- a/pkg/object/mutation/annotation.go
+++ b/pkg/object/mutation/annotation.go
@@ -37,7 +37,7 @@ func ReadAnnotation(obj *unstructured.Unstructured) (ApplyTimeMutation, error) {
 		return mutation, nil
 	}
 	if klog.V(5).Enabled() {
-		klog.Infof("resource (%v) has apply-time-mutation annotation:\n%s", ResourceReferenceFromUnstructured(obj), mutationYaml)
+		klog.Infof("object (%v) has apply-time-mutation annotation:\n%s", ResourceReferenceFromUnstructured(obj), mutationYaml)
 	}
 
 	err := yaml.Unmarshal([]byte(mutationYaml), &mutation)

--- a/pkg/object/mutation/types.go
+++ b/pkg/object/mutation/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ApplyTimeMutation is a list of substitutions to perform in the target
-// resource before applying, after waiting for the source resources to be
+// object before applying, after waiting for the source objects to be
 // reconciled.
 // This most notibly allows status fields to be substituted into spec fields.
 type ApplyTimeMutation []FieldSubstitution
@@ -44,17 +44,17 @@ func (a ApplyTimeMutation) Equal(b ApplyTimeMutation) bool {
 }
 
 // FieldSubstitution specifies a substitution that will be performed at
-// apply-time. The source resource field will be read and substituted into the
-// target resource field, replacing the token.
+// apply-time. The source object field will be read and substituted into the
+// target object field, replacing the token.
 type FieldSubstitution struct {
-	// SourceRef is a reference to the resource that contains the source field.
+	// SourceRef is a reference to the object that contains the source field.
 	SourceRef ResourceReference `json:"sourceRef"`
 
-	// SourcePath is a JSONPath reference to a field in the source resource.
+	// SourcePath is a JSONPath reference to a field in the source object.
 	// Example: "$.status.number"
 	SourcePath string `json:"sourcePath"`
 
-	// TargetPath is a JSONPath reference to a field in the target resource.
+	// TargetPath is a JSONPath reference to a field in the target object.
 	// Example: "$.spec.member"
 	TargetPath string `json:"targetPath"`
 
@@ -85,11 +85,11 @@ type ResourceReference struct {
 	// +optional
 	Group string `json:"group,omitempty"`
 
-	// Name of the resource.
+	// Name of the object.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name string `json:"name,omitempty"`
 
-	// Namespace is optional, defaults to the namespace of the target resource.
+	// Namespace is optional, defaults to the namespace of the target object.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 	// +optional
 	Namespace string `json:"namespace,omitempty"`


### PR DESCRIPTION
- Rename "resource" to "object" in mutation code.
  Resource is a REST interface. Object is an instance of a Resource.