### PR TITLE
Ensure that Daemonset controller has acted on the Daemonset.

### DIFF
--- a/pkg/kstatus/status/status_compute_test.go
+++ b/pkg/kstatus/status/status_compute_test.go
@@ -503,6 +503,21 @@ status:
    numberReady: 4
    observedGeneration: 1
 `
+var dsDifferentGeneration = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+   name: test
+   namespace: qual
+   generation: 2
+status:
+   desiredNumberScheduled: 4
+   currentNumberScheduled: 4
+   updatedNumberScheduled: 4
+   numberAvailable: 4
+   numberReady: 4
+   observedGeneration: 1
+`
 
 var dsLessReady = `
 apiVersion: apps/v1
@@ -543,7 +558,7 @@ func TestDaemonsetStatus(t *testing.T) {
 			expectedConditions: []Condition{{
 				Type:   ConditionReconciling,
 				Status: corev1.ConditionTrue,
-				Reason: "NoDesiredNumber",
+				Reason: "NoObservedGeneration",
 			}},
 			absentConditionTypes: []ConditionType{
 				ConditionStalled,
@@ -577,6 +592,18 @@ func TestDaemonsetStatus(t *testing.T) {
 				Type:   ConditionReconciling,
 				Status: corev1.ConditionTrue,
 				Reason: "LessReady",
+			}},
+			absentConditionTypes: []ConditionType{
+				ConditionStalled,
+			},
+		},
+		"dsDifferentGeneration": {
+			spec:           dsDifferentGeneration,
+			expectedStatus: InProgressStatus,
+			expectedConditions: []Condition{{
+				Type:   ConditionReconciling,
+				Status: corev1.ConditionTrue,
+				Reason: "LatestGenerationNotObserved",
 			}},
 			absentConditionTypes: []ConditionType{
 				ConditionStalled,


### PR DESCRIPTION
In status.Compute() -> checkGenericProperties() -> checkGeneration(),
we check that metadata.generation is equal to status.observedGeneration
but don't return an InProgress status if either of them is unset.

This may be reasonable for generic resource where we are unsure if these
fields would be set, but for daemonsets, we *know* that these fields get
set by the controller and so we should ensure that.

This fixes #548.