### PR TITLE
[WIP] feat: immediate status check after apply

### DIFF
--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -35,9 +35,11 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 	"sigs.k8s.io/cli-utils/pkg/object/graph"
 	"sigs.k8s.io/cli-utils/pkg/object/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type TaskQueueBuilder struct {
+	Client        client.Client
 	Pruner        *prune.Pruner
 	DynamicClient dynamic.Interface
 	OpenAPIGetter discovery.OpenAPISchemaInterface
@@ -248,6 +250,7 @@ func (t *TaskQueueBuilder) newApplyTask(applyObjs object.UnstructuredSet,
 		Mutators:          applyMutators,
 		ServerSideOptions: o.ServerSideOptions,
 		DryRunStrategy:    o.DryRunStrategy,
+		Client:            t.Client,
 		DynamicClient:     t.DynamicClient,
 		OpenAPIGetter:     t.OpenAPIGetter,
 		InfoHelper:        t.InfoHelper,

--- a/pkg/kstatus/polling/polling.go
+++ b/pkg/kstatus/polling/polling.go
@@ -28,7 +28,7 @@ func NewStatusPoller(reader client.Reader, mapper meta.RESTMapper, o Options) *S
 
 	statusReaders = append(statusReaders, o.CustomStatusReaders...)
 
-	srs, defaultStatusReader := createStatusReaders(mapper)
+	srs, defaultStatusReader := DefaultStatusReaders(mapper)
 	statusReaders = append(statusReaders, srs...)
 
 	return &StatusPoller{
@@ -103,12 +103,12 @@ type PollOptions struct {
 	PollInterval time.Duration
 }
 
-// createStatusReaders creates an instance of all the statusreaders. This includes a set of statusreaders for
+// DefaultStatusReaders creates an instance of all the statusreaders. This includes a set of statusreaders for
 // a particular GroupKind, and a default engine used for all resource types that does not have
 // a specific statusreaders.
 // TODO: We should consider making the registration more automatic instead of having to create each of them
 // here. Also, it might be worth creating them on demand.
-func createStatusReaders(mapper meta.RESTMapper) ([]engine.StatusReader, engine.StatusReader) {
+func DefaultStatusReaders(mapper meta.RESTMapper) ([]engine.StatusReader, engine.StatusReader) {
 	defaultStatusReader := statusreaders.NewGenericStatusReader(mapper, status.Compute)
 
 	replicaSetStatusReader := statusreaders.NewReplicaSetStatusReader(mapper, defaultStatusReader)


### PR DESCRIPTION
This change adds an immediate status check after apply using the response object. This should short-circuit waiting for the StatusPoller for objects that reconcile immediately (e.g. ConfigMaps).

Unfortunately, this won't help CRDs or Namespaces, which actually need their controller to update their status.

This PoC impl is a hack. To do ti right, we'll need to refactor the StatusPoller to expose the injected StatusReaders, otherwise the ones used after apply won't match the ones injected by the user. Alternatively, we could just have users inject a list of StatusReaders and construct the StatusPoller ourselves.