### PR TITLE
fix: Sort reconcile events to fix flakey test

### DIFF
--- a/pkg/apply/destroyer_test.go
+++ b/pkg/apply/destroyer_test.go
@@ -259,6 +259,7 @@ func TestDestroyerCancel(t *testing.T) {
 						Type:      event.Started,
 					},
 				},
+				// Wait events sorted Pending > Successful (see pkg/testutil)
 				{
 					// Deployment reconcile pending.
 					EventType: event.WaitType,
@@ -373,6 +374,9 @@ func TestDestroyerCancel(t *testing.T) {
 					t.Errorf("Expected status event not received: %#v", e)
 				}
 			}
+
+			// sort to allow comparison of multiple wait events
+			testutil.SortExpEvents(receivedEvents)
 
 			// Validate the rest of the events
 			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents,

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -136,15 +136,6 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig invconf
 			},
 		},
 		{
-			// CRD reconcile Skipped.
-			EventType: event.WaitType,
-			WaitEvent: &testutil.ExpWaitEvent{
-				GroupName:  "wait-0",
-				Status:     event.ReconcileSkipped,
-				Identifier: object.UnstructuredToObjMetadata(invalidCrdObj),
-			},
-		},
-		{
 			// Pod1 reconcile Pending.
 			EventType: event.WaitType,
 			WaitEvent: &testutil.ExpWaitEvent{
@@ -154,7 +145,16 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig invconf
 			},
 		},
 		{
-			// Pod1 confirmed Current.
+			// CRD reconcile Skipped.
+			EventType: event.WaitType,
+			WaitEvent: &testutil.ExpWaitEvent{
+				GroupName:  "wait-0",
+				Status:     event.ReconcileSkipped,
+				Identifier: object.UnstructuredToObjMetadata(invalidCrdObj),
+			},
+		},
+		{
+			// Pod1 reconcile Successful.
 			EventType: event.WaitType,
 			WaitEvent: &testutil.ExpWaitEvent{
 				GroupName:  "wait-0",

--- a/test/e2e/depends_on_test.go
+++ b/test/e2e/depends_on_test.go
@@ -382,7 +382,10 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig invconfig.Inv
 			},
 		},
 	}
-	Expect(testutil.EventsToExpEvents(applierEvents)).To(testutil.Equal(expEvents))
+	receivedEvents := testutil.EventsToExpEvents(applierEvents)
+	// sort to handle objects reconciling in random order
+	testutil.SortExpEvents(receivedEvents)
+	Expect(receivedEvents).To(testutil.Equal(expEvents))
 
 	By("verify namespace1 created")
 	e2eutil.AssertUnstructuredExists(ctx, c, namespace1Obj)
@@ -660,21 +663,21 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig invconfig.Inv
 			},
 		},
 		{
-			// Namespace2 reconcile Pending.
-			EventType: event.WaitType,
-			WaitEvent: &testutil.ExpWaitEvent{
-				GroupName:  "wait-3",
-				Status:     event.ReconcilePending,
-				Identifier: object.UnstructuredToObjMetadata(namespace2Obj),
-			},
-		},
-		{
 			// Namespace1 reconcile Pending.
 			EventType: event.WaitType,
 			WaitEvent: &testutil.ExpWaitEvent{
 				GroupName:  "wait-3",
 				Status:     event.ReconcilePending,
 				Identifier: object.UnstructuredToObjMetadata(namespace1Obj),
+			},
+		},
+		{
+			// Namespace2 reconcile Pending.
+			EventType: event.WaitType,
+			WaitEvent: &testutil.ExpWaitEvent{
+				GroupName:  "wait-3",
+				Status:     event.ReconcilePending,
+				Identifier: object.UnstructuredToObjMetadata(namespace2Obj),
 			},
 		},
 		{
@@ -723,7 +726,10 @@ func dependsOnTest(ctx context.Context, c client.Client, invConfig invconfig.Inv
 			},
 		},
 	}
-	Expect(testutil.EventsToExpEvents(destroyerEvents)).To(testutil.Equal(expEvents))
+	receivedEvents = testutil.EventsToExpEvents(destroyerEvents)
+	// sort to handle objects reconciling in random order
+	testutil.SortExpEvents(receivedEvents)
+	Expect(receivedEvents).To(testutil.Equal(expEvents))
 
 	By("verify pod1 deleted")
 	e2eutil.AssertUnstructuredDoesNotExist(ctx, c, pod1Obj)


### PR DESCRIPTION
Change the sorting algorithm to fix some flaky tests that became more frequent when client-side throttling was disabled.

With the current impl, only the WaitEvents have unpredictable ordering, reasoning is in comments in the sorting algorithm.