### PR TITLE
Reduce minimum Go requirement to v1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cli-utils
 
-go 1.22.4
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
A previous commit pinned 1.22.4, but that's not necessary and affects all downstream user's go.mod.