### PR TITLE
fix: Send Failed status when erroring

### DIFF
--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -68,6 +68,7 @@ func (pef PruneEventFactory) CreateFailedEvent(id object.ObjMetadata, err error)
 		Type: event.PruneType,
 		PruneEvent: event.PruneEvent{
 			GroupName:  pef.groupName,
+			Status:     event.PruneFailed,
 			Identifier: id,
 			Error:      err,
 		},
@@ -110,6 +111,7 @@ func (def DeleteEventFactory) CreateFailedEvent(id object.ObjMetadata, err error
 		Type: event.DeleteType,
 		DeleteEvent: event.DeleteEvent{
 			GroupName:  def.groupName,
+			Status:     event.DeleteFailed,
 			Identifier: id,
 			Error:      err,
 		},

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -697,6 +697,7 @@ func TestPruneWithErrors(t *testing.T) {
 					EventType: event.PruneType,
 					PruneEvent: &testutil.ExpPruneEvent{
 						Identifier: object.UnstructuredToObjMetadata(pdbDeleteFailure),
+						Status:     event.PruneFailed,
 						Error:      fmt.Errorf("expected delete error"),
 					},
 				},
@@ -710,6 +711,7 @@ func TestPruneWithErrors(t *testing.T) {
 					EventType: event.DeleteType,
 					DeleteEvent: &testutil.ExpDeleteEvent{
 						Identifier: object.UnstructuredToObjMetadata(pdbDeleteFailure),
+						Status:     event.DeleteFailed,
 						Error:      fmt.Errorf("expected delete error"),
 					},
 				},

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -251,6 +251,7 @@ func (a *ApplyTask) createApplyFailedEvent(id object.ObjMetadata, err error) eve
 		ApplyEvent: event.ApplyEvent{
 			GroupName:  a.Name(),
 			Identifier: id,
+			Status:     event.ApplyFailed,
 			Error:      err,
 		},
 	}

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -412,7 +412,8 @@ func TestApplyTaskWithError(t *testing.T) {
 				{
 					Type: event.ApplyType,
 					ApplyEvent: event.ApplyEvent{
-						Error: fmt.Errorf("expected apply error"),
+						Status: event.ApplyFailed,
+						Error:  fmt.Errorf("expected apply error"),
 					},
 				},
 			},

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -73,6 +73,7 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig invconf
 			EventType: event.ApplyType,
 			ApplyEvent: &testutil.ExpApplyEvent{
 				GroupName:  "apply-0",
+				Status:     event.ApplyFailed,
 				Identifier: object.UnstructuredToObjMetadata(invalidCrdObj),
 				Error: testutil.EqualErrorType(
 					applyerror.NewApplyRunError(errors.New("failed to apply")),


### PR DESCRIPTION
- Caller should switch on Type == Failed, not Error != nil
- Error should always be non-nil for Failed and Skipped events