### PR TITLE
Change printing functions to support the status output for other inventory types

### DIFF
--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -99,8 +99,8 @@ func TestCommand(t *testing.T) {
 				},
 			},
 			expectedOutput: `
-deployment.apps/foo is InProgress: inProgress
-statefulset.apps/bar is Current: current
+foo/deployment.apps/default/foo is InProgress: inProgress
+foo/statefulset.apps/default/bar is Current: current
 `,
 		},
 		"wait for all current": {
@@ -146,10 +146,10 @@ statefulset.apps/bar is Current: current
 				},
 			},
 			expectedOutput: `
-deployment.apps/foo is InProgress: inProgress
-statefulset.apps/bar is InProgress: inProgress
-statefulset.apps/bar is Current: current
-deployment.apps/foo is Current: current
+foo/deployment.apps/default/foo is InProgress: inProgress
+foo/statefulset.apps/default/bar is InProgress: inProgress
+foo/statefulset.apps/default/bar is Current: current
+foo/deployment.apps/default/foo is Current: current
 `,
 		},
 		"wait for all deleted": {
@@ -179,8 +179,8 @@ deployment.apps/foo is Current: current
 				},
 			},
 			expectedOutput: `
-statefulset.apps/bar is NotFound: notFound
-deployment.apps/foo is NotFound: notFound
+foo/statefulset.apps/default/bar is NotFound: notFound
+foo/deployment.apps/default/foo is NotFound: notFound
 `,
 		},
 		"forever with timeout": {
@@ -211,8 +211,8 @@ deployment.apps/foo is NotFound: notFound
 				},
 			},
 			expectedOutput: `
-statefulset.apps/bar is InProgress: inProgress
-deployment.apps/foo is InProgress: inProgress
+foo/statefulset.apps/default/bar is InProgress: inProgress
+foo/deployment.apps/default/foo is InProgress: inProgress
 `,
 		},
 	}

--- a/cmd/status/printers/printer/printer.go
+++ b/cmd/status/printers/printer/printer.go
@@ -9,6 +9,13 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
 
+// PrintData records data required for printing
+type PrintData struct {
+	Identifiers object.ObjMetadataSet
+	InvNameMap  map[object.ObjMetadata]string
+	StatusSet   map[string]bool
+}
+
 // Printer defines an interface for outputting information about status of
 // resources. Different implementations allow output formats tailored to
 // different use cases.

--- a/cmd/status/printers/printers.go
+++ b/cmd/status/printers/printers.go
@@ -4,20 +4,19 @@
 package printers
 
 import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/cmd/status/printers/event"
 	"sigs.k8s.io/cli-utils/cmd/status/printers/printer"
 	"sigs.k8s.io/cli-utils/cmd/status/printers/table"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // CreatePrinter return an implementation of the Printer interface. The
 // actual implementation is based on the printerType requested.
-func CreatePrinter(printerType string, ioStreams genericclioptions.IOStreams) (printer.Printer, error) {
+func CreatePrinter(printerType string, ioStreams genericclioptions.IOStreams, printData *printer.PrintData) (printer.Printer, error) {
 	switch printerType {
 	case "table":
 		return table.NewPrinter(ioStreams), nil
 	default:
-		return event.NewPrinter(ioStreams), nil
+		return event.NewPrinter(ioStreams, printData), nil
 	}
 }


### PR DESCRIPTION
This change is to make the status command work for other inventory types.
The change includes adding a status filter option and inventory name for event format status printer, and since the output structure will be changed for this update, the test cases are also modified to fit the new expected structure.