### PR TITLE
refactor: rename ClusterClientFactory to ConfigMapClientFactory

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	loader := manifestreader.NewManifestLoader(f)
-	invFactory := inventory.ClusterClientFactory{StatusPolicy: inventory.StatusPolicyNone}
+	invFactory := inventory.ConfigMapClientFactory{StatusPolicy: inventory.StatusPolicyNone}
 
 	names := []string{"init", "apply", "destroy", "diff", "preview", "status"}
 	subCmds := []*cobra.Command{

--- a/pkg/apply/common_test.go
+++ b/pkg/apply/common_test.go
@@ -125,7 +125,7 @@ func newTestInventory(
 ) inventory.Client {
 	// Use an Client with a fakeInfoHelper to allow generating Info
 	// objects that use the FakeRESTClient as the UnstructuredClient.
-	invClient, err := inventory.ClusterClientFactory{StatusPolicy: inventory.StatusPolicyAll}.NewClient(tf)
+	invClient, err := inventory.ConfigMapClientFactory{StatusPolicy: inventory.StatusPolicyAll}.NewClient(tf)
 	require.NoError(t, err)
 	return invClient
 }

--- a/pkg/inventory/configmap-client-factory.go
+++ b/pkg/inventory/configmap-client-factory.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	_ ClientFactory = ClusterClientFactory{}
+	_ ClientFactory = ConfigMapClientFactory{}
 )
 
 // ClientFactory is a factory that constructs new Client instances.
@@ -16,11 +16,12 @@ type ClientFactory interface {
 	NewClient(factory cmdutil.Factory) (Client, error)
 }
 
-// ClusterClientFactory is a factory that creates instances of ClusterClient inventory client.
-type ClusterClientFactory struct {
+// ConfigMapClientFactory is a factory that creates instances of inventory clients
+// which are backed by ConfigMaps.
+type ConfigMapClientFactory struct {
 	StatusPolicy StatusPolicy
 }
 
-func (ccf ClusterClientFactory) NewClient(factory cmdutil.Factory) (Client, error) {
+func (ccf ConfigMapClientFactory) NewClient(factory cmdutil.Factory) (Client, error) {
 	return NewClient(factory, ConfigMapToInventoryObj, InvInfoToConfigMap, ccf.StatusPolicy, ConfigMapGVK)
 }

--- a/test/e2e/invconfig/configmap.go
+++ b/test/e2e/invconfig/configmap.go
@@ -37,7 +37,7 @@ func NewConfigMapTypeInvConfig(cfg *rest.Config) InventoryConfig {
 func newDefaultInvApplierFactory(cfg *rest.Config) applierFactoryFunc {
 	cfgPtrCopy := cfg
 	return func() *apply.Applier {
-		return newApplier(inventory.ClusterClientFactory{
+		return newApplier(inventory.ConfigMapClientFactory{
 			StatusPolicy: inventory.StatusPolicyAll,
 		}, cfgPtrCopy)
 	}
@@ -46,7 +46,7 @@ func newDefaultInvApplierFactory(cfg *rest.Config) applierFactoryFunc {
 func newDefaultInvDestroyerFactory(cfg *rest.Config) destroyerFactoryFunc {
 	cfgPtrCopy := cfg
 	return func() *apply.Destroyer {
-		return newDestroyer(inventory.ClusterClientFactory{
+		return newDestroyer(inventory.ConfigMapClientFactory{
 			StatusPolicy: inventory.StatusPolicyAll,
 		}, cfgPtrCopy)
 	}


### PR DESCRIPTION
The previous name was somewhat misleading, as this factory is specifically for creating a ConfigMap client.