### PR TITLE
Bump golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: generate license fix vet fmt test lint tidy
 	go install github.com/google/addlicense@v1.0.0
 
 "$(MYGOBIN)/golangci-lint":
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 
 "$(MYGOBIN)/deepcopy-gen":
 	go install k8s.io/code-generator/cmd/deepcopy-gen@v0.25.2


### PR DESCRIPTION
Maybe this will resolve the linter being killed in https://github.com/kubernetes-sigs/cli-utils/pull/619? I have no idea why it's getting killed.