### PR TITLE
Support the status output in table format for other inventory types

### DIFF
--- a/cmd/status/printers/printers.go
+++ b/cmd/status/printers/printers.go
@@ -15,7 +15,7 @@ import (
 func CreatePrinter(printerType string, ioStreams genericclioptions.IOStreams, printData *printer.PrintData) (printer.Printer, error) {
 	switch printerType {
 	case "table":
-		return table.NewPrinter(ioStreams), nil
+		return table.NewPrinter(ioStreams, printData), nil
 	default:
 		return event.NewPrinter(ioStreams, printData), nil
 	}


### PR DESCRIPTION
This change is to make the status command work for other inventory types.
Add a new column in the table output format representing the inventory name.
