### PR TITLE
feat: allow disabling/overriding ObjectFilter in status watcher

### DIFF
--- a/pkg/kstatus/watcher/object_status_reporter.go
+++ b/pkg/kstatus/watcher/object_status_reporter.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
+
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -446,7 +447,7 @@ func (w *ObjectStatusReporter) eventHandler(
 			panic(fmt.Sprintf("AddFunc received unexpected object type %T", iobj))
 		}
 		id := object.UnstructuredToObjMetadata(obj)
-		if w.ObjectFilter.Filter(obj) {
+		if w.ObjectFilter != nil && w.ObjectFilter.Filter(obj) {
 			klog.V(7).Infof("Watch Event Skipped: AddFunc: %s", id)
 			return
 		}
@@ -495,7 +496,7 @@ func (w *ObjectStatusReporter) eventHandler(
 			panic(fmt.Sprintf("UpdateFunc received unexpected object type %T", iobj))
 		}
 		id := object.UnstructuredToObjMetadata(obj)
-		if w.ObjectFilter.Filter(obj) {
+		if w.ObjectFilter != nil && w.ObjectFilter.Filter(obj) {
 			klog.V(7).Infof("UpdateFunc: Watch Event Skipped: %s", id)
 			return
 		}
@@ -549,7 +550,7 @@ func (w *ObjectStatusReporter) eventHandler(
 			panic(fmt.Sprintf("DeleteFunc received unexpected object type %T", iobj))
 		}
 		id := object.UnstructuredToObjMetadata(obj)
-		if w.ObjectFilter.Filter(obj) {
+		if w.ObjectFilter != nil && w.ObjectFilter.Filter(obj) {
 			klog.V(7).Infof("DeleteFunc: Watch Event Skipped: %s", id)
 			return
 		}

--- a/pkg/kstatus/watcher/watcher.go
+++ b/pkg/kstatus/watcher/watcher.go
@@ -26,6 +26,13 @@ type Options struct {
 	// RESTScopeStrategy specifies which strategy to use when listing and
 	// watching resources. By default, the strategy is selected automatically.
 	RESTScopeStrategy RESTScopeStrategy
+
+	// ObjectFilter is used to filter objects on the client side.
+	ObjectFilter ObjectFilter
+
+	// UseCustomObjectFilter controls whether custom ObjectFilter provided in options
+	// should be used instead of the default one.
+	UseCustomObjectFilter bool
 }
 
 //go:generate stringer -type=RESTScopeStrategy -linecomment


### PR DESCRIPTION
With the addition of `Filters` to the `DefaultStatusWatcher` it is now possible to apply server-side filtering via labels/fields. This PR allows dropping or overriding client-side filtering with a custom `ObjectFilter`. In our case we are making sure that every resource in the inventory will contain a static label that can be used for server-side filtering and further client-side filtering is obsolete.