### PR TITLE
Fix: Ignore extra underscored when Object is an RBAC object in objmetadata

### DIFF
--- a/pkg/object/objmetadata.go
+++ b/pkg/object/objmetadata.go
@@ -93,7 +93,15 @@ func ParseObjMetadata(s string) (ObjMetadata, error) {
 	name = strings.ReplaceAll(name, colonTranscoded, ":")
 	// Check that there are no extra fields by search for fieldSeparator.
 	if strings.Contains(name, fieldSeparator) {
-		return NilObjMetadata, fmt.Errorf("too many fields within: %s", s)
+		// RBAC resources only need to satisfy Path Segment requirements
+		// This can lead to extra field separators in resource name
+		groupkind := schema.GroupKind{
+			Group: group,
+			Kind:  kind,
+		}
+		if _, exists := RBACGroupKind[groupkind]; !exists {
+			return NilObjMetadata, fmt.Errorf("too many fields within: %s", s)
+		}
 	}
 	// Create the ObjMetadata object from the four parsed fields.
 	id := ObjMetadata{

--- a/pkg/object/objmetadata_test.go
+++ b/pkg/object/objmetadata_test.go
@@ -102,6 +102,30 @@ func TestParseObjMetadata(t *testing.T) {
 			inventory: &ObjMetadata{},
 			isError:   true,
 		},
+		"RBAC with underscores": {
+			invStr: "test-namespace_leader_locking_kube_scheduler___rbac.authorization.k8s.io_RoleBinding",
+			inventory: &ObjMetadata{
+				Namespace: "test-namespace",
+				Name:      "leader_locking_kube_scheduler:",
+				GroupKind: schema.GroupKind{
+					Group: rbacv1.GroupName,
+					Kind:  "RoleBinding",
+				},
+			},
+			isError: false,
+		},
+		"Non-RBAC with underscores": {
+			invStr: "test-namespace_leader_locking_kube_scheduler_apps_Deployment",
+			inventory: &ObjMetadata{
+				Namespace: "test-namespace",
+				Name:      "leader_locking_kube_scheduler",
+				GroupKind: schema.GroupKind{
+					Group: "apps",
+					Kind:  "Deployment",
+				},
+			},
+			isError: true,
+		},
 	}
 
 	for tn, tc := range tests {


### PR DESCRIPTION
Ref. #487
Skips the test for extra underscores when we are dealing with RBAC objects as they are only restricted to path objects for naming. Included new tests for this new use case