### PR TITLE
chore: Change solver to decide which tasks to use

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -677,22 +677,6 @@ func TestApplier(t *testing.T) {
 				{
 					EventType: event.ActionGroupType,
 					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Started,
-					},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Finished,
-					},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
 						GroupName: "prune-0",
 						Action:    event.PruneAction,
 						Type:      event.Started,
@@ -956,22 +940,6 @@ func TestApplier(t *testing.T) {
 				{
 					EventType: event.ActionGroupType,
 					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Started,
-					},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Finished,
-					},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
 						GroupName: "prune-0",
 						Action:    event.PruneAction,
 						Type:      event.Started,
@@ -1091,22 +1059,6 @@ func TestApplier(t *testing.T) {
 				{
 					EventType: event.InitType,
 					InitEvent: &testutil.ExpInitEvent{},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Started,
-					},
-				},
-				{
-					EventType: event.ActionGroupType,
-					ActionGroupEvent: &testutil.ExpActionGroupEvent{
-						GroupName: "inventory-add-0",
-						Action:    event.InventoryAction,
-						Type:      event.Finished,
-					},
 				},
 				{
 					EventType: event.ActionGroupType,


### PR DESCRIPTION
- This redesign of the solver moves complexity about deciding which
  tasks to use from the applier/destroyer into the solver. This makes
  the solver more of a solver and less of a "do what your told"-er.
- One major difference is that the InvAddTask is now skipped if there
  are no objects to be applied. This makes logic sense because the
  inventory doesn't need to be expanded.
- This change unblocks unification of graph dependency resolution
  using both the apploy objects and prune objects, which will help
  distinguish between external dependencies and dependencies being
  accidentally deleted.