### PR TITLE
fix: Don't error if inventory namespace already exists

### DIFF
--- a/pkg/inventory/inventory-client.go
+++ b/pkg/inventory/inventory-client.go
@@ -439,6 +439,9 @@ func (cic *ClusterClient) ApplyInventoryNamespace(obj *unstructured.Unstructured
 	}
 
 	_, err = cic.dc.Resource(mapping.Resource).Create(context.TODO(), invNamespace, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
 	return err
 }
 

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
 	clienttesting "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -493,6 +495,45 @@ func TestDeleteInventoryObj(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestApplyInventoryNamespace(t *testing.T) {
+	testCases := map[string]struct {
+		namespace      *unstructured.Unstructured
+		dryRunStrategy common.DryRunStrategy
+		reactorError   error
+	}{
+		"inventory namespace doesn't exist": {
+			namespace:      inventoryNamespace,
+			dryRunStrategy: common.DryRunNone,
+			reactorError:   nil,
+		},
+		"inventory namespace already exist": {
+			namespace:      inventoryNamespace,
+			dryRunStrategy: common.DryRunNone,
+			reactorError: errors.NewAlreadyExists(schema.GroupResource{
+				Group:    "",
+				Resource: "namespaces",
+			}, testNamespace),
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
+			defer tf.Cleanup()
+
+			tf.FakeDynamicClient.PrependReactor("create", "namespaces", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, tc.reactorError
+			})
+
+			invClient, err := NewClient(tf,
+				WrapInventoryObj, InvInfoToConfigMap)
+			require.NoError(t, err)
+			err = invClient.ApplyInventoryNamespace(tc.namespace, tc.dryRunStrategy)
+			assert.NoError(t, err)
+		})
 	}
 }
 

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -124,6 +124,16 @@ var pod3Info = &resource.Info{
 	Object: pod3,
 }
 
+var inventoryNamespace = &unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": testNamespace,
+		},
+	},
+}
+
 func TestFindInventoryObj(t *testing.T) {
 	tests := map[string]struct {
 		infos  []*unstructured.Unstructured


### PR DESCRIPTION
Currently the Inventory Client returns an error if the inventory namespace already exists. This fixes that and adds tests. 

This is a bug from https://github.com/kubernetes-sigs/cli-utils/pull/515