### PR TITLE
chore: Bump golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -31,14 +30,12 @@ linters:
     - misspell
     - nakedret
     - staticcheck
-    - structcheck
     - stylecheck
     - revive
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: generate license fix vet fmt test lint tidy
 	go install github.com/google/addlicense@v1.0.0
 
 "$(MYGOBIN)/golangci-lint":
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
 
 "$(MYGOBIN)/deepcopy-gen":
 	go install k8s.io/code-generator/cmd/deepcopy-gen@v0.23.6

--- a/cmd/diff/cmddiff.go
+++ b/cmd/diff/cmddiff.go
@@ -4,7 +4,6 @@
 package diff
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -104,7 +103,7 @@ func Initialize(o *diff.DiffOptions, f util.Factory, args []string) (func(), err
 func createTempDir() (string, error) {
 	// Create a temporary file with the passed prefix in
 	// the default temporary directory.
-	tmpDir, err := ioutil.TempDir("", tmpDirPrefix)
+	tmpDir, err := os.MkdirTemp("", tmpDirPrefix)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"testing"
@@ -240,20 +240,20 @@ func (g *genericHandler) handle(t *testing.T, req *http.Request) (*http.Response
 
 		if req.URL.Path == singlePath && req.Method == http.MethodGet {
 			if r.exists {
-				bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
+				bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 			}
 			return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")}, true, nil
 		}
 
 		if req.URL.Path == singlePath && req.Method == http.MethodPatch {
-			bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
+			bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
 			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 		}
 
 		if req.URL.Path == singlePath && req.Method == http.MethodDelete {
 			if r.exists {
-				bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
+				bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 			}
 
@@ -271,12 +271,12 @@ func (g *genericHandler) handle(t *testing.T, req *http.Request) (*http.Response
 					Kind: r.resource.GetKind(),
 				},
 			}
-			bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, result)))
+			bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, result)))
 			return &http.Response{StatusCode: status, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 		}
 
 		if req.URL.Path == allPath && req.Method == http.MethodPost {
-			bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
+			bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, r.resource)))
 			return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 		}
 	}
@@ -341,7 +341,7 @@ func (n *nsHandler) handle(t *testing.T, req *http.Request) (*http.Response, boo
 				Name: nsName,
 			},
 		}
-		bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(t, &ns)))
+		bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(t, &ns)))
 		return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, true, nil
 	}
 	return nil, false, nil

--- a/pkg/apply/event/event.go
+++ b/pkg/apply/event/event.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Type determines the type of events that are available.
+//
 //go:generate stringer -type=Type
 type Type int
 

--- a/pkg/apply/prune/event-factory.go
+++ b/pkg/apply/prune/event-factory.go
@@ -33,6 +33,7 @@ func CreateEventFactory(isDelete bool, groupName string) EventFactory {
 
 // PruneEventFactory implements EventFactory interface as a concrete
 // representation of for prune events.
+//
 //nolint:revive // stuttering ok because Prune is a type of PruneEvent
 type PruneEventFactory struct {
 	groupName string

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -80,11 +80,12 @@ type Options struct {
 // automatically prune/delete).
 //
 // Parameters:
-//   objs - objects to prune (delete)
-//   pruneFilters - list of filters for deletion permission
-//   taskContext - task for apply/prune
-//   taskName - name of the parent task group, for events
-//   opts - options for dry-run
+//
+//	objs - objects to prune (delete)
+//	pruneFilters - list of filters for deletion permission
+//	taskContext - task for apply/prune
+//	taskName - name of the parent task group, for events
+//	opts - options for dry-run
 func (p *Pruner) Prune(
 	objs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter,

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -192,8 +192,8 @@ func newApplyOptions(taskName string, eventChannel chan<- event.Event, serverSid
 		OpenAPIPatch:      true, // Normally set in apply.NewApplyOptions
 		Recorder:          genericclioptions.NoopRecorder{},
 		IOStreams: genericclioptions.IOStreams{
-			Out:    ioutil.Discard,
-			ErrOut: ioutil.Discard, // TODO: Warning for no lastConfigurationAnnotation
+			Out:    io.Discard,
+			ErrOut: io.Discard, // TODO: Warning for no lastConfigurationAnnotation
 			// is printed directly to stderr in ApplyOptions. We
 			// should turn that into a warning on the event channel.
 		},

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -42,11 +42,11 @@ type Options struct {
 //
 // The tasks run in a loop where a single goroutine will process events from
 // three different channels.
-// - taskQueue is read to allow updating the task queue at runtime.
-// - statusChannel is read to allow updates to the resource cache and triggering
-//   validation of wait conditions.
-// - eventChannel is written to with events based on status updates, if
-//   emitStatusEvents is true.
+//   - taskQueue is read to allow updating the task queue at runtime.
+//   - statusChannel is read to allow updates to the resource cache and triggering
+//     validation of wait conditions.
+//   - eventChannel is written to with events based on status updates, if
+//     emitStatusEvents is true.
 func (tsr *TaskStatusRunner) Run(
 	ctx context.Context,
 	taskContext *TaskContext,

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -90,6 +90,7 @@ const (
 )
 
 // ClientDryRun returns true if input drs is DryRunClient
+//
 //nolint:stylecheck  // Prevent lint errors on receiver names caused by string generation above
 func (drs DryRunStrategy) ClientDryRun() bool {
 	return drs == DryRunClient

--- a/pkg/common/path.go
+++ b/pkg/common/path.go
@@ -6,7 +6,6 @@ package common
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -94,11 +93,11 @@ func ExpandPackageDir(f genericclioptions.FileNameFlags) (genericclioptions.File
 // an error if one occurs.
 func FilterInputFile(in io.Reader, tmpDir string) error {
 	// Copy the config from "in" into a local temp file.
-	dir, err := ioutil.TempDir("", tmpDirPrefix)
+	dir, err := os.MkdirTemp("", tmpDirPrefix)
 	if err != nil {
 		return err
 	}
-	tmpFile, err := ioutil.TempFile(dir, fileRegexp)
+	tmpFile, err := os.CreateTemp(dir, fileRegexp)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/path_test.go
+++ b/pkg/common/path_test.go
@@ -5,7 +5,6 @@ package common
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -201,7 +200,7 @@ func TestFilterInputFile(t *testing.T) {
 				t.Fatalf("Unexpected error in FilterInputFile: %s", err)
 			}
 			// Retrieve the files from the test filesystem.
-			actualFiles, err := ioutil.ReadDir(tf.GetRootDir())
+			actualFiles, err := os.ReadDir(tf.GetRootDir())
 			if err != nil {
 				t.Fatalf("Error reading test filesystem directory: %s", err)
 			}
@@ -215,7 +214,7 @@ func TestFilterInputFile(t *testing.T) {
 			if len(actualFiles) != 0 {
 				actualFilename := (actualFiles[0]).Name()
 				defer os.Remove(actualFilename)
-				actual, err := ioutil.ReadFile(actualFilename)
+				actual, err := os.ReadFile(actualFilename)
 				if err != nil {
 					t.Fatalf("Error reading created file (%s): %s", actualFilename, err)
 				}

--- a/pkg/config/initoptions.go
+++ b/pkg/config/initoptions.go
@@ -122,7 +122,6 @@ func FindNamespace(loader namespaceLoader, dir string) (string, error) {
 // passed directory or an error. This function cleans up paths
 // such as current directory (.), relative directories (..), or
 // multiple separators.
-//
 func NormalizeDir(dirPath string) (string, error) {
 	if !common.IsDir(dirPath) {
 		return "", fmt.Errorf("invalid directory argument: %s", dirPath)

--- a/pkg/config/initoptions_test.go
+++ b/pkg/config/initoptions_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -19,7 +18,7 @@ import (
 
 // writeFile writes a file under the test directory
 func writeFile(t *testing.T, path string, value []byte) {
-	err := ioutil.WriteFile(path, value, 0600)
+	err := os.WriteFile(path, value, 0600)
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())
 	}
@@ -153,7 +152,7 @@ func TestComplete(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var err error
-			dir, err := ioutil.TempDir("", "test-dir")
+			dir, err := os.MkdirTemp("", "test-dir")
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, err.Error())
 			}
@@ -222,7 +221,7 @@ func TestFindNamespace(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			var err error
-			dir, err := ioutil.TempDir("", "test-dir")
+			dir, err := os.MkdirTemp("", "test-dir")
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, err.Error())
 			}

--- a/pkg/flowcontrol/flowcontrol_test.go
+++ b/pkg/flowcontrol/flowcontrol_test.go
@@ -6,7 +6,6 @@ package flowcontrol
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +36,7 @@ func TestIsEnabled(t *testing.T) {
 				return &http.Response{
 					StatusCode: 200,
 					Header:     headers,
-					Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+					Body:       io.NopCloser(bytes.NewReader(nil)),
 				}
 			},
 			expectedEnabled: true,
@@ -49,7 +48,7 @@ func TestIsEnabled(t *testing.T) {
 				return &http.Response{
 					StatusCode: 200,
 					Header:     http.Header{},
-					Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+					Body:       io.NopCloser(bytes.NewReader(nil)),
 				}
 			},
 			expectedEnabled: false,

--- a/pkg/inventory/configmap/cm-template.go
+++ b/pkg/inventory/configmap/cm-template.go
@@ -6,11 +6,10 @@ package configmap
 // Template for ConfigMap inventory object. The following fields
 // must be filled in for this to be valid:
 //
-//  <DATETIME>: The time this is auto-generated
-//  <NAMESPACE>: The namespace to place this inventory object
-//  <RANDOMSUFFIX>: The random suffix added to the end of the name
-//  <INVENTORYID>: The label value to retrieve this inventory object
-//
+//	<DATETIME>: The time this is auto-generated
+//	<NAMESPACE>: The namespace to place this inventory object
+//	<RANDOMSUFFIX>: The random suffix added to the end of the name
+//	<INVENTORYID>: The label value to retrieve this inventory object
 const ConfigMapTemplate = `# NOTE: auto-generated. Some fields should NOT be modified.
 # Date: <DATETIME>
 #

--- a/pkg/inventory/fake-builder.go
+++ b/pkg/inventory/fake-builder.go
@@ -5,7 +5,7 @@ package inventory
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 
@@ -65,7 +65,7 @@ func fakeClient(objs object.ObjMetadataSet) resource.FakeClientFunc {
 			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				if req.Method == "POST" && cmPathRegex.Match([]byte(req.URL.Path)) {
-					b, err := ioutil.ReadAll(req.Body)
+					b, err := io.ReadAll(req.Body)
 					if err != nil {
 						return nil, err
 					}
@@ -74,7 +74,7 @@ func fakeClient(objs object.ObjMetadataSet) resource.FakeClientFunc {
 					if err != nil {
 						return nil, err
 					}
-					bodyRC := ioutil.NopCloser(bytes.NewReader(b))
+					bodyRC := io.NopCloser(bytes.NewReader(b))
 					return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
 				}
 				if req.Method == "GET" && cmPathRegex.Match([]byte(req.URL.Path)) {
@@ -97,7 +97,7 @@ func fakeClient(objs object.ObjMetadataSet) resource.FakeClientFunc {
 						Data: objs.ToStringMap(),
 					}
 					cmList.Items = append(cmList.Items, cm)
-					bodyRC := ioutil.NopCloser(bytes.NewReader(toJSONBytes(&cmList)))
+					bodyRC := io.NopCloser(bytes.NewReader(toJSONBytes(&cmList)))
 					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyRC}, nil
 				}
 				return nil, nil

--- a/pkg/inventory/policy.go
+++ b/pkg/inventory/policy.go
@@ -17,6 +17,7 @@ import (
 // can go through for a resource based on the comparison
 // the inventory-id value in the package and the owning-inventory
 // annotation in the live object.
+//
 //go:generate stringer -type=Policy -linecomment
 type Policy int
 
@@ -72,6 +73,7 @@ const OwningInventoryKey = "config.k8s.io/owning-inventory"
 
 // IDMatchStatus represents the result of comparing the
 // id from current inventory info and the inventory-id from a live object.
+//
 //go:generate stringer -type=IDMatchStatus
 type IDMatchStatus int
 

--- a/pkg/inventory/status-policy.go
+++ b/pkg/inventory/status-policy.go
@@ -6,6 +6,7 @@ package inventory
 // StatusPolicy specifies whether the inventory client should apply status to
 // the inventory object. The status contains the actuation and reconcile stauts
 // of each object in the inventory.
+//
 //go:generate stringer -type=StatusPolicy -linecomment
 type StatusPolicy int
 

--- a/pkg/kstatus/polling/aggregator/aggregator.go
+++ b/pkg/kstatus/polling/aggregator/aggregator.go
@@ -10,14 +10,14 @@ import (
 
 // AggregateStatus computes the aggregate status for all the resources.
 // The rules are the following:
-// - If any of the resources has the FailedStatus, the aggregate status is also
-//   FailedStatus
-// - If none of the resources have the FailedStatus and at least one is
-//   UnknownStatus, the aggregate status is UnknownStatus
-// - If all the resources have the desired status, the aggregate status is the
-//   desired status.
-// - If none of the first three rules apply, the aggregate status is
-//   InProgressStatus
+//   - If any of the resources has the FailedStatus, the aggregate status is also
+//     FailedStatus
+//   - If none of the resources have the FailedStatus and at least one is
+//     UnknownStatus, the aggregate status is UnknownStatus
+//   - If all the resources have the desired status, the aggregate status is the
+//     desired status.
+//   - If none of the first three rules apply, the aggregate status is
+//     InProgressStatus
 func AggregateStatus(rss []*event.ResourceStatus, desired status.Status) status.Status {
 	if len(rss) == 0 {
 		return desired

--- a/pkg/kstatus/polling/doc.go
+++ b/pkg/kstatus/polling/doc.go
@@ -12,30 +12,29 @@
 // are several interfaces that can be implemented to support custom
 // behavior.
 //
-//
-// Polling Resources
+// # Polling Resources
 //
 // In order to poll a set of resources, create a StatusPoller
 // and pass in the list of ResourceIdentifiers to the Poll function.
 //
-//   import (
-//     "sigs.k8s.io/cli-utils/pkg/kstatus/polling"
-//   )
+//	import (
+//	  "sigs.k8s.io/cli-utils/pkg/kstatus/polling"
+//	)
 //
-//   identifiers := []prune.ObjMetadata{
-//     {
-//       GroupKind: schema.GroupKind{
-//         Group: "apps",
-//         Kind: "Deployment",
-//       },
-//       Name: "dep",
-//       Namespace: "default",
-//     }
-//   }
+//	identifiers := []prune.ObjMetadata{
+//	  {
+//	    GroupKind: schema.GroupKind{
+//	      Group: "apps",
+//	      Kind: "Deployment",
+//	    },
+//	    Name: "dep",
+//	    Namespace: "default",
+//	  }
+//	}
 //
-//   poller := polling.NewStatusPoller(reader, mapper, true)
-//   eventsChan := poller.Poll(context.Background(), identifiers, polling.PollOptions{})
-//   for e := range eventsChan {
-//      // Handle event
-//   }
+//	poller := polling.NewStatusPoller(reader, mapper, true)
+//	eventsChan := poller.Poll(context.Background(), identifiers, polling.PollOptions{})
+//	for e := range eventsChan {
+//	   // Handle event
+//	}
 package polling

--- a/pkg/kstatus/status/doc.go
+++ b/pkg/kstatus/status/doc.go
@@ -5,25 +5,26 @@
 // of Kubernetes resources.
 //
 // The statuses defined in this package are:
-//  * InProgress
-//  * Current
-//  * Failed
-//  * Terminating
-//  * NotFound
-//  * Unknown
+//   - InProgress
+//   - Current
+//   - Failed
+//   - Terminating
+//   - NotFound
+//   - Unknown
 //
 // Computing the status of a resources can be done by calling the
 // Compute function in the status package.
 //
-//   import (
-//     "sigs.k8s.io/cli-utils/pkg/kstatus/status"
-//   )
+//	import (
+//	  "sigs.k8s.io/cli-utils/pkg/kstatus/status"
+//	)
 //
-//   res, err := status.Compute(resource)
+//	res, err := status.Compute(resource)
 //
 // The package also defines a set of new conditions:
-//  * InProgress
-//  * Failed
+//   - InProgress
+//   - Failed
+//
 // These conditions have been chosen to follow the
 // "abnormal-true" pattern where conditions should be set to true
 // for error/abnormal conditions and the absence of a condition means
@@ -34,9 +35,9 @@
 // these conditions are decided based on other status information
 // available in the resources.
 //
-//   import (
-//     "sigs.k8s.io/cli-utils/pkg/kstatus/status
-//   )
+//	import (
+//	  "sigs.k8s.io/cli-utils/pkg/kstatus/status
+//	)
 //
-//   err := status.Augment(resource)
+//	err := status.Augment(resource)
 package status

--- a/pkg/kstatus/status/status.go
+++ b/pkg/kstatus/status/status.go
@@ -91,10 +91,11 @@ type Condition struct {
 //
 // The returned result contains the status of the resource, which will be
 // one of
-//  * InProgress
-//  * Current
-//  * Failed
-//  * Terminating
+//   - InProgress
+//   - Current
+//   - Failed
+//   - Terminating
+//
 // It also contains a message that provides more information on why
 // the resource has the given status. Finally, the result also contains
 // a list of standard resources that would belong on the given resource.

--- a/pkg/kstatus/watcher/doc.go
+++ b/pkg/kstatus/watcher/doc.go
@@ -6,34 +6,34 @@
 // until it is cancelled through the provided context. Updates on the status of
 // objects are streamed back to the caller through a channel.
 //
-// Watching Resources
+// # Watching Resources
 //
 // In order to watch a set of resources objects, create a StatusWatcher
 // and pass in the list of object identifiers to the Watch function.
 //
-//   import (
-//     "sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
-//   )
+//	import (
+//	  "sigs.k8s.io/cli-utils/pkg/kstatus/watcher"
+//	)
 //
-//   ids := []prune.ObjMetadata{
-//     {
-//       GroupKind: schema.GroupKind{
-//         Group: "apps",
-//         Kind: "Deployment",
-//       },
-//       Name: "dep",
-//       Namespace: "default",
-//     }
-//   }
+//	ids := []prune.ObjMetadata{
+//	  {
+//	    GroupKind: schema.GroupKind{
+//	      Group: "apps",
+//	      Kind: "Deployment",
+//	    },
+//	    Name: "dep",
+//	    Namespace: "default",
+//	  }
+//	}
 //
-//   statusWatcher := watcher.NewDefaultStatusWatcher(dynamicClient, mapper)
-//   ctx, cancelFunc := context.WithCancel(context.Background())
-//   eventCh := statusWatcher.Watch(ctx, ids, watcher.Options{})
-//   for e := range eventCh {
-//      // Handle event
-//      if e.Type == event.ErrorEvent {
-//        cancelFunc()
-//        return e.Err
-//      }
-//   }
+//	statusWatcher := watcher.NewDefaultStatusWatcher(dynamicClient, mapper)
+//	ctx, cancelFunc := context.WithCancel(context.Background())
+//	eventCh := statusWatcher.Watch(ctx, ids, watcher.Options{})
+//	for e := range eventCh {
+//	   // Handle event
+//	   if e.Type == event.ErrorEvent {
+//	     cancelFunc()
+//	     return e.Err
+//	   }
+//	}
 package watcher

--- a/pkg/kstatus/watcher/object_status_reporter.go
+++ b/pkg/kstatus/watcher/object_status_reporter.go
@@ -48,18 +48,18 @@ func (gkn GroupKindNamespace) GroupKind() schema.GroupKind {
 // network of informers to watch one or more resources (types).
 //
 // Unlike SharedIndexInformer, ObjectStatusReporter...
-// - Reports object status.
-// - Can watch multiple resource types simultaneously.
-// - Specific objects can be ignored for efficiency by specifying an ObjectFilter.
-// - Resolves GroupKinds into Resources at runtime, to pick up newly added
-//   resources.
-// - Starts and Stops individual watches automaically to reduce errors when a
-//   CRD or Namespace is deleted.
-// - Resources can be watched in root-scope mode or namespace-scope mode,
-//   allowing the caller to optimize for efficiency or least-privilege.
-// - Gives unschedulable Pods (and objects that generate them) a 15s grace
-//   period before reporting them as Failed.
-// - Resets the RESTMapper cache automatically when CRDs are modified.
+//   - Reports object status.
+//   - Can watch multiple resource types simultaneously.
+//   - Specific objects can be ignored for efficiency by specifying an ObjectFilter.
+//   - Resolves GroupKinds into Resources at runtime, to pick up newly added
+//     resources.
+//   - Starts and Stops individual watches automaically to reduce errors when a
+//     CRD or Namespace is deleted.
+//   - Resources can be watched in root-scope mode or namespace-scope mode,
+//     allowing the caller to optimize for efficiency or least-privilege.
+//   - Gives unschedulable Pods (and objects that generate them) a 15s grace
+//     period before reporting them as Failed.
+//   - Resets the RESTMapper cache automatically when CRDs are modified.
 //
 // ObjectStatusReporter is NOT repeatable. It will panic if started more than
 // once. If you need a repeatable factory, use DefaultStatusWatcher.

--- a/pkg/manifestreader/manifestloader_test.go
+++ b/pkg/manifestreader/manifestloader_test.go
@@ -4,7 +4,7 @@
 package manifestreader
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,10 +50,10 @@ func TestMReader_Read(t *testing.T) {
 				t.FailNow()
 			}
 
-			dir, err := ioutil.TempDir("", "reader-test")
+			dir, err := os.MkdirTemp("", "reader-test")
 			assert.NoError(t, err)
 			p := filepath.Join(dir, "dep.yaml")
-			err = ioutil.WriteFile(p, []byte(depManifest), 0600)
+			err = os.WriteFile(p, []byte(depManifest), 0600)
 			assert.NoError(t, err)
 			stringReader := strings.NewReader(depManifest)
 

--- a/pkg/manifestreader/path_test.go
+++ b/pkg/manifestreader/path_test.go
@@ -4,7 +4,7 @@
 package manifestreader
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -56,11 +56,11 @@ func TestPathManifestReader_Read(t *testing.T) {
 				t.FailNow()
 			}
 
-			dir, err := ioutil.TempDir("", "path-reader-test")
+			dir, err := os.MkdirTemp("", "path-reader-test")
 			assert.NoError(t, err)
 			for filename, content := range tc.manifests {
 				p := filepath.Join(dir, filename)
-				err := ioutil.WriteFile(p, []byte(content), 0600)
+				err := os.WriteFile(p, []byte(content), 0600)
 				assert.NoError(t, err)
 			}
 

--- a/pkg/object/dependson/strings.go
+++ b/pkg/object/dependson/strings.go
@@ -72,8 +72,9 @@ func ParseDependencySet(depsStr string) (DependencySet, error) {
 // Fields are separated by '/'.
 //
 // Examples:
-//   Cluster-Scoped: <group>/<kind>/<name> (3 fields)
-//   Namespaced: <group>/namespaces/<namespace>/<kind>/<name> (5 fields)
+//
+//	Cluster-Scoped: <group>/<kind>/<name> (3 fields)
+//	Namespaced: <group>/namespaces/<namespace>/<kind>/<name> (5 fields)
 //
 // Group and namespace may be empty, but name and kind may not.
 //
@@ -101,8 +102,9 @@ func FormatObjMetadata(obj object.ObjMetadata) (string, error) {
 // Fields are separated by '/'.
 //
 // Examples:
-//   Cluster-Scoped: <group>/<kind>/<name> (3 fields)
-//   Namespaced: <group>/namespaces/<namespace>/<kind>/<name> (5 fields)
+//
+//	Cluster-Scoped: <group>/<kind>/<name> (3 fields)
+//	Namespaced: <group>/namespaces/<namespace>/<kind>/<name> (5 fields)
 //
 // Group and namespace may be empty, but name and kind may not.
 //

--- a/pkg/object/graph/graph_test.go
+++ b/pkg/object/graph/graph_test.go
@@ -24,14 +24,14 @@ var (
 )
 
 var (
-	e1 Edge = Edge{From: o1, To: o2}
-	e2 Edge = Edge{From: o2, To: o3}
-	e3 Edge = Edge{From: o1, To: o3}
-	e4 Edge = Edge{From: o3, To: o4}
-	e5 Edge = Edge{From: o2, To: o4}
-	e6 Edge = Edge{From: o2, To: o1}
-	e7 Edge = Edge{From: o3, To: o1}
-	e8 Edge = Edge{From: o4, To: o5}
+	e1 = Edge{From: o1, To: o2}
+	e2 = Edge{From: o2, To: o3}
+	e3 = Edge{From: o1, To: o3}
+	e4 = Edge{From: o3, To: o4}
+	e5 = Edge{From: o2, To: o4}
+	e6 = Edge{From: o2, To: o1}
+	e7 = Edge{From: o3, To: o1}
+	e8 = Edge{From: o4, To: o5}
 )
 
 func TestObjectGraphSort(t *testing.T) {

--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -61,7 +61,7 @@ type ObjMetadata struct {
 // and returns an ObjMetadata struct storing the four fields.
 // Example inventory string:
 //
-//   test-namespace_test-name_apps_ReplicaSet
+//	test-namespace_test-name_apps_ReplicaSet
 //
 // Returns an error if unable to parse and create the ObjMetadata struct.
 //

--- a/pkg/print/list/base.go
+++ b/pkg/print/list/base.go
@@ -54,6 +54,7 @@ func (sc *StatusCollector) LatestStatus() map[object.ObjMetadata]event.StatusEve
 // format on StdOut. As we support other printer implementations
 // this should probably be an interface.
 // This function will block until the channel is closed.
+//
 //nolint:gocyclo
 func (b *BaseListPrinter) Print(ch <-chan event.Event, previewStrategy common.DryRunStrategy, printStatus bool) error {
 	var actionGroups []event.ActionGroup

--- a/pkg/printers/json/doc.go
+++ b/pkg/printers/json/doc.go
@@ -6,18 +6,18 @@
 // appear as a stream of json objects, each representing a single event.
 //
 // Every event will contain the following properties:
-//  * timestamp: RFC3339-formatted timestamp describing when the event happened.
-//  * type: Describes the type of the operation which the event is related to.
-//    Type values include:
-//    * validation - ValidationEvent
-//    * error - ErrorEvent
-//    * group - ActionGroupEvent
-//    * apply - ApplyEvent
-//    * prune - PruneEvent
-//    * delete - DeleteEvent
-//    * wait - WaitEvent
-//    * status - StatusEvent
-//    * summary - aggregate stats collected by the printer
+//   - timestamp: RFC3339-formatted timestamp describing when the event happened.
+//   - type: Describes the type of the operation which the event is related to.
+//     Type values include:
+//   - validation - ValidationEvent
+//   - error - ErrorEvent
+//   - group - ActionGroupEvent
+//   - apply - ApplyEvent
+//   - prune - PruneEvent
+//   - delete - DeleteEvent
+//   - wait - WaitEvent
+//   - status - StatusEvent
+//   - summary - aggregate stats collected by the printer
 //
 // Validation events correspond to zero or more objects. For these events, the
 // objects field includes a list of object identifiers. These generally fire
@@ -25,10 +25,11 @@
 //
 // Validation events have the following fields:
 // * objects (array of objects) - a list of object identifiers
-//   * group (string, optional) - The object's API group.
-//   * kind (string) - The object's kind.
-//   * name (string) - The object's name.
-//   * namespace (string, optional) - The object's namespace.
+//   - group (string, optional) - The object's API group.
+//   - kind (string) - The object's kind.
+//   - name (string) - The object's name.
+//   - namespace (string, optional) - The object's namespace.
+//
 // * timestamp (string) - ISO-8601 format
 // * type (string) - "validation"
 // * error (string) - a fatal error message specific to these objects
@@ -55,29 +56,29 @@
 // group, kind, name, and namespace fields identify the object.
 //
 // Operation events have the following fields:
-// * group (string, optional) - The object's API group.
-// * kind (string) - The object's kind.
-// * name (string) - The object's name.
-// * namespace (string, optional) - The object's namespace.
-// * status (string) - One of: "Pending", "Successful", "Skipped", "Failed", or
-//                     "Timeout".
-// * timestamp (string) - ISO-8601 format
-// * type (string) - "apply", "prune", "delete", or "wait"
-// * error (string, optional) - A non-fatal error message specific to this object
+//   - group (string, optional) - The object's API group.
+//   - kind (string) - The object's kind.
+//   - name (string) - The object's name.
+//   - namespace (string, optional) - The object's namespace.
+//   - status (string) - One of: "Pending", "Successful", "Skipped", "Failed", or
+//     "Timeout".
+//   - timestamp (string) - ISO-8601 format
+//   - type (string) - "apply", "prune", "delete", or "wait"
+//   - error (string, optional) - A non-fatal error message specific to this object
 //
 // Status types are asynchronous events that correspond to status updates for
 // a specific object.
 //
 // Status events have the following fields:
-// * group (string, optional) - The object's API group.
-// * kind (string) - The object's kind.
-// * name (string) - The object's name.
-// * namespace (string, optional) - The object's namespace.
-// * status (string) - One of: "InProgress", "Failed", "Current", "Terminating",
-//                     "NotFound", or "Unknown".
-// * message (string) - Human readable description of the status.
-// * timestamp (string) - ISO-8601 format
-// * type (string) - "status"
+//   - group (string, optional) - The object's API group.
+//   - kind (string) - The object's kind.
+//   - name (string) - The object's name.
+//   - namespace (string, optional) - The object's namespace.
+//   - status (string) - One of: "InProgress", "Failed", "Current", "Terminating",
+//     "NotFound", or "Unknown".
+//   - message (string) - Human readable description of the status.
+//   - timestamp (string) - ISO-8601 format
+//   - type (string) - "status"
 //
 // Summary types are a meta-event sent by the printer to summarize some stats
 // that have been collected from other events. For these events, the action
@@ -93,5 +94,4 @@
 // * timeout (number, optional) - Number of objects for which the action timed out.
 // * timestamp (string) - ISO-8601 format
 // * type (string) - "summary"
-//
 package json

--- a/pkg/printers/table/printer.go
+++ b/pkg/printers/table/printer.go
@@ -72,7 +72,7 @@ func (t *Printer) Print(ch <-chan event.Event, _ common.DryRunStrategy, _ bool) 
 }
 
 // columns defines the columns we want to print
-//TODO: We should have the number of columns and their widths be
+// TODO: We should have the number of columns and their widths be
 // dependent on the space available.
 var (
 	actionColumnDef = table.ColumnDef{

--- a/pkg/testutil/test-filesystem.go
+++ b/pkg/testutil/test-filesystem.go
@@ -4,7 +4,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ type TestFilesystem struct {
 // the TestFilesystem.
 func Setup(t *testing.T, dirs ...string) TestFilesystem {
 	tempDir := "" // Use the default temp directory
-	d, err := ioutil.TempDir(tempDir, "test-filesystem")
+	d, err := os.MkdirTemp(tempDir, "test-filesystem")
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())
 	}
@@ -52,7 +51,7 @@ func (tf TestFilesystem) WriteFile(t *testing.T, path string, value []byte) {
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())
 	}
-	err = ioutil.WriteFile(filepath.Join(tf.root, path), value, 0600)
+	err = os.WriteFile(filepath.Join(tf.root, path), value, 0600)
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, err.Error())
 	}


### PR DESCRIPTION
This commit bumps golangci-lint to v1.50.0 as the older version has memory issues that causes presubmits to time out.