### PR TITLE
add Loader interface for easier customized implementation

### DIFF
--- a/cmd/status/cmdstatus_test.go
+++ b/cmd/status/cmdstatus_test.go
@@ -499,7 +499,7 @@ foo/deployment.apps/default/foo is InProgress: inProgress
 			runner := &Runner{
 				factory:    tf,
 				invFactory: inventory.FakeClientFactory(tc.inventory),
-				loader:     loader,
+				loader:     NewInventoryLoader(loader),
 				pollerFactoryFunc: func(c cmdutil.Factory) (poller.Poller, error) {
 					return &fakePoller{tc.events}, nil
 				},
@@ -541,7 +541,7 @@ foo/deployment.apps/default/foo is InProgress: inProgress
 			runner := &Runner{
 				factory:    tf,
 				invFactory: inventory.FakeClientFactory(tc.inventory),
-				loader:     loader,
+				loader:     NewInventoryLoader(loader),
 				pollerFactoryFunc: func(c cmdutil.Factory) (poller.Poller, error) {
 					return &fakePoller{tc.events}, nil
 				},


### PR DESCRIPTION
This change exposes an interface for loading the manifest, allowing easier development for customized implementations on the function for reading manifest and parsing it to inventory info.