### PR TITLE
test: make CreateInventoryInfo return an error

### DIFF
--- a/test/e2e/apply_and_destroy_test.go
+++ b/test/e2e/apply_and_destroy_test.go
@@ -25,9 +25,10 @@ import (
 func applyAndDestroyTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	deployment1Obj := e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName)
 	resources := []*unstructured.Unstructured{

--- a/test/e2e/continue_on_error_test.go
+++ b/test/e2e/continue_on_error_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
 	. "github.com/onsi/gomega"    //nolint:revive
@@ -28,7 +29,9 @@ func continueOnErrorTest(ctx context.Context, c client.Client, invConfig invconf
 	By("apply an invalid CRD")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inv, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	invalidCrdObj := e2eutil.ManifestToUnstructured(invalidCrd)
 	pod1Obj := e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(pod1), namespaceName)

--- a/test/e2e/crd_test.go
+++ b/test/e2e/crd_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -26,7 +27,9 @@ func crdTest(ctx context.Context, _ client.Client, invConfig invconfig.Inventory
 	By("apply a set of resources that includes both a crd and a cr")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inv, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	crdObj := e2eutil.ManifestToUnstructured(crd)
 	crObj := e2eutil.ManifestToUnstructured(cr)

--- a/test/e2e/current_uid_filter_test.go
+++ b/test/e2e/current_uid_filter_test.go
@@ -59,8 +59,10 @@ type: Warning
 // - inventory should not double-track the object i.e. we should hold reference only to the object with the groupKind that was most recently applied
 func currentUIDFilterTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	applier := invConfig.ApplierFactoryFunc()
+
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	templateFields := struct{ Namespace string }{Namespace: namespaceName}
 	v1Event := e2eutil.TemplateToUnstructured(v1EventTemplate, templateFields)
@@ -70,7 +72,7 @@ func currentUIDFilterTest(ctx context.Context, c client.Client, invConfig invcon
 	resources := []*unstructured.Unstructured{
 		v1Event,
 	}
-	err := e2eutil.Run(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{}))
+	err = e2eutil.Run(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{}))
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Verify resource available in both apiGroups")

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -176,6 +176,6 @@ func fromUnstructured(obj *unstructured.Unstructured) (*inventory.UnstructuredIn
 	return inv, nil
 }
 
-func WrapInventoryInfoObj(obj *unstructured.Unstructured) inventory.Info {
-	return inventory.NewUnstructuredInventory(obj).Info()
+func WrapInventoryInfoObj(obj *unstructured.Unstructured) (inventory.Info, error) {
+	return inventory.NewUnstructuredInventory(obj).Info(), nil
 }

--- a/test/e2e/deletion_prevention_test.go
+++ b/test/e2e/deletion_prevention_test.go
@@ -22,9 +22,10 @@ import (
 func deletionPreventionTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	resources := []*unstructured.Unstructured{
 		e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName),

--- a/test/e2e/dry_run_test.go
+++ b/test/e2e/dry_run_test.go
@@ -26,9 +26,10 @@ import (
 func dryRunTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply with DryRun")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	namespace1Name := fmt.Sprintf("%s-ns1", namespaceName)
 

--- a/test/e2e/empty_set_test.go
+++ b/test/e2e/empty_set_test.go
@@ -25,7 +25,8 @@ func emptySetTest(ctx context.Context, c client.Client, invConfig invconfig.Inve
 	applier := invConfig.ApplierFactoryFunc()
 
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
-	inventoryInfo := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, inventoryID))
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	resources := []*unstructured.Unstructured{}
 

--- a/test/e2e/exit_early_test.go
+++ b/test/e2e/exit_early_test.go
@@ -25,7 +25,9 @@ func exitEarlyTest(ctx context.Context, c client.Client, invConfig invconfig.Inv
 	By("exit early on invalid object")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	fields := struct{ Namespace string }{Namespace: namespaceName}
 	// valid pod
@@ -42,7 +44,7 @@ func exitEarlyTest(ctx context.Context, c client.Client, invConfig invconfig.Inv
 		invalidPodObj,
 	}
 
-	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 		ValidationPolicy: validation.ExitEarly,
 	}))

--- a/test/e2e/invconfig/configmap.go
+++ b/test/e2e/invconfig/configmap.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
@@ -18,13 +17,9 @@ import (
 
 func NewConfigMapTypeInvConfig(cfg *rest.Config) InventoryConfig {
 	return InventoryConfig{
-		ClientConfig: cfg,
-		FactoryFunc:  cmInventoryManifest,
-		InvWrapperFunc: func(obj *unstructured.Unstructured) inventory.Info {
-			info, err := inventory.ConfigMapToInventoryInfo(obj)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
-			return info
-		},
+		ClientConfig:         cfg,
+		FactoryFunc:          cmInventoryManifest,
+		InvWrapperFunc:       inventory.ConfigMapToInventoryInfo,
 		ApplierFactoryFunc:   newDefaultInvApplierFactory(cfg),
 		DestroyerFactoryFunc: newDefaultInvDestroyerFactory(cfg),
 		InvSizeVerifyFunc:    defaultInvSizeVerifyFunc,

--- a/test/e2e/invconfig/invconfig.go
+++ b/test/e2e/invconfig/invconfig.go
@@ -17,7 +17,7 @@ import (
 )
 
 type inventoryFactoryFunc func(name, namespace, id string) *unstructured.Unstructured
-type invWrapperFunc func(*unstructured.Unstructured) inventory.Info
+type invWrapperFunc func(*unstructured.Unstructured) (inventory.Info, error)
 type applierFactoryFunc func() *apply.Applier
 type destroyerFactoryFunc func() *apply.Destroyer
 type invSizeVerifyFunc func(ctx context.Context, c client.Client, name, namespace, id string, specCount, statusCount int)
@@ -35,7 +35,7 @@ type InventoryConfig struct {
 	InvNotExistsFunc     invNotExistsFunc
 }
 
-func CreateInventoryInfo(invConfig InventoryConfig, inventoryName, namespaceName, inventoryID string) inventory.Info {
+func CreateInventoryInfo(invConfig InventoryConfig, inventoryName, namespaceName, inventoryID string) (inventory.Info, error) {
 	return invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, inventoryID))
 }
 

--- a/test/e2e/namespace_filter_test.go
+++ b/test/e2e/namespace_filter_test.go
@@ -26,7 +26,9 @@ func namespaceFilterTest(ctx context.Context, c client.Client, invConfig invconf
 	By("apply resources in order based on depends-on annotation")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	namespace1Name := fmt.Sprintf("%s-ns1", namespaceName)
 
@@ -47,7 +49,7 @@ func namespaceFilterTest(ctx context.Context, c client.Client, invConfig invconf
 		e2eutil.DeleteUnstructuredIfExists(ctx, c, namespace1Obj)
 	}(ctx, c)
 
-	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -243,7 +245,7 @@ func namespaceFilterTest(ctx context.Context, c client.Client, invConfig invconf
 		podBObj,
 	}
 
-	applierEvents = e2eutil.RunCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents = e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 

--- a/test/e2e/prune_retrieve_error_test.go
+++ b/test/e2e/prune_retrieve_error_test.go
@@ -25,15 +25,15 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig invc
 	applier := invConfig.ApplierFactoryFunc()
 
 	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
-
-	inv := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	pod1Obj := e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(pod1), namespaceName)
 	resource1 := []*unstructured.Unstructured{
 		pod1Obj,
 	}
 
-	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inv, resource1, apply.ApplierOptions{
+	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resource1, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -171,7 +171,7 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig invc
 		pod2Obj,
 	}
 
-	applierEvents = e2eutil.RunCollect(applier.Run(ctx, inv, resource2, apply.ApplierOptions{
+	applierEvents = e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resource2, apply.ApplierOptions{
 		EmitStatusEvents: false,
 	}))
 
@@ -307,7 +307,7 @@ func pruneRetrieveErrorTest(ctx context.Context, c client.Client, invConfig invc
 	destroyer := invConfig.DestroyerFactoryFunc()
 
 	options := apply.DestroyerOptions{InventoryPolicy: inventory.PolicyAdoptIfNoInventory}
-	destroyerEvents := e2eutil.RunCollect(destroyer.Run(ctx, inv, options))
+	destroyerEvents := e2eutil.RunCollect(destroyer.Run(ctx, inventoryInfo, options))
 
 	expEvents = []testutil.ExpEvent{
 		{

--- a/test/e2e/reconcile_failed_timeout_test.go
+++ b/test/e2e/reconcile_failed_timeout_test.go
@@ -22,9 +22,10 @@ import (
 func reconciliationFailed(ctx context.Context, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	podObj := e2eutil.WithNodeSelector(e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(pod1), namespaceName), "foo", "bar")
 	resources := []*unstructured.Unstructured{
@@ -45,9 +46,10 @@ func reconciliationFailed(ctx context.Context, invConfig invconfig.InventoryConf
 func reconciliationTimeout(ctx context.Context, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	podObj := e2eutil.PodWithImage(e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(pod1), namespaceName), "kubernetes-pause", "does-not-exist")
 	resources := []*unstructured.Unstructured{

--- a/test/e2e/serverside_apply_test.go
+++ b/test/e2e/serverside_apply_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive
@@ -23,13 +24,16 @@ func serversideApplyTest(ctx context.Context, c client.Client, invConfig invconf
 	By("Apply a Deployment and an APIService by server-side apply")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
+
 	firstResources := []*unstructured.Unstructured{
 		e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName),
 		e2eutil.ManifestToUnstructured(apiservice1),
 	}
 
-	e2eutil.RunWithNoErr(applier.Run(ctx, inv, firstResources, apply.ApplierOptions{
+	e2eutil.RunWithNoErr(applier.Run(ctx, inventoryInfo, firstResources, apply.ApplierOptions{
 		ReconcileTimeout: 2 * time.Minute,
 		EmitStatusEvents: true,
 		ServerSideOptions: common.ServerSideOptions{

--- a/test/e2e/skip_invalid_test.go
+++ b/test/e2e/skip_invalid_test.go
@@ -30,7 +30,9 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig invconfig.I
 	By("apply valid objects and skip invalid objects")
 	applier := invConfig.ApplierFactoryFunc()
 
-	inv := invConfig.InvWrapperFunc(invConfig.FactoryFunc(inventoryName, namespaceName, "test"))
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	fields := struct{ Namespace string }{Namespace: namespaceName}
 	// valid pod
@@ -57,7 +59,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig invconfig.I
 		invalidPodObj,
 	}
 
-	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inv, resources, apply.ApplierOptions{
+	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
 		EmitStatusEvents: false,
 		ValidationPolicy: validation.SkipInvalid,
 	}))
@@ -354,7 +356,7 @@ func skipInvalidTest(ctx context.Context, c client.Client, invConfig invconfig.I
 
 	By("destroy valid objects and skip invalid objects")
 	destroyer := invConfig.DestroyerFactoryFunc()
-	destroyerEvents := e2eutil.RunCollect(destroyer.Run(ctx, inv, apply.DestroyerOptions{
+	destroyerEvents := e2eutil.RunCollect(destroyer.Run(ctx, inventoryInfo, apply.DestroyerOptions{
 		InventoryPolicy:  inventory.PolicyAdoptIfNoInventory,
 		ValidationPolicy: validation.SkipInvalid,
 	}))

--- a/test/stress/thousand_deployments_retry_test.go
+++ b/test/stress/thousand_deployments_retry_test.go
@@ -30,9 +30,10 @@ import (
 func thousandDeploymentsRetryTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply LOTS of resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	resources := []*unstructured.Unstructured{}
 

--- a/test/stress/thousand_deployments_test.go
+++ b/test/stress/thousand_deployments_test.go
@@ -28,9 +28,10 @@ import (
 func thousandDeploymentsTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply LOTS of resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	resources := []*unstructured.Unstructured{}
 

--- a/test/stress/thousand_namespaces_test.go
+++ b/test/stress/thousand_namespaces_test.go
@@ -33,9 +33,10 @@ import (
 func thousandNamespacesTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
 	By("Apply LOTS of resources")
 	applier := invConfig.ApplierFactoryFunc()
-	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
 
-	inventoryInfo := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
 
 	crdObj := e2eutil.ManifestToUnstructured([]byte(cronTabCRDYaml))
 


### PR DESCRIPTION
Instead of a panic, have CreateInventoryInfo and invWrapperFunc return an error, and then check the error in the tests calling these functions.

Take this oportunity to make all the calls more consistent.