### PR TITLE
refactor: return error from ConfigMap wrap functions

### DIFF
--- a/cmd/apply/cmdapply.go
+++ b/cmd/apply/cmdapply.go
@@ -129,7 +129,10 @@ func (r *Runner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
+	inv, err := inventory.ConfigMapToInventoryInfo(invObj)
+	if err != nil {
+		return err
+	}
 
 	invClient, err := r.invFactory.NewClient(r.factory)
 	if err != nil {

--- a/cmd/destroy/cmddestroy.go
+++ b/cmd/destroy/cmddestroy.go
@@ -112,7 +112,10 @@ func (r *Runner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
+	inv, err := inventory.ConfigMapToInventoryInfo(invObj)
+	if err != nil {
+		return err
+	}
 
 	invClient, err := r.invFactory.NewClient(r.factory)
 	if err != nil {

--- a/cmd/preview/cmdpreview.go
+++ b/cmd/preview/cmdpreview.go
@@ -124,7 +124,10 @@ func (r *Runner) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
+	inv, err := inventory.ConfigMapToInventoryInfo(invObj)
+	if err != nil {
+		return err
+	}
 
 	invClient, err := r.invFactory.NewClient(r.factory)
 	if err != nil {

--- a/cmd/status/cmdstatus.go
+++ b/cmd/status/cmdstatus.go
@@ -371,6 +371,9 @@ func (ir *InventoryLoader) GetInvInfo(cmd *cobra.Command, args []string) (invent
 	if err != nil {
 		return nil, err
 	}
-	inv := inventory.WrapInventoryInfoObj(invObj)
+	inv, err := inventory.ConfigMapToInventoryInfo(invObj)
+	if err != nil {
+		return nil, err
+	}
 	return inv, nil
 }

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -64,8 +64,8 @@ func (i inventoryInfo) toUnstructured() *unstructured.Unstructured {
 	}
 }
 
-func (i inventoryInfo) toWrapped() inventory.Info {
-	return inventory.WrapInventoryInfoObj(i.toUnstructured())
+func (i inventoryInfo) toWrapped() (inventory.Info, error) {
+	return inventory.ConfigMapToInventoryInfo(i.toUnstructured())
 }
 
 func newTestApplier(

--- a/pkg/apply/destroyer_test.go
+++ b/pkg/apply/destroyer_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/cli-utils/pkg/apply/event"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	pollevent "sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
@@ -313,12 +314,15 @@ func TestDestroyerCancel(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			statusWatcher := newFakeWatcher(tc.statusEvents)
 
-			invInfo := tc.invInfo.toWrapped()
+			invInfo, err := tc.invInfo.toWrapped()
+			require.NoError(t, err)
+			cm, err := inventory.InvInfoToConfigMap(invInfo)
+			require.NoError(t, err)
 
 			destroyer := newTestDestroyer(t,
 				tc.invInfo,
 				// Add the inventory to the cluster (to allow deletion)
-				append(tc.clusterObjs, inventory.InvInfoToConfigMap(invInfo)),
+				append(tc.clusterObjs, cm),
 				statusWatcher,
 			)
 

--- a/pkg/apply/filter/inventory-policy-apply-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter_test.go
@@ -6,6 +6,7 @@ package filter
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -98,14 +99,16 @@ func TestInventoryPolicyApplyFilter(t *testing.T) {
 			}
 			invObj := invObjTemplate.DeepCopy()
 			invObj.SetLabels(invIDLabel)
+			invInfoObj, err := inventory.ConfigMapToInventoryInfo(invObj)
+			require.NoError(t, err)
 			filter := InventoryPolicyApplyFilter{
 				Client: dynamicfake.NewSimpleDynamicClient(scheme.Scheme, obj),
 				Mapper: testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme,
 					scheme.Scheme.PrioritizedVersionsAllGroups()...),
-				Inv:       inventory.WrapInventoryInfoObj(invObj),
+				Inv:       invInfoObj,
 				InvPolicy: tc.policy,
 			}
-			err := filter.Filter(t.Context(), obj)
+			err = filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/filter/inventory-policy-prune-filter_test.go
+++ b/pkg/apply/filter/inventory-policy-prune-filter_test.go
@@ -6,6 +6,7 @@ package filter
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -90,8 +91,10 @@ func TestInventoryPolicyPruneFilter(t *testing.T) {
 			}
 			invObj := inventoryObj.DeepCopy()
 			invObj.SetLabels(invIDLabel)
+			invInfoObj, err := inventory.ConfigMapToInventoryInfo(invObj)
+			require.NoError(t, err)
 			filter := InventoryPolicyPruneFilter{
-				Inv:       inventory.WrapInventoryInfoObj(invObj),
+				Inv:       invInfoObj,
 				InvPolicy: tc.policy,
 			}
 			objIDAnnotation := map[string]string{
@@ -99,7 +102,7 @@ func TestInventoryPolicyPruneFilter(t *testing.T) {
 			}
 			obj := defaultObj.DeepCopy()
 			obj.SetAnnotations(objIDAnnotation)
-			err := filter.Filter(t.Context(), obj)
+			err = filter.Filter(t.Context(), obj)
 			testutil.AssertEqual(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/apply/prune"
@@ -130,8 +131,9 @@ func TestTaskQueueBuilder_ApplyBuild(t *testing.T) {
 		inventoryInfoComparer(),
 	)
 
-	invInfo := inventory.WrapInventoryInfoObj(newInvObject(
+	invInfo, err := inventory.ConfigMapToInventoryInfo(newInvObject(
 		"abc-123", "default", "test"))
+	require.NoError(t, err)
 
 	testCases := map[string]struct {
 		applyObjs      []*unstructured.Unstructured
@@ -844,8 +846,9 @@ func TestTaskQueueBuilder_PruneBuild(t *testing.T) {
 		inventoryInfoComparer(),
 	)
 
-	invInfo := inventory.WrapInventoryInfoObj(newInvObject(
+	invInfo, err := inventory.ConfigMapToInventoryInfo(newInvObject(
 		"abc-123", "default", "test"))
+	require.NoError(t, err)
 
 	testCases := map[string]struct {
 		pruneObjs      []*unstructured.Unstructured
@@ -1520,8 +1523,9 @@ func TestTaskQueueBuilder_ApplyPruneBuild(t *testing.T) {
 		inventoryInfoComparer(),
 	)
 
-	invInfo := inventory.WrapInventoryInfoObj(newInvObject(
+	invInfo, err := inventory.ConfigMapToInventoryInfo(newInvObject(
 		"abc-123", "default", "test"))
+	require.NoError(t, err)
 
 	testCases := map[string]struct {
 		inventoryIDs   object.ObjMetadataSet

--- a/pkg/apply/task/inv_add_task_test.go
+++ b/pkg/apply/task/inv_add_task_test.go
@@ -6,6 +6,7 @@ package task
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
@@ -33,8 +34,6 @@ var inventoryObj = &unstructured.Unstructured{
 		},
 	},
 }
-
-var localInv = inventory.WrapInventoryInfoObj(inventoryObj)
 
 var obj1 = &unstructured.Unstructured{
 	Object: map[string]interface{}{
@@ -82,6 +81,8 @@ var nsObj = &unstructured.Unstructured{
 const taskName = "test-inventory-task"
 
 func TestInvAddTask(t *testing.T) {
+	localInv, err := inventory.ConfigMapToInventoryInfo(inventoryObj)
+	require.NoError(t, err)
 	id1 := object.UnstructuredToObjMetadata(obj1)
 	id2 := object.UnstructuredToObjMetadata(obj2)
 	id3 := object.UnstructuredToObjMetadata(obj3)
@@ -179,6 +180,8 @@ func TestInvAddTask(t *testing.T) {
 }
 
 func TestInventoryNamespaceInSet(t *testing.T) {
+	localInv, err := inventory.ConfigMapToInventoryInfo(inventoryObj)
+	require.NoError(t, err)
 	inventoryNamespace := createNamespace(namespace)
 
 	tests := map[string]struct {

--- a/pkg/inventory/inventory-client-factory.go
+++ b/pkg/inventory/inventory-client-factory.go
@@ -22,5 +22,5 @@ type ClusterClientFactory struct {
 }
 
 func (ccf ClusterClientFactory) NewClient(factory cmdutil.Factory) (Client, error) {
-	return NewClient(factory, WrapInventoryObj, InvInfoToConfigMap, ccf.StatusPolicy, ConfigMapGVK)
+	return NewClient(factory, ConfigMapToInventoryObj, InvInfoToConfigMap, ccf.StatusPolicy, ConfigMapGVK)
 }

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -49,8 +50,6 @@ var legacyInvObj = &unstructured.Unstructured{
 		},
 	},
 }
-
-var localInv = WrapInventoryInfoObj(inventoryObj)
 
 var invInfo = &resource.Info{
 	Namespace: testNamespace,
@@ -416,7 +415,9 @@ func copyInventoryInfo() *unstructured.Unstructured {
 	return inventoryObj.DeepCopy()
 }
 
-func copyInventory() Info {
+func copyInventory(t *testing.T) Info {
 	u := inventoryObj.DeepCopy()
-	return WrapInventoryInfoObj(u)
+	invInfoObj, err := ConfigMapToInventoryInfo(u)
+	require.NoError(t, err)
+	return invInfoObj
 }

--- a/pkg/inventory/inventorycm.go
+++ b/pkg/inventory/inventorycm.go
@@ -31,26 +31,26 @@ var ConfigMapGVK = schema.GroupVersionKind{
 	Version: "v1",
 }
 
-// WrapInventoryObj takes a passed ConfigMap (as a resource.Info),
+// ConfigMapToInventoryObj takes a passed ConfigMap (as a resource.Info),
 // wraps it with the ConfigMap and upcasts the wrapper as
 // an the Inventory interface.
-func WrapInventoryObj(inv *unstructured.Unstructured) Storage {
-	return &ConfigMap{inv: inv}
+func ConfigMapToInventoryObj(inv *unstructured.Unstructured) (Storage, error) {
+	return &ConfigMap{inv: inv}, nil
 }
 
-// WrapInventoryInfoObj takes a passed ConfigMap (as a resource.Info),
+// ConfigMapToInventoryInfo takes a passed ConfigMap (as a resource.Info),
 // wraps it with the ConfigMap and upcasts the wrapper as
 // an the Info interface.
-func WrapInventoryInfoObj(inv *unstructured.Unstructured) Info {
-	return &ConfigMap{inv: inv}
+func ConfigMapToInventoryInfo(inv *unstructured.Unstructured) (Info, error) {
+	return &ConfigMap{inv: inv}, nil
 }
 
-func InvInfoToConfigMap(inv Info) *unstructured.Unstructured {
+func InvInfoToConfigMap(inv Info) (*unstructured.Unstructured, error) {
 	icm, ok := inv.(*ConfigMap)
 	if ok {
-		return icm.inv
+		return icm.inv, nil
 	}
-	return nil
+	return nil, fmt.Errorf("failed to convert to ConfigMap")
 }
 
 // ConfigMap wraps a ConfigMap resource and implements

--- a/pkg/inventory/storage.go
+++ b/pkg/inventory/storage.go
@@ -51,11 +51,11 @@ type Storage interface {
 
 // StorageFactoryFunc creates the object which implements the Inventory
 // interface from the passed info object.
-type StorageFactoryFunc func(*unstructured.Unstructured) Storage
+type StorageFactoryFunc func(*unstructured.Unstructured) (Storage, error)
 
 // ToUnstructuredFunc returns the unstructured object for the
 // given Info.
-type ToUnstructuredFunc func(Info) *unstructured.Unstructured
+type ToUnstructuredFunc func(Info) (*unstructured.Unstructured, error)
 
 // FindInventoryObj returns the "Inventory" object (ConfigMap with
 // inventory label) if it exists, or nil if it does not exist.

--- a/pkg/manifestreader/fake-loader.go
+++ b/pkg/manifestreader/fake-loader.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
@@ -42,9 +41,4 @@ func (f *FakeLoader) ManifestReader(reader io.Reader, _ string) (ManifestReader,
 		Reader:        reader,
 		ReaderOptions: readerOptions,
 	}, nil
-}
-
-func (f *FakeLoader) InventoryInfo(objs []*unstructured.Unstructured) (inventory.Info, []*unstructured.Unstructured, error) {
-	inv, objs, err := inventory.SplitUnstructureds(objs)
-	return inventory.WrapInventoryInfoObj(inv), objs, err
 }

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -116,17 +116,17 @@ func (CustomClientFactory) NewClient(factory util.Factory) (inventory.Client, er
 		WrapInventoryObj, invToUnstructuredFunc, inventory.StatusPolicyAll, inventory.ConfigMapGVK)
 }
 
-func invToUnstructuredFunc(inv inventory.Info) *unstructured.Unstructured {
+func invToUnstructuredFunc(inv inventory.Info) (*unstructured.Unstructured, error) {
 	switch invInfo := inv.(type) {
 	case *InventoryCustomType:
-		return invInfo.inv
+		return invInfo.inv, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("wrong type: want %T but got %T", InventoryCustomType{}, inv)
 	}
 }
 
-func WrapInventoryObj(obj *unstructured.Unstructured) inventory.Storage {
-	return &InventoryCustomType{inv: obj}
+func WrapInventoryObj(obj *unstructured.Unstructured) (inventory.Storage, error) {
+	return &InventoryCustomType{inv: obj}, nil
 }
 
 func WrapInventoryInfoObj(obj *unstructured.Unstructured) inventory.Info {

--- a/test/e2e/invconfig/configmap.go
+++ b/test/e2e/invconfig/configmap.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -17,10 +18,14 @@ import (
 
 func NewConfigMapTypeInvConfig(cfg *rest.Config) InventoryConfig {
 	return InventoryConfig{
-		ClientConfig:         cfg,
-		Strategy:             inventory.LabelStrategy,
-		FactoryFunc:          cmInventoryManifest,
-		InvWrapperFunc:       inventory.WrapInventoryInfoObj,
+		ClientConfig: cfg,
+		Strategy:     inventory.LabelStrategy,
+		FactoryFunc:  cmInventoryManifest,
+		InvWrapperFunc: func(obj *unstructured.Unstructured) inventory.Info {
+			info, err := inventory.ConfigMapToInventoryInfo(obj)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			return info
+		},
 		ApplierFactoryFunc:   newDefaultInvApplierFactory(cfg),
 		DestroyerFactoryFunc: newDefaultInvDestroyerFactory(cfg),
 		InvSizeVerifyFunc:    defaultInvSizeVerifyFunc,


### PR DESCRIPTION
This change is primarily motivated by a subsequent change which replaces the lazy conversion with an immediate conversion, which requires for an error to be returned. Since this touches so many pieces of code this is broken out as a separate change.

This also fixes several places where errors were not being propagated.