### PR TITLE
test: reduce size of stress test deployments

### DIFF
--- a/test/stress/artifacts_test.go
+++ b/test/stress/artifacts_test.go
@@ -76,19 +76,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx
+      app: pause
   template:
     metadata:
       labels:
-        app: nginx
+        app: pause
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.19.6
-        ports:
-        - containerPort: 80
+      - name: kubernetes-pause
+        image: registry.k8s.io/pause:2.0
         resources:
           requests:
-            cpu: 10m
+            cpu: 1m
             memory: 1Mi
 `

--- a/test/stress/thousand_deployments_retry_test.go
+++ b/test/stress/thousand_deployments_retry_test.go
@@ -46,7 +46,7 @@ func thousandDeploymentsRetryTest(ctx context.Context, c client.Client, invConfi
 		deploymentObj.SetNamespace(namespaceName)
 
 		// change name & selector labels to avoid overlap between deployments
-		name := fmt.Sprintf("nginx-%d", i)
+		name := fmt.Sprintf("pause-%d", i)
 		deploymentObj.SetName(name)
 		err := unstructured.SetNestedField(deploymentObj.Object, name, "spec", "selector", "matchLabels", "app")
 		Expect(err).ToNot(HaveOccurred())

--- a/test/stress/thousand_deployments_test.go
+++ b/test/stress/thousand_deployments_test.go
@@ -44,7 +44,7 @@ func thousandDeploymentsTest(ctx context.Context, c client.Client, invConfig inv
 		deploymentObj.SetNamespace(namespaceName)
 
 		// change name & selector labels to avoid overlap between deployments
-		name := fmt.Sprintf("nginx-%d", i)
+		name := fmt.Sprintf("pause-%d", i)
 		deploymentObj.SetName(name)
 		err := unstructured.SetNestedField(deploymentObj.Object, name, "spec", "selector", "matchLabels", "app")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The stress tests create 1000 copies of this deployment on the kind cluster, which means that these deployments are in contention for resources with the kind control plane and test suite. Reducing the size of these test deployments should help the stress test run with fewer resources available, and will hopefully get the presubmits passing.