### PR TITLE
chore: Disable client-side throttling for tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,10 +57,10 @@ var _ = Describe("Applier", func() {
 		cfg, err := ctrl.GetConfig()
 		Expect(err).NotTo(HaveOccurred())
 
-		// increase QPS from 5 to 20
-		cfg.QPS = 20
-		// increase Burst QPS from 10 to 40
-		cfg.Burst = 40
+		// Disable client-side throttling.
+		// Recent versions of kind support server-side throttling.
+		cfg.QPS = -1
+		cfg.Burst = -1
 
 		inventoryConfigs[ConfigMapTypeInvConfig] = invconfig.NewConfigMapTypeInvConfig(cfg)
 		inventoryConfigs[CustomTypeInvConfig] = invconfig.NewCustomTypeInvConfig(cfg)

--- a/test/stress/stress_suite_test.go
+++ b/test/stress/stress_suite_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestE2e(t *testing.T) {
+func TestStress(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Stress Test Suite")
 }

--- a/test/stress/stress_test.go
+++ b/test/stress/stress_test.go
@@ -45,10 +45,10 @@ var _ = Describe("Applier", func() {
 		cfg, err := ctrl.GetConfig()
 		Expect(err).NotTo(HaveOccurred())
 
-		// increase QPS from 5 to 20
-		cfg.QPS = 20
-		// increase Burst QPS from 10 to 40
-		cfg.Burst = 40
+		// Disable client-side throttling.
+		// Recent versions of kind support server-side throttling.
+		cfg.QPS = -1
+		cfg.Burst = -1
 
 		invConfig = invconfig.NewCustomTypeInvConfig(cfg)
 


### PR DESCRIPTION
Recent versions of kind have server-side throttling, and there's nothing else on the test cluster, so we can speed up the tests.