### PR TITLE
Allow to pass watcher strategy

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -242,7 +242,8 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.Info, objects objec
 		runner := taskrunner.NewTaskStatusRunner(allIds, statusWatcher)
 		klog.V(4).Infoln("applier running TaskStatusRunner...")
 		err = runner.Run(ctx, taskContext, taskQueue.ToChannel(), taskrunner.Options{
-			EmitStatusEvents: options.EmitStatusEvents,
+			EmitStatusEvents:         options.EmitStatusEvents,
+			WatcherRESTScopeStrategy: options.WatcherRESTScopeStrategy,
 		})
 		if err != nil {
 			handleError(eventChannel, err)
@@ -288,6 +289,10 @@ type ApplierOptions struct {
 
 	// ValidationPolicy defines how to handle invalid objects.
 	ValidationPolicy validation.Policy
+
+	// RESTScopeStrategy specifies which strategy to use when listing and
+	// watching resources. By default, the strategy is selected automatically.
+	WatcherRESTScopeStrategy watcher.RESTScopeStrategy
 }
 
 // setDefaults set the options to the default values if they

--- a/pkg/apply/taskrunner/runner.go
+++ b/pkg/apply/taskrunner/runner.go
@@ -35,6 +35,9 @@ type TaskStatusRunner struct {
 // the statusPoller.
 type Options struct {
 	EmitStatusEvents bool
+	// RESTScopeStrategy specifies which strategy to use when listing and
+	// watching resources. By default, the strategy is selected automatically.
+	WatcherRESTScopeStrategy watcher.RESTScopeStrategy
 }
 
 // Run executes the tasks in the taskqueue, with the statusPoller running in the
@@ -57,7 +60,9 @@ func (tsr *TaskStatusRunner) Run(
 	// If taskStatusRunner.Run is cancelled, baseRunner.run will exit early,
 	// causing the poller to be cancelled.
 	statusCtx, cancelFunc := context.WithCancel(context.Background())
-	statusChannel := tsr.StatusWatcher.Watch(statusCtx, tsr.Identifiers, watcher.Options{})
+	statusChannel := tsr.StatusWatcher.Watch(statusCtx, tsr.Identifiers, watcher.Options{
+		RESTScopeStrategy: opts.WatcherRESTScopeStrategy,
+	})
 
 	// complete stops the statusPoller, drains the statusChannel, and returns
 	// the provided error.


### PR DESCRIPTION
Currently strategy is not specified and is always `RESTScopeAutomatic`. I have a case where I need to set it to `RESTScopeNamespace`, but there is no way to set it. This PR exposes an option to make it possible.

See https://github.com/kubernetes-sigs/cli-utils/pull/572#issuecomment-1111604485 and the following conversation for the background.