### PR TITLE
fix: objects flagged by CurrentUIDFilter should be removed from the inventory

### DIFF
--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -156,6 +156,7 @@ func (p *Pruner) Prune(
 				// Remove the object from inventory if it was determined that the object should not be pruned,
 				// because it had recently been applied. This probably means that the object is in the inventory
 				// more than one time with a different group (e.g. kind Ingress and apiGroups networking.k8s.io & extensions)
+				// due to being cohabitated: https://github.com/kubernetes/kubernetes/blob/v1.25.0/pkg/kubeapiserver/default_storage_factory_builder.go#L124-L131
 				var deleteAfterApplyErr *filter.ApplyPreventedDeletionError
 				if errors.As(filterErr, &deleteAfterApplyErr) {
 					if !opts.DryRunStrategy.ClientOrServerDryRun() {

--- a/pkg/apply/prune/prune_test.go
+++ b/pkg/apply/prune/prune_test.go
@@ -325,7 +325,7 @@ func TestPrune(t *testing.T) {
 				},
 			},
 		},
-		"UID match means prune skipped": {
+		"UID match means prune skipped and object abandoned": {
 			clusterObjs: []*unstructured.Unstructured{pod},
 			pruneObjs:   []*unstructured.Unstructured{pod},
 			pruneFilters: []filter.ValidationFilter{
@@ -351,8 +351,11 @@ func TestPrune(t *testing.T) {
 			expectedSkipped: object.ObjMetadataSet{
 				object.UnstructuredToObjMetadata(pod),
 			},
+			expectedAbandoned: object.ObjMetadataSet{
+				object.UnstructuredToObjMetadata(pod),
+			},
 		},
-		"UID match for only one object one pruned, one skipped": {
+		"UID match for only one object one pruned, one skipped and abandoned": {
 			clusterObjs: []*unstructured.Unstructured{pod, pdb},
 			pruneObjs:   []*unstructured.Unstructured{pod, pdb},
 			pruneFilters: []filter.ValidationFilter{
@@ -384,6 +387,9 @@ func TestPrune(t *testing.T) {
 				},
 			},
 			expectedSkipped: object.ObjMetadataSet{
+				object.UnstructuredToObjMetadata(pod),
+			},
+			expectedAbandoned: object.ObjMetadataSet{
 				object.UnstructuredToObjMetadata(pod),
 			},
 		},

--- a/test/e2e/current_uid_filter_test.go
+++ b/test/e2e/current_uid_filter_test.go
@@ -51,8 +51,10 @@ type: Warning
 
 // Note this tests the scenario of "cohabitating" k8s objects (an object available via multiple apiGroups), but having the same UID.
 // As of k8s 1.25 an example of such "cohabitating" kinds is Event which is available via both "v1" and "events.k8s.io/v1".
-// When the user upgrades from one apiGroup to the other:
-// - should not result in object being pruned
+// See the full list of cohabitating resources on the storage level here:
+// - https://github.com/kubernetes/kubernetes/blob/v1.25.0/pkg/kubeapiserver/default_storage_factory_builder.go#L124-L131
+// We test that when the user upgrades their manifest from one cohabitated apiGroup to the other, then:
+// - it should not result in object being pruned
 // - object pruning should be skipped due to CurrentUIDFilter (even though a diff is found)
 // - inventory should not double-track the object i.e. we should hold reference only to the object with the groupKind that was most recently applied
 func currentUIDFilterTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {

--- a/test/e2e/current_uid_filter_test.go
+++ b/test/e2e/current_uid_filter_test.go
@@ -1,0 +1,107 @@
+// Copyright 2021 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/test/e2e/e2eutil"
+	"sigs.k8s.io/cli-utils/test/e2e/invconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const v1EventTemplate = `
+apiVersion: v1
+involvedObject:
+  apiVersion: v1
+  kind: Pod
+  name: pod
+  namespace: {{.Namespace}}
+kind: Event
+message: Back-off restarting failed container
+metadata:
+  name: test
+  namespace: {{.Namespace}}
+reason: BackOff
+type: Warning
+`
+
+const v1EventsEventTemplate = `
+apiVersion: events.k8s.io/v1
+eventTime: null
+kind: Event
+metadata:
+  name: test
+  namespace: {{.Namespace}}
+note: Back-off restarting failed container
+reason: BackOff
+regarding:
+  apiVersion: v1
+  kind: Pod
+  name: pod
+  namespace: {{.Namespace}}
+type: Warning
+`
+
+// Note this tests the scenario of "cohabitating" k8s objects (an object available via multiple apiGroups), but having the same UID.
+// As of k8s 1.25 an example of such "cohabitating" kinds is Event which is available via both "v1" and "events.k8s.io/v1".
+// When the user upgrades from one apiGroup to the other:
+// - should not result in object being pruned
+// - object pruning should be skipped due to CurrentUIDFilter (even though a diff is found)
+// - inventory should not double-track the object i.e. we should hold reference only to the object with the groupKind that was most recently applied
+func currentUIDFilterTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
+	applier := invConfig.ApplierFactoryFunc()
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+
+	templateFields := struct{ Namespace string }{Namespace: namespaceName}
+	v1Event := e2eutil.TemplateToUnstructured(v1EventTemplate, templateFields)
+	v1EventsEvent := e2eutil.TemplateToUnstructured(v1EventsEventTemplate, templateFields)
+
+	By("Apply resource with deprecated groupKind")
+	resources := []*unstructured.Unstructured{
+		v1Event,
+	}
+	err := e2eutil.Run(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{}))
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Verify resource available in both apiGroups")
+	objDeprecated := e2eutil.AssertUnstructuredExists(ctx, c, v1Event)
+	objNew := e2eutil.AssertUnstructuredExists(ctx, c, v1EventsEvent)
+
+	By("Verify UID matches for cohabitating resources")
+	uid := objDeprecated.GetUID()
+	Expect(uid).ToNot(BeEmpty())
+	Expect(objDeprecated.GetUID()).To(Equal(objNew.GetUID()))
+
+	By("Verify only 1 item in inventory")
+	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 1, 1)
+
+	By("Apply resource with new groupKind")
+	resources = []*unstructured.Unstructured{
+		v1EventsEvent,
+	}
+	err = e2eutil.Run(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{}))
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Verify resource still available in both apiGroups")
+	objDeprecated = e2eutil.AssertUnstructuredExists(ctx, c, v1Event)
+	objNew = e2eutil.AssertUnstructuredExists(ctx, c, v1EventsEvent)
+
+	By("Verify UID matches for cohabitating resources")
+	Expect(objDeprecated.GetUID()).To(Equal(objNew.GetUID()))
+
+	By("Verify UID matches the UID from previous apply")
+	Expect(objDeprecated.GetUID()).To(Equal(uid))
+
+	By("Verify still only 1 item in inventory")
+	// Expecting statusCount=2:
+	//   one object applied and one prune skipped
+	invConfig.InvSizeVerifyFunc(ctx, c, inventoryName, namespaceName, inventoryID, 1, 2)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -183,6 +183,10 @@ var _ = Describe("E2E", func() {
 					namespaceFilterTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 				})
 
+				It("CurrentUIDFilter", func() {
+					currentUIDFilterTest(ctx, c, invConfig, inventoryName, namespace.GetName())
+				})
+
 				It("PruneRetrievalError", func() {
 					pruneRetrieveErrorTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 				})


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/cli-utils/issues/613

### Description

During pruning the code is filtering objects with `CurrentUIDFilter`:
> // CurrentUIDFilter implements ValidationFilter interface to determine
// if an object should not be pruned (deleted) because it has recently // been applied.

This must mean that the object has ended up being tracked in the inventory by more than one reference and the one that was flagged by the filter should be removed from the inventory. Otherwise, it gets stuck in the inventory indefinitely and during every invocation of prune it'll be logged as skipped.

A good example of this is `Ingress` kind existing in both groups `extensions` and `networking.k8s.io` in k8s 1.19 & 1.20. This means when you rename the apiGroup in your local yaml to the new recommended group, then the reference with the old group name gets permastuck in the inventory.