### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ metadata:
 spec:
   containers:
     - name: kubernetes-pause
-      image: k8s.gcr.io/pause:2.0
+      image: registry.k8s.io/pause:2.0
 ```
 
 ### Implicit Dependency Ordering

--- a/pkg/common/path_test.go
+++ b/pkg/common/path_test.go
@@ -79,7 +79,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0
 `)
 
 var podB = []byte(`
@@ -93,7 +93,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0
 `)
 
 func buildMultiResourceConfig(configs ...[]byte) []byte {

--- a/test/e2e/artifacts_test.go
+++ b/test/e2e/artifacts_test.go
@@ -70,7 +70,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0
 `))
 
 var pod2 = []byte(strings.TrimSpace(`
@@ -81,7 +81,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0
 `))
 
 var pod3 = []byte(strings.TrimSpace(`
@@ -92,7 +92,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: k8s.gcr.io/pause:2.0
+    image: registry.k8s.io/pause:2.0
 `))
 
 var podATemplate = `


### PR DESCRIPTION
This PR updates the registry from `k8s.gcr.io` to `registry.k8s.io`

Issue: https://github.com/kubernetes/k8s.io/issues/4738