### PR TITLE
chore: Fix event sorting for testing

### DIFF
--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -5,7 +5,6 @@ package apply
 
 import (
 	"context"
-	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -1511,7 +1510,7 @@ func TestApplier(t *testing.T) {
 			}
 
 			// sort to allow comparison of multiple apply/prune tasks in the same task group
-			sort.Sort(testutil.GroupedEventsByID(receivedEvents))
+			testutil.SortExpEvents(receivedEvents)
 
 			// Validate the rest of the events
 			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents,

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -6,7 +6,6 @@ package e2e
 import (
 	"context"
 	"errors"
-	"sort"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -165,7 +164,7 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig invconf
 	}
 	receivedEvents := testutil.EventsToExpEvents(applierEvents)
 	// sort to allow comparison of multiple ApplyTasks in the same task group
-	sort.Sort(testutil.GroupedEventsByID(receivedEvents))
+	testutil.SortExpEvents(receivedEvents)
 	Expect(receivedEvents).To(testutil.Equal(expEvents))
 
 	By("Verify pod1 created")


### PR DESCRIPTION
Previous sorting method was not stable, and only worked coincidentally
for the two use cases that were using it. This new method works on
more event types and only sorts contiguous events. This should make
the sort usable when we add parallel apply and watch instead of poll.