### PR TITLE
fix: Stop StatusWatcher on Forbidden API error

### DIFF
--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -121,6 +121,9 @@ func (tsr *TaskStatusRunner) Run(
 					statusEvent.Error)
 				if currentTask != nil {
 					currentTask.Cancel(taskContext)
+				} else {
+					// tasks not started yet - abort now
+					return complete(abortReason)
 				}
 				continue
 			}
@@ -207,6 +210,9 @@ func (tsr *TaskStatusRunner) Run(
 			klog.V(7).Infof("Runner aborting: %v", abortReason)
 			if currentTask != nil {
 				currentTask.Cancel(taskContext)
+			} else {
+				// tasks not started yet - abort now
+				return complete(abortReason)
 			}
 		}
 	}

--- a/pkg/kstatus/watcher/dynamic_informer_factory.go
+++ b/pkg/kstatus/watcher/dynamic_informer_factory.go
@@ -5,6 +5,8 @@ package watcher
 
 import (
 	"context"
+	"regexp"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -54,4 +56,37 @@ func (f *DynamicInformerFactory) NewInformer(ctx context.Context, mapping *meta.
 		f.ResyncPeriod,
 		f.Indexers,
 	)
+}
+
+// resourceNotFoundMessage is the condition message for metav1.StatusReasonNotFound.
+// This is necessary because the Informer doesn't properly wrap list errors.
+// https://github.com/kubernetes/client-go/blob/v0.24.0/tools/cache/reflector.go#L325
+// https://github.com/kubernetes/apimachinery/blob/v0.24.0/pkg/api/errors/errors.go#L448
+// TODO: Remove once fix is released (1.25+): https://github.com/kubernetes/kubernetes/pull/110076
+const resourceNotFoundMessage = "the server could not find the requested resource"
+
+// containsNotFoundMessage checks if the error string contains the message for
+// StatusReasonNotFound.
+func containsNotFoundMessage(err error) bool {
+	return strings.Contains(err.Error(), resourceNotFoundMessage)
+}
+
+// resourceForbiddenMessagePattern is a regex pattern to match the condition
+// message for metav1.StatusForbidden.
+// This is necessary because the Informer doesn't properly wrap list errors.
+// https://github.com/kubernetes/client-go/blob/v0.24.0/tools/cache/reflector.go#L325
+// https://github.com/kubernetes/apimachinery/blob/v0.24.0/pkg/api/errors/errors.go#L458
+// https://github.com/kubernetes/apimachinery/blob/v0.24.0/pkg/api/errors/errors.go#L208
+// https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/handlers/responsewriters/errors.go#L51
+// TODO: Remove once fix is released (1.25+): https://github.com/kubernetes/kubernetes/pull/110076
+const resourceForbiddenMessagePattern = `(.+) is forbidden: User "(.*)" cannot (.+) resource "(.*)" in API group "(.*)"`
+
+// resourceForbiddenMessageRegexp is the pre-compiled Regexp of
+// resourceForbiddenMessagePattern.
+var resourceForbiddenMessageRegexp = regexp.MustCompile(resourceForbiddenMessagePattern)
+
+// containsForbiddenMessage checks if the error string contains the message for
+// StatusForbidden.
+func containsForbiddenMessage(err error) bool {
+	return resourceForbiddenMessageRegexp.Match([]byte(err.Error()))
 }

--- a/pkg/kstatus/watcher/event_funnel.go
+++ b/pkg/kstatus/watcher/event_funnel.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 )
 
@@ -37,6 +38,7 @@ func newEventFunnel(ctx context.Context) *eventFunnel {
 	go func() {
 		defer func() {
 			// Don't close counterCh, otherwise AddInputChannel may panic.
+			klog.V(5).Info("Closing funnel")
 			close(funnel.outCh)
 			close(funnel.doneCh)
 		}()
@@ -48,6 +50,7 @@ func newEventFunnel(ctx context.Context) *eventFunnel {
 			select {
 			case delta := <-funnel.counterCh:
 				inputs += delta
+				klog.V(5).Infof("Funnel input channels (%+d): %d", delta, inputs)
 			case <-ctxDoneCh:
 				// Stop waiting for context closure.
 				// Nil channel avoids busy waiting.


### PR DESCRIPTION
- This matches previous StatusPoller behavior which would error
  and exit if there was a 403 Forbidden error from the apiserver.
- Handle status error before synchronization with immediate exit

Without this fix, the StatusWatcher gets stuck in an endless retry loop until cancelled or permission is granted, printing the following warning:

> W0516 21:03:57.305558   13045 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.0/tools/cache/reflector.go:167: failed to list /v1, Kind=ConfigMap: configmaps is forbidden: User "system:serviceaccount:default:user" cannot list resource "configmaps" in API group "" at the cluster scope 