### PR TITLE
pod.status.phase = Failed (incorrectly?) marked as `CurrentStatus` 

### DIFF
--- a/pkg/kstatus/status/core.go
+++ b/pkg/kstatus/status/core.go
@@ -422,7 +422,7 @@ func podConditions(u *unstructured.Unstructured) (*Result, error) {
 		}, nil
 	case "Failed":
 		return &Result{
-			Status:     CurrentStatus,
+			Status:     FailedStatus,
 			Message:    "Pod has completed, but not successfully",
 			Conditions: []Condition{},
 		}, nil

--- a/pkg/kstatus/status/status_compute_test.go
+++ b/pkg/kstatus/status/status_compute_test.go
@@ -197,7 +197,7 @@ func TestPodStatus(t *testing.T) {
 		},
 		"podCompletedFailed": {
 			spec:               podCompletedFail,
-			expectedStatus:     CurrentStatus,
+			expectedStatus:     FailedStatus,
 			expectedConditions: []Condition{},
 			absentConditionTypes: []ConditionType{
 				ConditionReconciling,


### PR DESCRIPTION
I was trying to compute status of a pod and to my surprise it came back as `Current` when it really had failed. Given that this code has been here for almost 3 years, this might be on purpose? However, if not, please review this PR. 