### PR TITLE
chore: add stress test that validates retries

### DIFF
--- a/test/stress/stress_test.go
+++ b/test/stress/stress_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Stress", func() {
 		thousandDeploymentsTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 	})
 
+	It("ThousandDeploymentsRetry", func() {
+		thousandDeploymentsRetryTest(ctx, c, invConfig, inventoryName, namespace.GetName())
+	})
+
 	It("ThousandNamespaces", func() {
 		thousandNamespacesTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 	})

--- a/test/stress/thousand_namespaces_test.go
+++ b/test/stress/thousand_namespaces_test.go
@@ -41,17 +41,14 @@ func thousandNamespacesTest(ctx context.Context, c client.Client, invConfig invc
 
 	resources := []*unstructured.Unstructured{crdObj}
 
-	labelKey := "created-for"
-	labelValue := "stress-test"
-
 	namespaceObjTemplate := e2eutil.ManifestToUnstructured([]byte(namespaceYaml))
-	namespaceObjTemplate.SetLabels(map[string]string{labelKey: labelValue})
+	namespaceObjTemplate.SetLabels(map[string]string{e2eutil.TestIDLabel: inventoryID})
 
 	configMapObjTemplate := e2eutil.ManifestToUnstructured([]byte(configMapYaml))
-	configMapObjTemplate.SetLabels(map[string]string{labelKey: labelValue})
+	configMapObjTemplate.SetLabels(map[string]string{e2eutil.TestIDLabel: inventoryID})
 
 	cronTabObjTemplate := e2eutil.ManifestToUnstructured([]byte(cronTabYaml))
-	cronTabObjTemplate.SetLabels(map[string]string{labelKey: labelValue})
+	cronTabObjTemplate.SetLabels(map[string]string{e2eutil.TestIDLabel: inventoryID})
 
 	objectCount := 1000
 


### PR DESCRIPTION
- Duplicate the 1,000 Deployment test, but use a 1m reconcile timeout in
  a retry loop.
- This verifies that the applier and destroyer are re-entrant at scale.