### PR TITLE
fix: treat rate limiter deadline as context deadline

### DIFF
--- a/pkg/kstatus/polling/statusreaders/common_test.go
+++ b/pkg/kstatus/polling/statusreaders/common_test.go
@@ -76,6 +76,19 @@ func TestLookupResource(t *testing.T) {
 			expectErr:          true,
 			expectedErrMessage: context.Canceled.Error(),
 		},
+		"rate would exceed context deadline": {
+			identifier:         deploymentIdentifier,
+			readerErr:          fmt.Errorf("client rate limiter Wait returned an error: %w", fmt.Errorf("rate: Wait(n=1) would exceed context deadline")),
+			expectErr:          true,
+			expectedErrMessage: "client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline",
+		},
+		"rate would exceed context deadline wrapped error": {
+			identifier: deploymentIdentifier,
+			readerErr: fmt.Errorf("wrapped deeper: %w",
+				fmt.Errorf("client rate limiter Wait returned an error: %w", fmt.Errorf("rate: Wait(n=1) would exceed context deadline"))),
+			expectErr:          true,
+			expectedErrMessage: "wrapped deeper: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline",
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
We often bump into race condition where resource status [won't be read](https://github.com/kubernetes/client-go/blob/5a0a4247921dd9e72d158aaa6c1ee124aba1da80/rest/request.go#L614) because context is [reaching the deadline](https://cs.opensource.google/go/x/time/+/refs/tags/v0.5.0:rate/rate.go;l=275). This results in `Unknown` status being returned.

This PRs treats this edge case the same way as `context.Canceled` and `context.DeadlineExceeded` are treated.