### PR TITLE
chore: clean up inventory Client interface

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -64,26 +64,6 @@ func (a *Applier) prepareObjects(localInv inventory.Info, localObjs object.Unstr
 	for _, localObj := range localObjs {
 		inventory.AddInventoryIDAnnotation(localObj, localInv)
 	}
-	// If the inventory uses the Name strategy and an inventory ID is provided,
-	// verify that the existing inventory object (if there is one) has an ID
-	// label that matches.
-	// TODO(seans): This inventory id validation should happen in destroy and status.
-	if localInv.Strategy() == inventory.NameStrategy && localInv.ID() != "" {
-		prevInvObjs, err := a.invClient.GetClusterInventoryObjs(localInv)
-		if err != nil {
-			return nil, nil, err
-		}
-		if len(prevInvObjs) > 1 {
-			panic(fmt.Errorf("found %d inv objects with Name strategy", len(prevInvObjs)))
-		}
-		if len(prevInvObjs) == 1 {
-			invObj := prevInvObjs[0]
-			val := invObj.GetLabels()[common.InventoryLabel]
-			if val != localInv.ID() {
-				return nil, nil, fmt.Errorf("inventory-id of inventory object in cluster doesn't match provided id %q", localInv.ID())
-			}
-		}
-	}
 	pruneObjs, err := a.pruner.GetPruneObjs(localInv, localObjs, prune.Options{
 		DryRunStrategy: o.DryRunStrategy,
 	})

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -158,11 +158,13 @@ func (t *TaskQueueBuilder) Build(taskContext *taskrunner.TaskContext, o Options)
 		// InvAddTask creates the inventory and adds any objects being applied
 		klog.V(2).Infof("adding inventory add task (%d objects)", len(applyObjs))
 		tasks = append(tasks, &task.InvAddTask{
-			TaskName:  "inventory-add-0",
-			InvClient: t.InvClient,
-			InvInfo:   t.invInfo,
-			Objects:   applyObjs,
-			DryRun:    o.DryRunStrategy,
+			TaskName:      "inventory-add-0",
+			InvClient:     t.InvClient,
+			DynamicClient: t.DynamicClient,
+			Mapper:        t.Mapper,
+			InvInfo:       t.invInfo,
+			Objects:       applyObjs,
+			DryRun:        o.DryRunStrategy,
 		})
 	}
 

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -803,6 +803,8 @@ func TestTaskQueueBuilder_ApplyBuild(t *testing.T) {
 					typedTask.Mapper = mapper
 				case *taskrunner.WaitTask:
 					typedTask.Mapper = mapper
+				case *task.InvAddTask:
+					typedTask.Mapper = mapper
 				}
 			}
 
@@ -1477,6 +1479,8 @@ func TestTaskQueueBuilder_PruneBuild(t *testing.T) {
 					typedTask.Pruner = &prune.Pruner{}
 				case *taskrunner.WaitTask:
 					typedTask.Mapper = mapper
+				case *task.InvAddTask:
+					typedTask.Mapper = mapper
 				}
 			}
 
@@ -1830,6 +1834,8 @@ func TestTaskQueueBuilder_ApplyPruneBuild(t *testing.T) {
 				case *task.PruneTask:
 					typedTask.Pruner = &prune.Pruner{}
 				case *taskrunner.WaitTask:
+					typedTask.Mapper = mapper
+				case *task.InvAddTask:
 					typedTask.Mapper = mapper
 				}
 			}

--- a/pkg/apply/task/inv_add_task.go
+++ b/pkg/apply/task/inv_add_task.go
@@ -4,9 +4,16 @@
 package task
 
 import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -22,11 +29,13 @@ var (
 // into the cluster. The InvAddTask should add/merge inventory references
 // before the actual object is applied.
 type InvAddTask struct {
-	TaskName  string
-	InvClient inventory.Client
-	InvInfo   inventory.Info
-	Objects   object.UnstructuredSet
-	DryRun    common.DryRunStrategy
+	TaskName      string
+	InvClient     inventory.Client
+	DynamicClient dynamic.Interface
+	Mapper        meta.RESTMapper
+	InvInfo       inventory.Info
+	Objects       object.UnstructuredSet
+	DryRun        common.DryRunStrategy
 }
 
 func (i *InvAddTask) Name() string {
@@ -50,12 +59,14 @@ func (i *InvAddTask) Start(taskContext *taskrunner.TaskContext) {
 			i.sendTaskResult(taskContext, err)
 			return
 		}
-		// Ensures the namespace exists before applying the inventory object into it.
-		if invNamespace := inventoryNamespaceInSet(i.InvInfo, i.Objects); invNamespace != nil {
-			klog.V(4).Infof("applying inventory namespace %s", invNamespace.GetName())
-			if err := i.InvClient.ApplyInventoryNamespace(invNamespace, i.DryRun); err != nil {
-				i.sendTaskResult(taskContext, err)
-				return
+		// If the inventory is namespaced, ensure the namespace exists
+		if i.InvInfo.Namespace() != "" {
+			if invNamespace := inventoryNamespaceInSet(i.InvInfo, i.Objects); invNamespace != nil {
+				if err := i.createNamespace(context.TODO(), invNamespace, i.DryRun); err != nil {
+					err = fmt.Errorf("failed to create inventory namespace: %w", err)
+					i.sendTaskResult(taskContext, err)
+					return
+				}
 			}
 		}
 		klog.V(4).Infof("merging %d local objects into inventory", len(i.Objects))
@@ -88,6 +99,35 @@ func inventoryNamespaceInSet(inv inventory.Info, objs object.UnstructuredSet) *u
 		}
 	}
 	return nil
+}
+
+// createNamespace creates the specified namespace object
+func (i *InvAddTask) createNamespace(ctx context.Context, obj *unstructured.Unstructured, dryRun common.DryRunStrategy) error {
+	if dryRun.ClientOrServerDryRun() {
+		klog.V(4).Infof("skipped applying inventory namespace (dry-run): %s", obj.GetName())
+		return nil
+	}
+	klog.V(4).Infof("applying inventory namespace: %s", obj.GetName())
+
+	nsObj := obj.DeepCopy()
+	object.StripKyamlAnnotations(nsObj)
+	if err := util.CreateApplyAnnotation(nsObj, unstructured.UnstructuredJSONScheme); err != nil {
+		return err
+	}
+
+	mapping, err := i.getMapping(obj)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.DynamicClient.Resource(mapping.Resource).Create(ctx, nsObj, metav1.CreateOptions{})
+	return err
+}
+
+// getMapping returns the RESTMapping for the provided resource.
+func (i *InvAddTask) getMapping(obj *unstructured.Unstructured) (*meta.RESTMapping, error) {
+	gvk := obj.GroupVersionKind()
+	return i.Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
 func (i *InvAddTask) sendTaskResult(taskContext *taskrunner.TaskContext, err error) {

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -124,16 +124,6 @@ var pod3Info = &resource.Info{
 	Object: pod3,
 }
 
-var inventoryNamespace = &unstructured.Unstructured{
-	Object: map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Namespace",
-		"metadata": map[string]interface{}{
-			"name": testNamespace,
-		},
-	},
-}
-
 func TestFindInventoryObj(t *testing.T) {
 	tests := map[string]struct {
 		infos  []*unstructured.Unstructured

--- a/test/e2e/name_inv_strategy_test.go
+++ b/test/e2e/name_inv_strategy_test.go
@@ -47,5 +47,7 @@ func applyWithExistingInvTest(ctx context.Context, c client.Client, invConfig in
 
 	By("Verify that we get the correct error")
 	Expect(err).To(HaveOccurred())
-	Expect(err.Error()).To(ContainSubstring("inventory-id of inventory object in cluster doesn't match provided id"))
+	Expect(err.Error()).To(ContainSubstring(
+		fmt.Sprintf("inventory-id of inventory object %s/%s in cluster doesn't match provided id",
+			namespaceName, inventoryName)))
 }


### PR DESCRIPTION
The Client interface had several repetetive and/or extraneous methods which would make it more cumbersome to create different implementations of the interface. This trims down the interface to a core set of methods which are necessary for the applier.

Removed Client methods:
- ApplyInventoryNamespace -> InvAddTask.createNamespace
- GetClusterInventoryInfo -> ClusterClient.getClusterInventoryInfo
- GetClusterInventoryObjs -> ClusterClient.getClusterInventoryObjs
- ListClusterInventoryObjs -> Runner.listClusterInventoryObjs