### PR TITLE
fix: do not panic when the inventory object is missing

### DIFF
--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -64,6 +64,10 @@ func TestCommand(t *testing.T) {
 		expectedErrMsg string
 		expectedOutput string
 	}{
+		"no inventory template": {
+			input:          "",
+			expectedErrMsg: "Package uninitialized. Please run \"init\" command.",
+		},
 		"no inventory in live state": {
 			input:          inventoryTemplate,
 			expectedOutput: "no resources found in the inventory\n",

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -256,11 +256,11 @@ func TestSplitUnstructureds(t *testing.T) {
 		expectedObjs []*unstructured.Unstructured
 		isError      bool
 	}{
-		"No objects is returns nil and no objects": {
+		"No objects returns error": {
 			allObjs:      []*unstructured.Unstructured{},
 			expectedInv:  nil,
 			expectedObjs: []*unstructured.Unstructured{},
-			isError:      false,
+			isError:      true,
 		},
 		"Only inventory object returns inv and no objects": {
 			allObjs:      []*unstructured.Unstructured{inventoryObj},
@@ -268,17 +268,17 @@ func TestSplitUnstructureds(t *testing.T) {
 			expectedObjs: []*unstructured.Unstructured{},
 			isError:      false,
 		},
-		"Single object returns nil inventory and object": {
-			allObjs:      []*unstructured.Unstructured{pod1},
-			expectedInv:  nil,
+		"Inventory object with single object returns inventory and object": {
+			allObjs:      []*unstructured.Unstructured{inventoryObj, pod1},
+			expectedInv:  inventoryObj,
 			expectedObjs: []*unstructured.Unstructured{pod1},
 			isError:      false,
 		},
-		"Multiple non-inventory objects returns nil inventory and objs": {
+		"Multiple non-inventory objects returns error": {
 			allObjs:      []*unstructured.Unstructured{pod1, pod2, pod3},
 			expectedInv:  nil,
 			expectedObjs: []*unstructured.Unstructured{pod1, pod2, pod3},
-			isError:      false,
+			isError:      true,
 		},
 		"Inventory object with multiple others splits correctly": {
 			allObjs:      []*unstructured.Unstructured{pod1, pod2, inventoryObj, pod3},

--- a/pkg/inventory/storage.go
+++ b/pkg/inventory/storage.go
@@ -110,9 +110,8 @@ func ValidateNoInventory(objs object.UnstructuredSet) error {
 
 // splitUnstructureds takes a set of unstructured.Unstructured objects and
 // splits it into one set that contains the inventory object templates and
-// another one that contains the remaining resources. If there is no inventory
-// object the first return value is nil. Returns an error if there are
-// more than one inventory objects.
+// another one that contains the remaining resources. Returns an error if there
+// there is no inventory object or more than one inventory objects.
 func SplitUnstructureds(objs object.UnstructuredSet) (*unstructured.Unstructured, object.UnstructuredSet, error) {
 	invs := make(object.UnstructuredSet, 0)
 	resources := make(object.UnstructuredSet, 0)
@@ -125,12 +124,13 @@ func SplitUnstructureds(objs object.UnstructuredSet) (*unstructured.Unstructured
 	}
 	var inv *unstructured.Unstructured
 	var err error
-	if len(invs) == 1 {
+	switch len(invs) {
+	case 0:
+		err = &NoInventoryObjError{}
+	case 1:
 		inv = invs[0]
-	} else if len(invs) > 1 {
-		err = &MultipleInventoryObjError{
-			InventoryObjectTemplates: invs,
-		}
+	default:
+		err = &MultipleInventoryObjError{InventoryObjectTemplates: invs}
 	}
 	return inv, resources, err
 }


### PR DESCRIPTION
fixes https://github.com/kubernetes-sigs/cli-utils/issues/595

This patch adds back the user-friendly message when the inventory object is missing.

### Before
```console
$ kapply apply /foo/bar
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4354dc2]

goroutine 162 [running]:
k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.(*Unstructured).GetLabels(...)
```

### After
```console
$ kapply apply /foo/bar
Package uninitialized. Please run "init" command.
	
The package needs to be initialized to generate the template
which will store state for resource sets. This state is
necessary to perform functionality such as deleting an entire
package or automatically deleting omitted resources (pruning).
```