### PR TITLE
fix: pass context throughout applier

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func main() {
 		destroy.Command(f, invFactory, loader, ioStreams),
 		diff.NewCommand(f, ioStreams),
 		preview.Command(f, invFactory, loader, ioStreams),
-		status.Command(context.TODO(), f, invFactory, status.NewInventoryLoader(loader)),
+		status.Command(cmd.Context(), f, invFactory, status.NewInventoryLoader(loader)),
 	}
 	for _, subCmd := range subCmds {
 		subCmd.PreRunE = preRunE

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -164,7 +164,7 @@ func (r *Runner) loadInvFromDisk(cmd *cobra.Command, args []string) (*printer.Pr
 
 	// Based on the inventory template manifest we look up the inventory
 	// from the live state using the inventory client.
-	identifiers, err := invClient.GetClusterObjs(inv)
+	identifiers, err := invClient.GetClusterObjs(cmd.Context(), inv)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apply/applier_test.go
+++ b/pkg/apply/applier_test.go
@@ -1943,7 +1943,7 @@ func TestApplierCancel(t *testing.T) {
 
 func TestReadAndPrepareObjectsNilInv(t *testing.T) {
 	applier := Applier{}
-	_, _, err := applier.prepareObjects(nil, object.UnstructuredSet{}, ApplierOptions{})
+	_, _, err := applier.prepareObjects(t.Context(), nil, object.UnstructuredSet{}, ApplierOptions{})
 	assert.Error(t, err)
 }
 
@@ -2050,7 +2050,7 @@ func TestReadAndPrepareObjects(t *testing.T) {
 				watcher.BlindStatusWatcher{},
 			)
 
-			applyObjs, pruneObjs, err := applier.prepareObjects(tc.invInfo.toWrapped(), tc.resources, ApplierOptions{})
+			applyObjs, pruneObjs, err := applier.prepareObjects(t.Context(), tc.invInfo.toWrapped(), tc.resources, ApplierOptions{})
 			if tc.isError {
 				assert.Error(t, err)
 				return

--- a/pkg/apply/destroyer.go
+++ b/pkg/apply/destroyer.go
@@ -82,7 +82,7 @@ func (d *Destroyer) Run(ctx context.Context, invInfo inventory.Info, options Des
 		// Retrieve the objects to be deleted from the cluster. Second parameter is empty
 		// because no local objects returns all inventory objects for deletion.
 		emptyLocalObjs := object.UnstructuredSet{}
-		deleteObjs, err := d.pruner.GetPruneObjs(invInfo, emptyLocalObjs, prune.Options{
+		deleteObjs, err := d.pruner.GetPruneObjs(ctx, invInfo, emptyLocalObjs, prune.Options{
 			DryRunStrategy: options.DryRunStrategy,
 		})
 		if err != nil {
@@ -101,7 +101,7 @@ func (d *Destroyer) Run(ctx context.Context, invInfo inventory.Info, options Des
 
 		// Build a TaskContext for passing info between tasks
 		resourceCache := cache.NewResourceCacheMap()
-		taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
+		taskContext := taskrunner.NewTaskContext(ctx, eventChannel, resourceCache)
 
 		klog.V(4).Infoln("destroyer building task queue...")
 		deleteFilters := []filter.ValidationFilter{

--- a/pkg/apply/filter/current-uids-filter.go
+++ b/pkg/apply/filter/current-uids-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,7 +26,7 @@ func (cuf CurrentUIDFilter) Name() string {
 
 // Filter returns a ApplyPreventedDeletionError if the object prune/delete
 // should be skipped.
-func (cuf CurrentUIDFilter) Filter(obj *unstructured.Unstructured) error {
+func (cuf CurrentUIDFilter) Filter(_ context.Context, obj *unstructured.Unstructured) error {
 	uid := obj.GetUID()
 	if cuf.CurrentUIDs.Has(string(uid)) {
 		return &ApplyPreventedDeletionError{UID: uid}

--- a/pkg/apply/filter/current-uids-filter_test.go
+++ b/pkg/apply/filter/current-uids-filter_test.go
@@ -48,7 +48,7 @@ func TestCurrentUIDFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetUID(types.UID(tc.objUID))
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/dependency-filter.go
+++ b/pkg/apply/filter/dependency-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func (dnrf DependencyFilter) Name() string {
 // Typed Errors:
 // - DependencyPreventedActuationError
 // - DependencyActuationMismatchError
-func (dnrf DependencyFilter) Filter(obj *unstructured.Unstructured) error {
+func (dnrf DependencyFilter) Filter(_ context.Context, obj *unstructured.Unstructured) error {
 	id := object.UnstructuredToObjMetadata(obj)
 
 	switch dnrf.ActuationStrategy {

--- a/pkg/apply/filter/dependency-filter_test.go
+++ b/pkg/apply/filter/dependency-filter_test.go
@@ -529,7 +529,7 @@ func TestDependencyFilter(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			taskContext := taskrunner.NewTaskContext(nil, nil)
+			taskContext := taskrunner.NewTaskContext(t.Context(), nil, nil)
 			tc.contextSetup(taskContext)
 
 			filter := DependencyFilter{
@@ -542,7 +542,7 @@ func TestDependencyFilter(t *testing.T) {
 			obj.SetName(tc.id.Name)
 			obj.SetNamespace(tc.id.Namespace)
 
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/filter.go
+++ b/pkg/apply/filter/filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -16,5 +18,5 @@ type ValidationFilter interface {
 	Name() string
 	// Filter returns an error if validation fails, indicating that actuation
 	// should be skipped for this object.
-	Filter(obj *unstructured.Unstructured) error
+	Filter(ctx context.Context, obj *unstructured.Unstructured) error
 }

--- a/pkg/apply/filter/inventory-policy-apply-filter.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter.go
@@ -33,13 +33,13 @@ func (ipaf InventoryPolicyApplyFilter) Name() string {
 
 // Filter returns an inventory.PolicyPreventedActuationError if the object
 // apply should be skipped.
-func (ipaf InventoryPolicyApplyFilter) Filter(obj *unstructured.Unstructured) error {
+func (ipaf InventoryPolicyApplyFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) error {
 	// optimization to avoid unnecessary API calls
 	if ipaf.InvPolicy == inventory.PolicyAdoptAll {
 		return nil
 	}
 	// Object must be retrieved from the cluster to get the inventory id.
-	clusterObj, err := ipaf.getObject(object.UnstructuredToObjMetadata(obj))
+	clusterObj, err := ipaf.getObject(ctx, object.UnstructuredToObjMetadata(obj))
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// This simply means the object hasn't been created yet.
@@ -55,7 +55,7 @@ func (ipaf InventoryPolicyApplyFilter) Filter(obj *unstructured.Unstructured) er
 }
 
 // getObject retrieves the passed object from the cluster, or an error if one occurred.
-func (ipaf InventoryPolicyApplyFilter) getObject(id object.ObjMetadata) (*unstructured.Unstructured, error) {
+func (ipaf InventoryPolicyApplyFilter) getObject(ctx context.Context, id object.ObjMetadata) (*unstructured.Unstructured, error) {
 	mapping, err := ipaf.Mapper.RESTMapping(id.GroupKind)
 	if err != nil {
 		return nil, err
@@ -64,5 +64,5 @@ func (ipaf InventoryPolicyApplyFilter) getObject(id object.ObjMetadata) (*unstru
 	if err != nil {
 		return nil, err
 	}
-	return namespacedClient.Get(context.TODO(), id.Name, metav1.GetOptions{})
+	return namespacedClient.Get(ctx, id.Name, metav1.GetOptions{})
 }

--- a/pkg/apply/filter/inventory-policy-apply-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter_test.go
@@ -105,7 +105,7 @@ func TestInventoryPolicyApplyFilter(t *testing.T) {
 				Inv:       inventory.WrapInventoryInfoObj(invObj),
 				InvPolicy: tc.policy,
 			}
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/inventory-policy-prune-filter.go
+++ b/pkg/apply/filter/inventory-policy-prune-filter.go
@@ -4,6 +4,8 @@
 package filter
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
@@ -23,7 +25,7 @@ func (ipf InventoryPolicyPruneFilter) Name() string {
 
 // Filter returns an inventory.PolicyPreventedActuationError if the object
 // prune/delete should be skipped.
-func (ipf InventoryPolicyPruneFilter) Filter(obj *unstructured.Unstructured) error {
+func (ipf InventoryPolicyPruneFilter) Filter(_ context.Context, obj *unstructured.Unstructured) error {
 	_, err := inventory.CanPrune(ipf.Inv, obj, ipf.InvPolicy)
 	if err != nil {
 		return err

--- a/pkg/apply/filter/inventory-policy-prune-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-prune-filter_test.go
@@ -99,7 +99,7 @@ func TestInventoryPolicyPruneFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(objIDAnnotation)
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/local-namespaces-filter.go
+++ b/pkg/apply/filter/local-namespaces-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +31,7 @@ func (lnf LocalNamespacesFilter) Name() string {
 
 // Filter returns a NamespaceInUseError if the object prune/delete should be
 // skipped.
-func (lnf LocalNamespacesFilter) Filter(obj *unstructured.Unstructured) error {
+func (lnf LocalNamespacesFilter) Filter(_ context.Context, obj *unstructured.Unstructured) error {
 	id := object.UnstructuredToObjMetadata(obj)
 	if id.GroupKind == namespaceGK &&
 		lnf.LocalNamespaces.Has(id.Name) {

--- a/pkg/apply/filter/local-namespaces-filter_test.go
+++ b/pkg/apply/filter/local-namespaces-filter_test.go
@@ -51,7 +51,7 @@ func TestLocalNamespacesFilter(t *testing.T) {
 			}
 			obj := testNamespace.DeepCopy()
 			obj.SetName(tc.namespace)
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/prevent-remove-filter.go
+++ b/pkg/apply/filter/prevent-remove-filter.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,7 +26,7 @@ func (prf PreventRemoveFilter) Name() string {
 
 // Filter returns a AnnotationPreventedDeletionError if the object prune/delete
 // should be skipped.
-func (prf PreventRemoveFilter) Filter(obj *unstructured.Unstructured) error {
+func (prf PreventRemoveFilter) Filter(_ context.Context, obj *unstructured.Unstructured) error {
 	for annotation, value := range obj.GetAnnotations() {
 		if common.NoDeletion(annotation, value) {
 			return &AnnotationPreventedDeletionError{

--- a/pkg/apply/filter/prevent-remove-filter_test.go
+++ b/pkg/apply/filter/prevent-remove-filter_test.go
@@ -73,7 +73,7 @@ func TestPreventDeleteAnnotation(t *testing.T) {
 			filter := PreventRemoveFilter{}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(tc.annotations)
-			err := filter.Filter(obj)
+			err := filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/mutator/apply_time_mutator_test.go
+++ b/pkg/apply/mutator/apply_time_mutator_test.go
@@ -585,7 +585,7 @@ func TestMutate(t *testing.T) {
 				}
 			}()
 
-			mutated, reason, err := mutator.Mutate(context.TODO(), tc.target)
+			mutated, reason, err := mutator.Mutate(t.Context(), tc.target)
 			if tc.errMsg != "" {
 				require.EqualError(t, err, tc.errMsg)
 			} else {

--- a/pkg/apply/prune/prune.go
+++ b/pkg/apply/prune/prune.go
@@ -87,9 +87,9 @@ type Options struct {
 //	taskName - name of the parent task group, for events
 //	opts - options for dry-run
 func (p *Pruner) Prune(
+	taskContext *taskrunner.TaskContext,
 	objs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter,
-	taskContext *taskrunner.TaskContext,
 	taskName string,
 	opts Options,
 ) error {
@@ -117,7 +117,7 @@ func (p *Pruner) Prune(
 		var filterErr error
 		for _, pruneFilter := range pruneFilters {
 			klog.V(6).Infof("prune filter evaluating (filter: %s, object: %s)", pruneFilter.Name(), id)
-			filterErr = pruneFilter.Filter(obj)
+			filterErr = pruneFilter.Filter(taskContext.Context(), obj)
 			if filterErr != nil {
 				var fatalErr *filter.FatalError
 				if errors.As(filterErr, &fatalErr) {
@@ -137,7 +137,7 @@ func (p *Pruner) Prune(
 				if errors.As(filterErr, &abandonErr) {
 					if !opts.DryRunStrategy.ClientOrServerDryRun() {
 						var err error
-						obj, err = p.removeInventoryAnnotation(obj)
+						obj, err = p.removeInventoryAnnotation(taskContext.Context(), obj)
 						if err != nil {
 							if klog.V(4).Enabled() {
 								// only log event emitted errors if the verbosity > 4
@@ -177,7 +177,7 @@ func (p *Pruner) Prune(
 		// Filters passed--actually delete object if not dry run.
 		if !opts.DryRunStrategy.ClientOrServerDryRun() {
 			klog.V(4).Infof("deleting object (object: %q)", id)
-			err := p.deleteObject(id, metav1.DeleteOptions{
+			err := p.deleteObject(taskContext.Context(), id, metav1.DeleteOptions{
 				// Only delete the resource if it hasn't already been deleted
 				// and recreated since the last GET. Otherwise error.
 				Preconditions: &metav1.Preconditions{
@@ -207,7 +207,7 @@ func (p *Pruner) Prune(
 }
 
 // removeInventoryAnnotation removes the `config.k8s.io/owning-inventory` annotation from pruneObj.
-func (p *Pruner) removeInventoryAnnotation(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (p *Pruner) removeInventoryAnnotation(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	// Make a copy of the input object to avoid modifying the input.
 	// This prevents race conditions when writing to the underlying map.
 	obj = obj.DeepCopy()
@@ -222,7 +222,7 @@ func (p *Pruner) removeInventoryAnnotation(obj *unstructured.Unstructured) (*uns
 			if err != nil {
 				return obj, err
 			}
-			_, err = namespacedClient.Update(context.TODO(), obj, metav1.UpdateOptions{})
+			_, err = namespacedClient.Update(ctx, obj, metav1.UpdateOptions{})
 			return obj, err
 		}
 	}
@@ -234,12 +234,13 @@ func (p *Pruner) removeInventoryAnnotation(obj *unstructured.Unstructured) (*uns
 // objects minus the set of currently applied objects. Returns an error
 // if one occurs.
 func (p *Pruner) GetPruneObjs(
+	ctx context.Context,
 	inv inventory.Info,
 	objs object.UnstructuredSet,
 	opts Options,
 ) (object.UnstructuredSet, error) {
 	ids := object.UnstructuredSetToObjMetadataSet(objs)
-	invIDs, err := p.InvClient.GetClusterObjs(inv)
+	invIDs, err := p.InvClient.GetClusterObjs(ctx, inv)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (p *Pruner) GetPruneObjs(
 	ids = invIDs.Diff(ids)
 	objs = object.UnstructuredSet{}
 	for _, id := range ids {
-		pruneObj, err := p.getObject(id)
+		pruneObj, err := p.getObject(ctx, id)
 		if err != nil {
 			if meta.IsNoMatchError(err) {
 				klog.V(4).Infof("skip pruning (object: %q): resource type not registered", id)
@@ -264,20 +265,20 @@ func (p *Pruner) GetPruneObjs(
 	return objs, nil
 }
 
-func (p *Pruner) getObject(id object.ObjMetadata) (*unstructured.Unstructured, error) {
+func (p *Pruner) getObject(ctx context.Context, id object.ObjMetadata) (*unstructured.Unstructured, error) {
 	namespacedClient, err := p.namespacedClient(id)
 	if err != nil {
 		return nil, err
 	}
-	return namespacedClient.Get(context.TODO(), id.Name, metav1.GetOptions{})
+	return namespacedClient.Get(ctx, id.Name, metav1.GetOptions{})
 }
 
-func (p *Pruner) deleteObject(id object.ObjMetadata, opts metav1.DeleteOptions) error {
+func (p *Pruner) deleteObject(ctx context.Context, id object.ObjMetadata, opts metav1.DeleteOptions) error {
 	namespacedClient, err := p.namespacedClient(id)
 	if err != nil {
 		return err
 	}
-	return namespacedClient.Delete(context.TODO(), id.Name, opts)
+	return namespacedClient.Delete(ctx, id.Name, opts)
 }
 
 func (p *Pruner) namespacedClient(id object.ObjMetadata) (dynamic.ResourceInterface, error) {

--- a/pkg/apply/solver/solver.go
+++ b/pkg/apply/solver/solver.go
@@ -213,7 +213,7 @@ func (t *TaskQueueBuilder) Build(taskContext *taskrunner.TaskContext, o Options)
 		}
 	}
 
-	prevInvIDs, _ := t.InvClient.GetClusterObjs(t.invInfo)
+	prevInvIDs, _ := t.InvClient.GetClusterObjs(taskContext.Context(), t.invInfo)
 	klog.V(2).Infoln("adding delete/update inventory task")
 	var taskName string
 	if o.Destroy {
@@ -278,7 +278,7 @@ func (t *TaskQueueBuilder) newPruneTask(pruneObjs object.UnstructuredSet,
 	pruneFilters []filter.ValidationFilter, o Options) taskrunner.Task {
 	pruneObjs = t.Collector.FilterInvalidObjects(pruneObjs)
 	klog.V(2).Infof("adding prune task (%d objects)", len(pruneObjs))
-	task := &task.PruneTask{
+	pruneTask := &task.PruneTask{
 		TaskName:          fmt.Sprintf("prune-%d", t.pruneCounter),
 		Objects:           pruneObjs,
 		Filters:           pruneFilters,
@@ -288,5 +288,5 @@ func (t *TaskQueueBuilder) newPruneTask(pruneObjs object.UnstructuredSet,
 		Destroy:           o.Destroy,
 	}
 	t.pruneCounter++
-	return task
+	return pruneTask
 }

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -817,7 +817,7 @@ func TestTaskQueueBuilder_ApplyBuild(t *testing.T) {
 				InvClient: fakeInvClient,
 				Collector: vCollector,
 			}
-			taskContext := taskrunner.NewTaskContext(nil, nil)
+			taskContext := taskrunner.NewTaskContext(t.Context(), nil, nil)
 			tq := tqb.WithInventory(invInfo).
 				WithApplyObjects(tc.applyObjs).
 				Build(taskContext, tc.options)
@@ -1493,7 +1493,7 @@ func TestTaskQueueBuilder_PruneBuild(t *testing.T) {
 				InvClient: fakeInvClient,
 				Collector: vCollector,
 			}
-			taskContext := taskrunner.NewTaskContext(nil, nil)
+			taskContext := taskrunner.NewTaskContext(t.Context(), nil, nil)
 			tq := tqb.WithInventory(invInfo).
 				WithPruneObjects(tc.pruneObjs).
 				Build(taskContext, tc.options)
@@ -1848,7 +1848,7 @@ func TestTaskQueueBuilder_ApplyPruneBuild(t *testing.T) {
 				InvClient: fakeInvClient,
 				Collector: vCollector,
 			}
-			taskContext := taskrunner.NewTaskContext(nil, nil)
+			taskContext := taskrunner.NewTaskContext(t.Context(), nil, nil)
 			tq := tqb.WithInventory(invInfo).
 				WithApplyObjects(tc.applyObjs).
 				WithPruneObjects(tc.pruneObjs).

--- a/pkg/apply/task/apply_task.go
+++ b/pkg/apply/task/apply_task.go
@@ -87,8 +87,7 @@ func (a *ApplyTask) Identifiers() object.ObjMetadataSet {
 // the desired state of a resource is changed.
 func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 	go func() {
-		// TODO: pipe Context through TaskContext
-		ctx := context.TODO()
+		ctx := taskContext.Context()
 		objects := a.Objects
 		klog.V(2).Infof("apply task starting (name: %q, objects: %d)",
 			a.Name(), len(objects))
@@ -115,7 +114,7 @@ func (a *ApplyTask) Start(taskContext *taskrunner.TaskContext) {
 			var filterErr error
 			for _, applyFilter := range a.Filters {
 				klog.V(6).Infof("apply filter evaluating (filter: %s, object: %s)", applyFilter.Name(), id)
-				filterErr = applyFilter.Filter(obj)
+				filterErr = applyFilter.Filter(taskContext.Context(), obj)
 				if filterErr != nil {
 					var fatalErr *filter.FatalError
 					if errors.As(filterErr, &fatalErr) {

--- a/pkg/apply/task/apply_task_test.go
+++ b/pkg/apply/task/apply_task_test.go
@@ -81,7 +81,7 @@ func TestApplyTask_BasicAppliedObjects(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			defer close(eventChannel)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
+			taskContext := taskrunner.NewTaskContext(t.Context(), eventChannel, resourceCache)
 
 			objs := toUnstructureds(tc.applied)
 
@@ -173,7 +173,7 @@ func TestApplyTask_FetchGeneration(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			defer close(eventChannel)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
+			taskContext := taskrunner.NewTaskContext(t.Context(), eventChannel, resourceCache)
 
 			objs := toUnstructureds(tc.rss)
 
@@ -286,7 +286,7 @@ func TestApplyTask_DryRun(t *testing.T) {
 			t.Run(tn, func(t *testing.T) {
 				eventChannel := make(chan event.Event)
 				resourceCache := cache.NewResourceCacheMap()
-				taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
+				taskContext := taskrunner.NewTaskContext(t.Context(), eventChannel, resourceCache)
 
 				restMapper := testutil.NewFakeRESTMapper(schema.GroupVersionKind{
 					Group:   "apps",
@@ -435,7 +435,7 @@ func TestApplyTaskWithError(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := taskrunner.NewTaskContext(eventChannel, resourceCache)
+			taskContext := taskrunner.NewTaskContext(t.Context(), eventChannel, resourceCache)
 
 			restMapper := testutil.NewFakeRESTMapper(schema.GroupVersionKind{
 				Group:   "apps",

--- a/pkg/apply/task/inv_add_task.go
+++ b/pkg/apply/task/inv_add_task.go
@@ -62,7 +62,7 @@ func (i *InvAddTask) Start(taskContext *taskrunner.TaskContext) {
 		// If the inventory is namespaced, ensure the namespace exists
 		if i.InvInfo.Namespace() != "" {
 			if invNamespace := inventoryNamespaceInSet(i.InvInfo, i.Objects); invNamespace != nil {
-				if err := i.createNamespace(context.TODO(), invNamespace, i.DryRun); err != nil {
+				if err := i.createNamespace(taskContext.Context(), invNamespace, i.DryRun); err != nil {
 					err = fmt.Errorf("failed to create inventory namespace: %w", err)
 					i.sendTaskResult(taskContext, err)
 					return
@@ -71,7 +71,7 @@ func (i *InvAddTask) Start(taskContext *taskrunner.TaskContext) {
 		}
 		klog.V(4).Infof("merging %d local objects into inventory", len(i.Objects))
 		currentObjs := object.UnstructuredSetToObjMetadataSet(i.Objects)
-		_, err := i.InvClient.Merge(i.InvInfo, currentObjs, i.DryRun)
+		_, err := i.InvClient.Merge(taskContext.Context(), i.InvInfo, currentObjs, i.DryRun)
 		i.sendTaskResult(taskContext, err)
 	}()
 }

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -132,7 +132,7 @@ func TestInvAddTask(t *testing.T) {
 			client := inventory.NewFakeClient(tc.initialObjs)
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			context := taskrunner.NewTaskContext(eventChannel, resourceCache)
+			taskContext := taskrunner.NewTaskContext(t.Context(), eventChannel, resourceCache)
 			tf := cmdtesting.NewTestFactory().WithNamespace(namespace)
 			defer tf.Cleanup()
 
@@ -162,12 +162,12 @@ func TestInvAddTask(t *testing.T) {
 			if !task.Identifiers().Equal(applyIDs) {
 				t.Errorf("expected task ids (%s), got (%s)", applyIDs, task.Identifiers())
 			}
-			task.Start(context)
-			result := <-context.TaskChannel()
+			task.Start(taskContext)
+			result := <-taskContext.TaskChannel()
 			if result.Err != nil {
 				t.Errorf("unexpected error running InvAddTask: %s", result.Err)
 			}
-			actual, _ := client.GetClusterObjs(nil)
+			actual, _ := client.GetClusterObjs(t.Context(), nil)
 			if !tc.expectedObjs.Equal(actual) {
 				t.Errorf("expected merged inventory (%s), got (%s)", tc.expectedObjs, actual)
 			}

--- a/pkg/apply/task/prune_task.go
+++ b/pkg/apply/task/prune_task.go
@@ -61,9 +61,9 @@ func (p *PruneTask) Start(taskContext *taskrunner.TaskContext) {
 		}
 		p.Filters = append(p.Filters, uidFilter)
 		err := p.Pruner.Prune(
+			taskContext,
 			p.Objects,
 			p.Filters,
-			taskContext,
 			p.Name(),
 			prune.Options{
 				DryRunStrategy:    p.DryRunStrategy,

--- a/pkg/apply/taskrunner/condition_test.go
+++ b/pkg/apply/taskrunner/condition_test.go
@@ -153,7 +153,7 @@ func TestCollector_ConditionMet(t *testing.T) {
 				resourceCache.Load(tc.cacheContents...)
 			}
 
-			taskContext := NewTaskContext(nil, resourceCache)
+			taskContext := NewTaskContext(t.Context(), nil, resourceCache)
 
 			if tc.appliedGen != nil {
 				for id, gen := range tc.appliedGen {

--- a/pkg/apply/taskrunner/context.go
+++ b/pkg/apply/taskrunner/context.go
@@ -4,6 +4,8 @@
 package taskrunner
 
 import (
+	"context"
+
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
@@ -13,8 +15,9 @@ import (
 )
 
 // NewTaskContext returns a new TaskContext
-func NewTaskContext(eventChannel chan event.Event, resourceCache cache.ResourceCache) *TaskContext {
+func NewTaskContext(ctx context.Context, eventChannel chan event.Event, resourceCache cache.ResourceCache) *TaskContext {
 	return &TaskContext{
+		context:          ctx,
 		taskChannel:      make(chan TaskResult),
 		eventChannel:     eventChannel,
 		resourceCache:    resourceCache,
@@ -28,6 +31,7 @@ func NewTaskContext(eventChannel chan event.Event, resourceCache cache.ResourceC
 // TaskContext defines a context that is passed between all
 // the tasks that is in a taskqueue.
 type TaskContext struct {
+	context          context.Context
 	taskChannel      chan TaskResult
 	eventChannel     chan event.Event
 	resourceCache    cache.ResourceCache
@@ -35,6 +39,10 @@ type TaskContext struct {
 	abandonedObjects map[object.ObjMetadata]struct{}
 	invalidObjects   map[object.ObjMetadata]struct{}
 	graph            *graph.Graph
+}
+
+func (tc *TaskContext) Context() context.Context {
+	return tc.context
 }
 
 func (tc *TaskContext) TaskChannel() chan TaskResult {

--- a/pkg/apply/taskrunner/runner_test.go
+++ b/pkg/apply/taskrunner/runner_test.go
@@ -280,7 +280,7 @@ func TestBaseRunner(t *testing.T) {
 			statusWatcher := newFakeWatcher(tc.statusEvents)
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := NewTaskContext(eventChannel, resourceCache)
+			taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 			runner := NewTaskStatusRunner(ids, statusWatcher)
 
 			// Use a WaitGroup to make sure changes in the goroutines
@@ -452,7 +452,7 @@ func TestBaseRunnerCancellation(t *testing.T) {
 			statusWatcher := newFakeWatcher(tc.statusEvents)
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := NewTaskContext(eventChannel, resourceCache)
+			taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 			runner := NewTaskStatusRunner(ids, statusWatcher)
 
 			// Use a WaitGroup to make sure changes in the goroutines

--- a/pkg/apply/taskrunner/task_test.go
+++ b/pkg/apply/taskrunner/task_test.go
@@ -85,7 +85,7 @@ func TestWaitTask_CompleteEventually(t *testing.T) {
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
-	taskContext := NewTaskContext(eventChannel, resourceCache)
+	taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 	defer close(eventChannel)
 
 	// Update metadata on successfully applied objects
@@ -273,7 +273,7 @@ func TestWaitTask_Timeout(t *testing.T) {
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
-	taskContext := NewTaskContext(eventChannel, resourceCache)
+	taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 	defer close(eventChannel)
 
 	// Update metadata on successfully applied objects
@@ -438,7 +438,7 @@ func TestWaitTask_StartAndComplete(t *testing.T) {
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
-	taskContext := NewTaskContext(eventChannel, resourceCache)
+	taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 	defer close(eventChannel)
 
 	// Update metadata on successfully applied objects
@@ -523,7 +523,7 @@ func TestWaitTask_Cancel(t *testing.T) {
 
 	eventChannel := make(chan event.Event)
 	resourceCache := cache.NewResourceCacheMap()
-	taskContext := NewTaskContext(eventChannel, resourceCache)
+	taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 	defer close(eventChannel)
 
 	// Update metadata on successfully applied objects
@@ -611,7 +611,7 @@ func TestWaitTask_SingleTaskResult(t *testing.T) {
 	// buffer events, because they're sent by StatusUpdate
 	eventChannel := make(chan event.Event, 10)
 	resourceCache := cache.NewResourceCacheMap()
-	taskContext := NewTaskContext(eventChannel, resourceCache)
+	taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 	defer close(eventChannel)
 
 	// Update metadata on successfully applied objects
@@ -1115,7 +1115,7 @@ func TestWaitTask_Failed(t *testing.T) {
 
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := NewTaskContext(eventChannel, resourceCache)
+			taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 			defer close(eventChannel)
 
 			tc.configureTaskContextFunc(taskContext)
@@ -1365,7 +1365,7 @@ func TestWaitTask_UIDChanged(t *testing.T) {
 
 			eventChannel := make(chan event.Event)
 			resourceCache := cache.NewResourceCacheMap()
-			taskContext := NewTaskContext(eventChannel, resourceCache)
+			taskContext := NewTaskContext(t.Context(), eventChannel, resourceCache)
 			defer close(eventChannel)
 
 			tc.configureTaskContextFunc(taskContext)

--- a/pkg/inventory/fake-inventory-client.go
+++ b/pkg/inventory/fake-inventory-client.go
@@ -40,7 +40,7 @@ func NewFakeClient(initObjs object.ObjMetadataSet) *FakeClient {
 }
 
 // GetClusterObjs returns currently stored set of objects.
-func (fic *FakeClient) GetClusterObjs(Info) (object.ObjMetadataSet, error) {
+func (fic *FakeClient) GetClusterObjs(context.Context, Info) (object.ObjMetadataSet, error) {
 	if fic.Err != nil {
 		return object.ObjMetadataSet{}, fic.Err
 	}
@@ -50,7 +50,7 @@ func (fic *FakeClient) GetClusterObjs(Info) (object.ObjMetadataSet, error) {
 // Merge stores the passed objects with the current stored cluster inventory
 // objects. Returns the set difference of the current set of objects minus
 // the passed set of objects, or an error if one is set up.
-func (fic *FakeClient) Merge(_ Info, objs object.ObjMetadataSet, _ common.DryRunStrategy) (object.ObjMetadataSet, error) {
+func (fic *FakeClient) Merge(_ context.Context, _ Info, objs object.ObjMetadataSet, _ common.DryRunStrategy) (object.ObjMetadataSet, error) {
 	if fic.Err != nil {
 		return object.ObjMetadataSet{}, fic.Err
 	}
@@ -61,7 +61,7 @@ func (fic *FakeClient) Merge(_ Info, objs object.ObjMetadataSet, _ common.DryRun
 
 // Replace the stored cluster inventory objs with the passed obj, or an
 // error if one is set up.
-func (fic *FakeClient) Replace(_ Info, objs object.ObjMetadataSet, status []actuation.ObjectStatus,
+func (fic *FakeClient) Replace(_ context.Context, _ Info, objs object.ObjMetadataSet, status []actuation.ObjectStatus,
 	_ common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
@@ -72,7 +72,7 @@ func (fic *FakeClient) Replace(_ Info, objs object.ObjMetadataSet, status []actu
 }
 
 // DeleteInventoryObj returns an error if one is forced; does nothing otherwise.
-func (fic *FakeClient) DeleteInventoryObj(Info, common.DryRunStrategy) error {
+func (fic *FakeClient) DeleteInventoryObj(context.Context, Info, common.DryRunStrategy) error {
 	if fic.Err != nil {
 		return fic.Err
 	}

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -94,7 +94,7 @@ func TestGetClusterInventoryInfo(t *testing.T) {
 			if tc.inv != nil {
 				inv = storeObjsInInventory(tc.inv, tc.localObjs, tc.objStatus)
 			}
-			clusterInv, err := invClient.getClusterInventoryInfo(WrapInventoryInfoObj(inv))
+			clusterInv, err := invClient.getClusterInventoryInfo(t.Context(), WrapInventoryInfoObj(inv))
 			if tc.isError {
 				if err == nil {
 					t.Fatalf("expected error but received none")
@@ -202,7 +202,7 @@ func TestMerge(t *testing.T) {
 				require.NoError(t, err)
 
 				// Call "Merge" to create the union of clusterObjs and localObjs.
-				pruneObjs, err := invClient.Merge(tc.localInv, tc.localObjs, drs)
+				pruneObjs, err := invClient.Merge(t.Context(), tc.localInv, tc.localObjs, drs)
 				if tc.isError {
 					if err == nil {
 						t.Fatalf("expected error but received none")
@@ -289,11 +289,11 @@ func TestReplace(t *testing.T) {
 	invClient, err := NewClient(tf,
 		WrapInventoryObj, InvInfoToConfigMap, StatusPolicyAll, ConfigMapGVK)
 	require.NoError(t, err)
-	err = invClient.Replace(copyInventory(), object.ObjMetadataSet{}, nil, common.DryRunClient)
+	err = invClient.Replace(t.Context(), copyInventory(), object.ObjMetadataSet{}, nil, common.DryRunClient)
 	if err != nil {
 		t.Fatalf("unexpected error received: %s", err)
 	}
-	err = invClient.Replace(copyInventory(), object.ObjMetadataSet{}, nil, common.DryRunServer)
+	err = invClient.Replace(t.Context(), copyInventory(), object.ObjMetadataSet{}, nil, common.DryRunServer)
 	if err != nil {
 		t.Fatalf("unexpected error received: %s", err)
 	}
@@ -375,7 +375,7 @@ func TestGetClusterObjs(t *testing.T) {
 			invClient, err := NewClient(tf,
 				WrapInventoryObj, InvInfoToConfigMap, tc.statusPolicy, ConfigMapGVK)
 			require.NoError(t, err)
-			clusterObjs, err := invClient.GetClusterObjs(tc.localInv)
+			clusterObjs, err := invClient.GetClusterObjs(t.Context(), tc.localInv)
 			if tc.isError {
 				if err == nil {
 					t.Fatalf("expected error but received none")
@@ -442,7 +442,7 @@ func TestDeleteInventoryObj(t *testing.T) {
 				if inv != nil {
 					inv = storeObjsInInventory(tc.inv, tc.localObjs, tc.objStatus)
 				}
-				err = invClient.deleteInventoryObjByName(inv, drs)
+				err = invClient.deleteInventoryObjByName(t.Context(), inv, drs)
 				if err != nil {
 					t.Fatalf("unexpected error received: %s", err)
 				}

--- a/pkg/inventory/inventorycm.go
+++ b/pkg/inventory/inventorycm.go
@@ -134,14 +134,14 @@ func (icm *ConfigMap) GetObject() (*unstructured.Unstructured, error) {
 
 // Apply is an Storage interface function implemented to apply the inventory
 // object. StatusPolicy is not needed since ConfigMaps do not have a status subresource.
-func (icm *ConfigMap) Apply(dc dynamic.Interface, mapper meta.RESTMapper, _ StatusPolicy) error {
+func (icm *ConfigMap) Apply(ctx context.Context, dc dynamic.Interface, mapper meta.RESTMapper, _ StatusPolicy) error {
 	invInfo, namespacedClient, err := icm.getNamespacedClient(dc, mapper)
 	if err != nil {
 		return err
 	}
 
 	// Get cluster object, if exsists.
-	clusterObj, err := namespacedClient.Get(context.TODO(), invInfo.GetName(), metav1.GetOptions{})
+	clusterObj, err := namespacedClient.Get(ctx, invInfo.GetName(), metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -149,19 +149,19 @@ func (icm *ConfigMap) Apply(dc dynamic.Interface, mapper meta.RESTMapper, _ Stat
 	// Create cluster inventory object, if it does not exist on cluster.
 	if clusterObj == nil {
 		klog.V(4).Infof("creating inventory object: %s/%s", invInfo.GetNamespace(), invInfo.GetName())
-		_, err = namespacedClient.Create(context.TODO(), invInfo, metav1.CreateOptions{})
+		_, err = namespacedClient.Create(ctx, invInfo, metav1.CreateOptions{})
 		return err
 	}
 
 	// Update the cluster inventory object instead.
 	klog.V(4).Infof("updating inventory object: %s/%s", invInfo.GetNamespace(), invInfo.GetName())
-	_, err = namespacedClient.Update(context.TODO(), invInfo, metav1.UpdateOptions{})
+	_, err = namespacedClient.Update(ctx, invInfo, metav1.UpdateOptions{})
 	return err
 }
 
 // ApplyWithPrune is a Storage interface function implemented to apply the inventory object with a list of objects
 // to be pruned. StatusPolicy is not needed since ConfigMaps do not have a status subresource.
-func (icm *ConfigMap) ApplyWithPrune(dc dynamic.Interface, mapper meta.RESTMapper, _ StatusPolicy, _ object.ObjMetadataSet) error {
+func (icm *ConfigMap) ApplyWithPrune(ctx context.Context, dc dynamic.Interface, mapper meta.RESTMapper, _ StatusPolicy, _ object.ObjMetadataSet) error {
 	invInfo, namespacedClient, err := icm.getNamespacedClient(dc, mapper)
 	if err != nil {
 		return err
@@ -169,7 +169,7 @@ func (icm *ConfigMap) ApplyWithPrune(dc dynamic.Interface, mapper meta.RESTMappe
 
 	// Update the cluster inventory object.
 	klog.V(4).Infof("updating inventory object: %s/%s", invInfo.GetNamespace(), invInfo.GetName())
-	_, err = namespacedClient.Update(context.TODO(), invInfo, metav1.UpdateOptions{})
+	_, err = namespacedClient.Update(ctx, invInfo, metav1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/inventory/storage.go
+++ b/pkg/inventory/storage.go
@@ -12,6 +12,7 @@
 package inventory
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -40,12 +41,12 @@ type Storage interface {
 	GetObject() (*unstructured.Unstructured, error)
 	// Apply applies the inventory object. This utility function is used
 	// in InventoryClient.Merge and merges the metadata, spec and status.
-	Apply(dynamic.Interface, meta.RESTMapper, StatusPolicy) error
+	Apply(context.Context, dynamic.Interface, meta.RESTMapper, StatusPolicy) error
 	// ApplyWithPrune applies the inventory object with a set of pruneIDs of
 	// objects to be pruned (object.ObjMetadataSet). This function is used in
 	// InventoryClient.Replace. pruneIDs are required for enabling custom logic
 	// handling of multiple ResourceGroup inventories.
-	ApplyWithPrune(dynamic.Interface, meta.RESTMapper, StatusPolicy, object.ObjMetadataSet) error
+	ApplyWithPrune(context.Context, dynamic.Interface, meta.RESTMapper, StatusPolicy, object.ObjMetadataSet) error
 }
 
 // StorageFactoryFunc creates the object which implements the Inventory

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -236,14 +236,14 @@ func (i InventoryCustomType) GetObject() (*unstructured.Unstructured, error) {
 
 // Apply is an Inventory interface function implemented to apply the inventory
 // object.
-func (i InventoryCustomType) Apply(dc dynamic.Interface, mapper meta.RESTMapper, _ inventory.StatusPolicy) error {
+func (i InventoryCustomType) Apply(ctx context.Context, dc dynamic.Interface, mapper meta.RESTMapper, _ inventory.StatusPolicy) error {
 	invInfo, namespacedClient, err := i.getNamespacedClient(dc, mapper)
 	if err != nil {
 		return err
 	}
 
 	// Get cluster object, if exsists.
-	clusterObj, err := namespacedClient.Get(context.TODO(), invInfo.GetName(), metav1.GetOptions{})
+	clusterObj, err := namespacedClient.Get(ctx, invInfo.GetName(), metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -252,10 +252,10 @@ func (i InventoryCustomType) Apply(dc dynamic.Interface, mapper meta.RESTMapper,
 
 	if clusterObj == nil {
 		// Create cluster inventory object, if it does not exist on cluster.
-		appliedObj, err = namespacedClient.Create(context.TODO(), invInfo, metav1.CreateOptions{})
+		appliedObj, err = namespacedClient.Create(ctx, invInfo, metav1.CreateOptions{})
 	} else {
 		// Update the cluster inventory object instead.
-		appliedObj, err = namespacedClient.Update(context.TODO(), invInfo, metav1.UpdateOptions{})
+		appliedObj, err = namespacedClient.Update(ctx, invInfo, metav1.UpdateOptions{})
 	}
 	if err != nil {
 		return err
@@ -263,25 +263,25 @@ func (i InventoryCustomType) Apply(dc dynamic.Interface, mapper meta.RESTMapper,
 
 	// Update status.
 	invInfo.SetResourceVersion(appliedObj.GetResourceVersion())
-	_, err = namespacedClient.UpdateStatus(context.TODO(), invInfo, metav1.UpdateOptions{})
+	_, err = namespacedClient.UpdateStatus(ctx, invInfo, metav1.UpdateOptions{})
 	return err
 }
 
-func (i InventoryCustomType) ApplyWithPrune(dc dynamic.Interface, mapper meta.RESTMapper, _ inventory.StatusPolicy, _ object.ObjMetadataSet) error {
+func (i InventoryCustomType) ApplyWithPrune(ctx context.Context, dc dynamic.Interface, mapper meta.RESTMapper, _ inventory.StatusPolicy, _ object.ObjMetadataSet) error {
 	invInfo, namespacedClient, err := i.getNamespacedClient(dc, mapper)
 	if err != nil {
 		return err
 	}
 
 	// Update the cluster inventory object.
-	appliedObj, err := namespacedClient.Update(context.TODO(), invInfo, metav1.UpdateOptions{})
+	appliedObj, err := namespacedClient.Update(ctx, invInfo, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
 
 	// Update status.
 	invInfo.SetResourceVersion(appliedObj.GetResourceVersion())
-	_, err = namespacedClient.UpdateStatus(context.TODO(), invInfo, metav1.UpdateOptions{})
+	_, err = namespacedClient.UpdateStatus(ctx, invInfo, metav1.UpdateOptions{})
 	return err
 }
 


### PR DESCRIPTION
There were various spots in the applier that were not propagating the context and instead just using an empty context. This change fixes all such locations so that the parent context is always honored.