### PR TITLE
Add status watch label filter

### DIFF
--- a/pkg/apply/applier_builder.go
+++ b/pkg/apply/applier_builder.go
@@ -86,3 +86,8 @@ func (b *ApplierBuilder) WithStatusWatcher(statusWatcher watcher.StatusWatcher) 
 	b.statusWatcher = statusWatcher
 	return b
 }
+
+func (b *ApplierBuilder) WithStatusWatcherFilters(filters *watcher.Filters) *ApplierBuilder {
+	b.statusWatcherFilters = filters
+	return b
+}

--- a/pkg/kstatus/watcher/dynamic_informer_factory.go
+++ b/pkg/kstatus/watcher/dynamic_informer_factory.go
@@ -5,12 +5,16 @@ package watcher
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
@@ -20,15 +24,14 @@ type DynamicInformerFactory struct {
 	Client       dynamic.Interface
 	ResyncPeriod time.Duration
 	Indexers     cache.Indexers
+	Filters      *Filters
 }
 
 func NewDynamicInformerFactory(client dynamic.Interface, resyncPeriod time.Duration) *DynamicInformerFactory {
 	return &DynamicInformerFactory{
 		Client:       client,
 		ResyncPeriod: resyncPeriod,
-		Indexers: cache.Indexers{
-			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-		},
+		Indexers:     DefaultIndexers(),
 	}
 }
 
@@ -36,22 +39,122 @@ func (f *DynamicInformerFactory) NewInformer(ctx context.Context, mapping *meta.
 	// Unstructured example output need `"apiVersion"` and `"kind"` set.
 	example := &unstructured.Unstructured{}
 	example.SetGroupVersionKind(mapping.GroupVersionKind)
-
 	return cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return f.Client.Resource(mapping.Resource).
-					Namespace(namespace).
-					List(ctx, options)
-			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return f.Client.Resource(mapping.Resource).
-					Namespace(namespace).
-					Watch(ctx, options)
-			},
-		},
+		NewFilteredListWatchFromDynamicClient(
+			ctx,
+			f.Client,
+			mapping.Resource,
+			namespace,
+			f.Filters,
+		),
 		example,
 		f.ResyncPeriod,
 		f.Indexers,
 	)
+}
+
+// DefaultIndexers returns the default set of cache indexers, namely the
+// namespace indexer.
+func DefaultIndexers() cache.Indexers {
+	return cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	}
+}
+
+// Filters are optional selectors for list and watch
+type Filters struct {
+	Labels labels.Selector
+	Fields fields.Selector
+}
+
+// NewFilteredListWatchFromDynamicClient creates a new ListWatch from the
+// specified client, resource, namespace, and optional filters.
+func NewFilteredListWatchFromDynamicClient(
+	ctx context.Context,
+	client dynamic.Interface,
+	resource schema.GroupVersionResource,
+	namespace string,
+	filters *Filters,
+) *cache.ListWatch {
+	optionsModifier := func(options *metav1.ListOptions) error {
+		if filters == nil {
+			return nil
+		}
+		if filters.Labels != nil {
+			selector := filters.Labels
+			// Merge label selectors, if both were provided
+			if options.LabelSelector != "" {
+				var err error
+				selector, err = labels.Parse(options.LabelSelector)
+				if err != nil {
+					return fmt.Errorf("parsing label selector: %w", err)
+				}
+				selector = andLabelSelectors(selector, filters.Labels)
+			}
+			options.LabelSelector = selector.String()
+		}
+		if filters.Fields != nil {
+			selector := filters.Fields
+			// Merge field selectors, if both were provided
+			if options.FieldSelector != "" {
+				var err error
+				selector, err = fields.ParseSelector(options.FieldSelector)
+				if err != nil {
+					return fmt.Errorf("parsing field selector: %w", err)
+				}
+				selector = fields.AndSelectors(selector, filters.Fields)
+			}
+			options.FieldSelector = selector.String()
+		}
+		return nil
+	}
+	return NewModifiedListWatchFromDynamicClient(ctx, client, resource, namespace, optionsModifier)
+}
+
+// NewModifiedListWatchFromDynamicClient creates a new ListWatch from the
+// specified client, resource, namespace, and options modifier.
+// Options modifier is a function takes a ListOptions and modifies the consumed
+// ListOptions. Provide customized modifier function to apply modification to
+// ListOptions with field selectors, label selectors, or any other desired options.
+func NewModifiedListWatchFromDynamicClient(
+	ctx context.Context,
+	client dynamic.Interface,
+	resource schema.GroupVersionResource,
+	namespace string,
+	optionsModifier func(*metav1.ListOptions) error,
+) *cache.ListWatch {
+	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
+		if err := optionsModifier(&options); err != nil {
+			return nil, fmt.Errorf("modifying list options: %w", err)
+		}
+		return client.Resource(resource).
+			Namespace(namespace).
+			List(ctx, options)
+	}
+	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+		options.Watch = true
+		if err := optionsModifier(&options); err != nil {
+			return nil, fmt.Errorf("modifying watch options: %w", err)
+		}
+		return client.Resource(resource).
+			Namespace(namespace).
+			Watch(ctx, options)
+	}
+	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+}
+
+func andLabelSelectors(selectors ...labels.Selector) labels.Selector {
+	var s labels.Selector
+	for _, item := range selectors {
+		if s == nil {
+			s = item
+		} else {
+			reqs, selectable := item.Requirements()
+			if !selectable {
+				return item // probably the nothing selector
+			}
+			s = s.Add(reqs...)
+		}
+	}
+	return s
 }

--- a/pkg/kstatus/watcher/dynamic_informer_factory_test.go
+++ b/pkg/kstatus/watcher/dynamic_informer_factory_test.go
@@ -6,14 +6,19 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/testapigroup"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/test"
@@ -229,4 +234,512 @@ func newGenericServerResponse(action clienttesting.Action, statusError *apierror
 	name := statusError.ErrStatus.Details.Name
 	// https://github.com/kubernetes/apimachinery/blob/v0.24.0/pkg/api/errors/errors.go#L435
 	return apierrors.NewGenericServerResponse(errorCode, verb, qualifiedResource, name, statusError.Error(), -1, false)
+}
+
+func TestNewFilteredListWatchFromDynamicClientList(t *testing.T) {
+	fakeMapper := testutil.NewFakeRESTMapper(
+		v1.SchemeGroupVersion.WithKind("Pod"),
+	)
+
+	pod1 := yamlToUnstructured(t, pod1Yaml)
+	pod1.SetNamespace("ns-1")
+	// pod1ID := object.UnstructuredToObjMetadata(pod1)
+	// pod1Current := yamlToUnstructured(t, pod1CurrentYaml)
+	podGVR := getGVR(t, fakeMapper, pod1)
+
+	pod2 := pod1.DeepCopy()
+	pod2.SetNamespace("ns-2")
+	pod2.SetName("pod-2")
+
+	labelKey := "example-key-2"
+	labelValue := "example-value-2"
+	pod2Labels := pod2.GetLabels()
+	if pod2Labels == nil {
+		pod2Labels = map[string]string{}
+	}
+	pod2Labels[labelKey] = labelValue
+	pod2.SetLabels(pod2Labels)
+
+	pod3 := pod1.DeepCopy()
+	pod3.SetNamespace("ns-2")
+	pod3.SetName("pod-3")
+
+	annotationKey := "example-key-3"
+	annotationValue := "example-value-3"
+	pod3Annotations := pod3.GetAnnotations()
+	if pod3Annotations == nil {
+		pod3Annotations = map[string]string{}
+	}
+	pod3Annotations[annotationKey] = annotationValue
+	pod3.SetAnnotations(pod3Annotations)
+
+	type args struct {
+		resource  schema.GroupVersionResource
+		namespace string
+		filters   *Filters
+	}
+	type listInput struct {
+		options metav1.ListOptions
+	}
+	type listOuput struct {
+		object runtime.Object
+		err    error
+	}
+	tests := []struct {
+		name      string
+		setup     func(*dynamicfake.FakeDynamicClient)
+		args      args
+		listInput listInput
+		listOuput listOuput
+	}{
+		{
+			name: "list pods cluster-scoped",
+			setup: func(fakeClient *dynamicfake.FakeDynamicClient) {
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+			},
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+			},
+			listInput: listInput{},
+			listOuput: listOuput{
+				object: &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"kind": "PodList",
+						"metadata": map[string]interface{}{
+							"continue":        "",
+							"resourceVersion": "",
+						},
+						"apiVersion": "v1",
+					},
+					Items: []unstructured.Unstructured{
+						*pod1.DeepCopy(),
+						*pod2.DeepCopy(),
+					},
+				},
+			},
+		},
+		{
+			name: "list pods namespace-scoped",
+			setup: func(fakeClient *dynamicfake.FakeDynamicClient) {
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+			},
+			args: args{
+				resource:  podGVR,
+				namespace: pod1.GetNamespace(),
+			},
+			listInput: listInput{},
+			listOuput: listOuput{
+				object: &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"kind": "PodList",
+						"metadata": map[string]interface{}{
+							"continue":        "",
+							"resourceVersion": "",
+						},
+						"apiVersion": "v1",
+					},
+					Items: []unstructured.Unstructured{
+						*pod1.DeepCopy(),
+					},
+				},
+			},
+		},
+		{
+			name: "list pods label selector",
+			setup: func(fakeClient *dynamicfake.FakeDynamicClient) {
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+			},
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+				filters: &Filters{
+					Labels: labels.SelectorFromSet(labels.Set{
+						labelKey: labelValue,
+					}),
+				},
+			},
+			listInput: listInput{},
+			listOuput: listOuput{
+				object: &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"kind": "PodList",
+						"metadata": map[string]interface{}{
+							"continue":        "",
+							"resourceVersion": "",
+						},
+						"apiVersion": "v1",
+					},
+					Items: []unstructured.Unstructured{
+						*pod2.DeepCopy(),
+					},
+				},
+			},
+		},
+		{
+			name: "list pods field selector",
+			setup: func(fakeClient *dynamicfake.FakeDynamicClient) {
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+				require.NoError(t, fakeClient.Tracker().Create(podGVR, pod3, pod3.GetNamespace()))
+			},
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+				filters: &Filters{
+					Fields: fields.SelectorFromSet(fields.Set{
+						fmt.Sprintf("metadata.annotations.%s", annotationKey): annotationValue,
+					}),
+				},
+			},
+			listInput: listInput{},
+			listOuput: listOuput{
+				object: &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"kind": "PodList",
+						"metadata": map[string]interface{}{
+							"continue":        "",
+							"resourceVersion": "",
+						},
+						"apiVersion": "v1",
+					},
+					Items: []unstructured.Unstructured{
+						// FakeDynamicClient does not support field selectors or
+						// specifying custom indexers to make them work.
+						// TODO: Update FakeDynamicClient (client-go) to support indexers and field selectors
+						*pod2.DeepCopy(), // Should not be returned
+						*pod3.DeepCopy(),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			scheme.AddKnownTypes(metav1.SchemeGroupVersion, &metav1.Status{})
+
+			// Register core v1 resources
+			require.NoError(t, v1.AddToScheme(scheme))
+
+			// Fake client that only knows about the types registered to the scheme
+			fakeClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+			// log fakeClient calls
+			fakeClient.PrependReactor("*", "*", func(a clienttesting.Action) (bool, runtime.Object, error) {
+				klog.Infof("FakeDynamicClient: %T{ Verb: %q, Resource: %q, Namespace: %q }",
+					a, a.GetVerb(), a.GetResource().Resource, a.GetNamespace())
+				return false, nil, nil
+			})
+			fakeClient.PrependWatchReactor("*", func(a clienttesting.Action) (bool, watch.Interface, error) {
+				klog.Infof("FakeDynamicClient: %T{ Verb: %q, Resource: %q, Namespace: %q }",
+					a, a.GetVerb(), a.GetResource().Resource, a.GetNamespace())
+				return false, nil, nil
+			})
+
+			tc.setup(fakeClient)
+
+			ctx := context.Background()
+			lw := NewFilteredListWatchFromDynamicClient(ctx, fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
+
+			obj, err := lw.List(tc.listInput.options)
+			testutil.AssertEqual(t, tc.listOuput.object, obj)
+			if err != nil && tc.listOuput.err != nil {
+				testutil.AssertEqual(t, testutil.EqualError(tc.listOuput.err), testutil.EqualError(err))
+			} else {
+				testutil.AssertEqual(t, tc.listOuput.err, err)
+			}
+		})
+	}
+}
+
+func TestNewFilteredListWatchFromDynamicClientWatch(t *testing.T) {
+	testTimeout := 10 * time.Second
+
+	fakeMapper := testutil.NewFakeRESTMapper(
+		v1.SchemeGroupVersion.WithKind("Pod"),
+	)
+
+	pod1 := yamlToUnstructured(t, pod1Yaml)
+	pod1.SetNamespace("ns-1")
+	// pod1ID := object.UnstructuredToObjMetadata(pod1)
+	// pod1Current := yamlToUnstructured(t, pod1CurrentYaml)
+	podGVR := getGVR(t, fakeMapper, pod1)
+
+	pod1Current := yamlToUnstructured(t, pod1CurrentYaml)
+	pod1Current.SetNamespace("ns-1")
+
+	pod2 := pod1.DeepCopy()
+	pod2.SetNamespace("ns-2")
+	pod2.SetName("pod-2")
+
+	labelKey := "example-key"
+	labelValue := "example-value"
+	pod2Labels := pod2.GetLabels()
+	if pod2Labels == nil {
+		pod2Labels = map[string]string{}
+	}
+	pod2Labels[labelKey] = labelValue
+	pod2.SetLabels(pod2Labels)
+
+	pod2Current := yamlToUnstructured(t, pod1CurrentYaml)
+	pod2Current.SetNamespace("ns-2")
+	pod2Current.SetName("pod-2")
+	pod2Current.SetLabels(pod2Labels)
+
+	pod3 := pod1.DeepCopy()
+	pod3.SetNamespace("ns-2")
+	pod3.SetName("pod-3")
+
+	pod3Current := yamlToUnstructured(t, pod1CurrentYaml)
+	pod3Current.SetNamespace("ns-2")
+	pod3Current.SetName("pod-3")
+
+	// nodeName is a valid server-side field selector
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/#supported-fields
+	nodeNameFieldPath := "spec.nodeName"
+	nodeNameFieldPathKeys := strings.Split(nodeNameFieldPath, ".")
+	nodeNameValue := "example-node"
+	require.NoError(t, unstructured.SetNestedField(pod3Current.Object, nodeNameValue, nodeNameFieldPathKeys...))
+
+	type args struct {
+		resource  schema.GroupVersionResource
+		namespace string
+		filters   *Filters
+	}
+	type watchInput struct {
+		options metav1.ListOptions
+	}
+	type watchOuput struct {
+		err error
+	}
+	tests := []struct {
+		name           string
+		setup          func(*dynamicfake.FakeDynamicClient)
+		args           args
+		watchInput     watchInput
+		watchOuput     watchOuput
+		clusterUpdates []func(*dynamicfake.FakeDynamicClient)
+		expectedEvents []watch.Event
+	}{
+		{
+			name: "watch pod cluster-scope",
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+			},
+			clusterUpdates: []func(fakeClient *dynamicfake.FakeDynamicClient){
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				},
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Update(podGVR, pod1Current, pod1Current.GetNamespace()))
+				},
+			},
+			expectedEvents: []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: pod1.DeepCopy(),
+				},
+				{
+					Type:   watch.Modified,
+					Object: pod1Current.DeepCopy(),
+				},
+			},
+		},
+		{
+			name: "watch pods namespace-scoped",
+			args: args{
+				resource:  podGVR,
+				namespace: pod1.GetNamespace(),
+			},
+			clusterUpdates: []func(fakeClient *dynamicfake.FakeDynamicClient){
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				},
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Update(podGVR, pod1Current, pod1Current.GetNamespace()))
+				},
+			},
+			expectedEvents: []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: pod1.DeepCopy(),
+				},
+				{
+					Type:   watch.Modified,
+					Object: pod1Current.DeepCopy(),
+				},
+			},
+		},
+		{
+			name: "watch pods label selector",
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+				filters: &Filters{
+					Labels: labels.SelectorFromSet(labels.Set{
+						labelKey: labelValue,
+					}),
+				},
+			},
+			// FakeDynamicClient doesn't implement watch restrictions (labels or fields),
+			// so we have to fake a label selector by not sending those cluster updates.
+			// TODO: Update FakeDynamicClient (client-go) to support watch restrictions.
+			clusterUpdates: []func(fakeClient *dynamicfake.FakeDynamicClient){
+				// func(fakeClient *dynamicfake.FakeDynamicClient) {
+				// 	require.NoError(t, fakeClient.Tracker().Create(podGVR, pod1, pod1.GetNamespace()))
+				// },
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+				},
+				// func(fakeClient *dynamicfake.FakeDynamicClient) {
+				// 	require.NoError(t, fakeClient.Tracker().Update(podGVR, pod1Current, pod1Current.GetNamespace()))
+				// },
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Update(podGVR, pod2Current, pod2Current.GetNamespace()))
+				},
+			},
+			expectedEvents: []watch.Event{
+				{
+					Type:   watch.Added,
+					Object: pod2.DeepCopy(),
+				},
+				{
+					Type:   watch.Modified,
+					Object: pod2Current.DeepCopy(),
+				},
+			},
+		},
+		{
+			name: "watch pods field selector",
+			args: args{
+				resource:  podGVR,
+				namespace: "",
+				filters: &Filters{
+					Fields: fields.SelectorFromSet(fields.Set{
+						nodeNameFieldPath: nodeNameValue,
+					}),
+				},
+			},
+			// FakeDynamicClient doesn't implement watch restrictions (labels or fields),
+			// so we have to fake a field selector by not sending those cluster updates.
+			// TODO: Update FakeDynamicClient (client-go) to support watch restrictions.
+			clusterUpdates: []func(fakeClient *dynamicfake.FakeDynamicClient){
+				// func(fakeClient *dynamicfake.FakeDynamicClient) {
+				// 	require.NoError(t, fakeClient.Tracker().Create(podGVR, pod2, pod2.GetNamespace()))
+				// },
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Create(podGVR, pod3, pod3.GetNamespace()))
+				},
+				// func(fakeClient *dynamicfake.FakeDynamicClient) {
+				// 	require.NoError(t, fakeClient.Tracker().Update(podGVR, pod2Current, pod2Current.GetNamespace()))
+				// },
+				func(fakeClient *dynamicfake.FakeDynamicClient) {
+					require.NoError(t, fakeClient.Tracker().Update(podGVR, pod3Current, pod3Current.GetNamespace()))
+				},
+			},
+			expectedEvents: []watch.Event{
+				// If FakeDynamicClient supported field selectors, the first
+				// and only event seen would be when the spec.nodeName is set,
+				// as an Added event.
+				// {
+				// 	Type:   watch.Added,
+				// 	Object: pod3Current.DeepCopy(),
+				// },
+				{
+					Type:   watch.Added,
+					Object: pod3.DeepCopy(),
+				},
+				{
+					Type:   watch.Modified,
+					Object: pod3Current.DeepCopy(),
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			scheme.AddKnownTypes(metav1.SchemeGroupVersion, &metav1.Status{})
+
+			// Register core v1 resources
+			require.NoError(t, v1.AddToScheme(scheme))
+
+			// Fake client that only knows about the types registered to the scheme
+			fakeClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+			// log fakeClient calls
+			fakeClient.PrependReactor("*", "*", func(a clienttesting.Action) (bool, runtime.Object, error) {
+				klog.V(3).Infof("FakeDynamicClient: %T{ Verb: %q, Resource: %q, Namespace: %q }",
+					a, a.GetVerb(), a.GetResource().Resource, a.GetNamespace())
+				return false, nil, nil
+			})
+			fakeClient.PrependWatchReactor("*", func(a clienttesting.Action) (bool, watch.Interface, error) {
+				klog.V(3).Infof("FakeDynamicClient: %T{ Verb: %q, Resource: %q, Namespace: %q }",
+					a, a.GetVerb(), a.GetResource().Resource, a.GetNamespace())
+				return false, nil, nil
+			})
+
+			if tc.setup != nil {
+				tc.setup(fakeClient)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			defer cancel()
+
+			lw := NewFilteredListWatchFromDynamicClient(ctx, fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
+
+			watcher, err := lw.Watch(tc.watchInput.options)
+
+			if err != nil && tc.watchOuput.err != nil {
+				testutil.AssertEqual(t, testutil.EqualError(tc.watchOuput.err), testutil.EqualError(err))
+			} else {
+				testutil.AssertEqual(t, tc.watchOuput.err, err)
+			}
+
+			nextCh := make(chan struct{})
+			defer close(nextCh)
+
+			// Synchronize event consumption and production for predictable test results.
+			go func() {
+				// Wait for start event
+				<-nextCh
+				for _, update := range tc.clusterUpdates {
+					update(fakeClient)
+					<-nextCh
+				}
+				// Stop the watcher
+				watcher.Stop()
+			}()
+
+			// Start server updates
+			nextCh <- struct{}{}
+
+			receivedEvents := []watch.Event{}
+			func() {
+				doneCh := ctx.Done()
+				resultCh := watcher.ResultChan()
+				for {
+					select {
+					case <-doneCh:
+						t.Errorf("test timed out before event channel closed")
+						return
+					case e, open := <-resultCh:
+						if !open {
+							klog.V(3).Info("event channel closed")
+							return
+						}
+						klog.V(3).Infof("event received: %#v", e)
+						receivedEvents = append(receivedEvents, e)
+						// Trigger next server update
+						nextCh <- struct{}{}
+					}
+				}
+			}()
+			testutil.AssertEqual(t, tc.expectedEvents, receivedEvents)
+		})
+	}
 }


### PR DESCRIPTION
Using a label filter significantly cuts down on watch events and memory used by the informer's watch cache. But you'll need to set the labels on the objects yourself before providing them to the applier.

I've tested it with Config Sync end-to-end tests and shown that it significantly reduces memory usage when there are other objects on the cluster with resource types and namespaces that overlap with the apply set being watched. This is because the informer caches objects it receives events for, even if they're not in the apply set.

Unfortunately, FakeDynamicClient (client-go) only supports list label selector, not watch label selectors. So the unit tests added here aren't particularly useful. We will need to upstream changes to client-go to make the unit tests more functional. But that shouldn't be a blocker.

I added field selectors as well, but these are even harder to test than label selectors, because the FakeDynamicClient doesn't support them at all. It's also not super clear how indexers relate to label filters, since the indexer is only used client-side and the label filter is server-side (i think).