### PR TITLE
Add conversion func for status-policy

### DIFF
--- a/cmd/flagutils/utils.go
+++ b/cmd/flagutils/utils.go
@@ -15,6 +15,9 @@ const (
 	InventoryPolicyStrict     = "strict"
 	InventoryPolicyAdopt      = "adopt"
 	InventoryPolicyForceAdopt = "force-adopt"
+	StatusPolicyFlag          = "status-policy"
+	StatusPolicyAll           = "all"
+	StatusPolicyNone          = "none"
 )
 
 // ConvertPropagationPolicy converts a propagationPolicy described as a
@@ -44,6 +47,19 @@ func ConvertInventoryPolicy(policy string) (inventory.Policy, error) {
 	default:
 		return inventory.PolicyMustMatch, fmt.Errorf(
 			"inventory policy must be one of strict, adopt")
+	}
+}
+
+// ConvertStatusPolicy converts as status policy described as a string to a
+// StatusPolicy type that is passed into the Applier.
+func ConvertStatusPolicy(policy string) (inventory.StatusPolicy, error) {
+	switch policy {
+	case StatusPolicyNone:
+		return inventory.StatusPolicyNone, nil
+	case StatusPolicyAll:
+		return inventory.StatusPolicyAll, nil
+	default:
+		return inventory.StatusPolicyAll, fmt.Errorf("status policy must be one of none, all")
 	}
 }
 


### PR DESCRIPTION
Hi 👋 

This change is intended for Kpt. We use `kpt live apply` in our CI/CD pipelines, but we don't need it saving statuses for all resources into the inventory. We want to be able to pass `--status-policy=none`.

I considered adding support for changing the status-policy flag in kapply as well, but I couldn't think of a way to introduce the flag without introducing it for all subcommands, or copying the description across for the applicable subcommands. Let me know if you want me to implement the flag here too.