### PR TITLE
Add release for kapply binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,9 @@ jobs:
           go-version-file: 'go.mod'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist -f release/goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/release/goreleaser.yml
+++ b/release/goreleaser.yml
@@ -1,8 +1,24 @@
 # Copyright 2020 The Kubernetes Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+archives:
+- name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
 builds:
-- skip: true
+- skip: false
+  main: ./cmd
+  id: "kapply"
+  binary: kapply
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/release/goreleaser.yml
+++ b/release/goreleaser.yml
@@ -3,6 +3,7 @@
 
 archives:
 - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  wrap_in_directory: true
 
 builds:
 - skip: false


### PR DESCRIPTION
Could you consider adding a release for the `kapply` binary?

I know that this binary is experimental and is currently only used for testing.
However, I think this binary can inform users about the overview of this library and how it works.