### PR TITLE
refactor: rename UnstructuredInv to SingleObjectInv

### DIFF
--- a/pkg/apply/solver/solver_test.go
+++ b/pkg/apply/solver/solver_test.go
@@ -737,7 +737,7 @@ func TestTaskQueueBuilder_ApplyBuild(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			mapper := testutil.NewFakeRESTMapper()
-			inventoryObj := inventory.NewUnstructuredInventory(uObj)
+			inventoryObj := inventory.NewSingleObjectInventory(uObj)
 			// inject mapper for equality comparison
 			for _, t := range tc.expectedTasks {
 				switch typedTask := t.(type) {
@@ -1359,7 +1359,7 @@ func TestTaskQueueBuilder_PruneBuild(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			mapper := testutil.NewFakeRESTMapper()
-			inventoryObj := inventory.NewUnstructuredInventory(uObj)
+			inventoryObj := inventory.NewSingleObjectInventory(uObj)
 			// inject mapper & pruner for equality comparison
 			for _, t := range tc.expectedTasks {
 				switch typedTask := t.(type) {
@@ -1696,7 +1696,7 @@ func TestTaskQueueBuilder_ApplyPruneBuild(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			mapper := testutil.NewFakeRESTMapper()
-			inventoryObj := inventory.NewUnstructuredInventory(uObj)
+			inventoryObj := inventory.NewSingleObjectInventory(uObj)
 			// inject mapper & pruner for equality comparison
 			for _, t := range tc.expectedTasks {
 				switch typedTask := t.(type) {

--- a/pkg/inventory/inventory-client_test.go
+++ b/pkg/inventory/inventory-client_test.go
@@ -73,7 +73,7 @@ func TestGet(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace(testNamespace)
 			defer tf.Cleanup()
 			tf.FakeDynamicClient.PrependReactor("get", "configmaps", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-				inv := NewUnstructuredInventory(emptyInventoryObject())
+				inv := NewSingleObjectInventory(emptyInventoryObject())
 				inv.SetObjectRefs(tc.localObjs)
 				inv.SetObjectStatuses(tc.objStatus)
 				cm, _ := inventoryToConfigMap(tc.statusPolicy)(emptyInventoryObject(), inv)
@@ -99,7 +99,7 @@ func TestGet(t *testing.T) {
 
 func TestCreateOrUpdate(t *testing.T) {
 	tests := map[string]struct {
-		inventory  *UnstructuredInventory
+		inventory  *SingleObjectInventory
 		createObjs object.ObjMetadataSet
 		updateObjs object.ObjMetadataSet
 		isError    bool
@@ -110,13 +110,13 @@ func TestCreateOrUpdate(t *testing.T) {
 			isError:    true,
 		},
 		"Create and update inventory with empty object set": {
-			inventory:  NewUnstructuredInventory(emptyInventoryObject()),
+			inventory:  NewSingleObjectInventory(emptyInventoryObject()),
 			createObjs: object.ObjMetadataSet{},
 			updateObjs: object.ObjMetadataSet{},
 			isError:    false,
 		},
 		"Create and Update inventory with identical object set": {
-			inventory: NewUnstructuredInventory(emptyInventoryObject()),
+			inventory: NewSingleObjectInventory(emptyInventoryObject()),
 			createObjs: object.ObjMetadataSet{
 				ignoreErrInfoToObjMeta(pod1Info),
 			},
@@ -126,7 +126,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			isError: false,
 		},
 		"Create and Update inventory with expanding object set": {
-			inventory: NewUnstructuredInventory(emptyInventoryObject()),
+			inventory: NewSingleObjectInventory(emptyInventoryObject()),
 			createObjs: object.ObjMetadataSet{
 				ignoreErrInfoToObjMeta(pod1Info),
 			},
@@ -137,7 +137,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			isError: false,
 		},
 		"Create and Update inventory with shrinking object set": {
-			inventory: NewUnstructuredInventory(emptyInventoryObject()),
+			inventory: NewSingleObjectInventory(emptyInventoryObject()),
 			createObjs: object.ObjMetadataSet{
 				ignoreErrInfoToObjMeta(pod1Info),
 				ignoreErrInfoToObjMeta(pod2Info),

--- a/pkg/inventory/inventorycm.go
+++ b/pkg/inventory/inventorycm.go
@@ -35,7 +35,7 @@ func ConfigMapToInventoryObj(uObj *unstructured.Unstructured) (Inventory, error)
 // wraps it with the ConfigMap and upcasts the wrapper as
 // an the Info interface.
 func ConfigMapToInventoryInfo(uObj *unstructured.Unstructured) (Info, error) {
-	inv := NewUnstructuredInventory(uObj)
+	inv := NewSingleObjectInventory(uObj)
 	return inv.Info(), nil
 }
 
@@ -59,8 +59,8 @@ func buildDataMap(objMetas object.ObjMetadataSet, objStatus []actuation.ObjectSt
 
 var _ FromUnstructuredFunc = configMapToInventory
 
-func configMapToInventory(configMap *unstructured.Unstructured) (*UnstructuredInventory, error) {
-	inv := NewUnstructuredInventory(configMap)
+func configMapToInventory(configMap *unstructured.Unstructured) (*SingleObjectInventory, error) {
+	inv := NewSingleObjectInventory(configMap)
 	objMap, exists, err := unstructured.NestedStringMap(configMap.Object, "data")
 	if err != nil {
 		err := fmt.Errorf("error retrieving object metadata from inventory object")
@@ -81,7 +81,7 @@ func configMapToInventory(configMap *unstructured.Unstructured) (*UnstructuredIn
 // ConfigMap does not have an actual status, so the object statuses are persisted
 // as values in the ConfigMap key/value pairs.
 func inventoryToConfigMap(statusPolicy StatusPolicy) ToUnstructuredFunc {
-	return func(uObj *unstructured.Unstructured, inv *UnstructuredInventory) (*unstructured.Unstructured, error) {
+	return func(uObj *unstructured.Unstructured, inv *SingleObjectInventory) (*unstructured.Unstructured, error) {
 		var dataMap map[string]string
 		if statusPolicy == StatusPolicyAll {
 			dataMap = buildDataMap(inv.GetObjectRefs(), inv.GetObjectStatuses())

--- a/test/e2e/customprovider/provider.go
+++ b/test/e2e/customprovider/provider.go
@@ -107,7 +107,7 @@ func (CustomClientFactory) NewClient(factory util.Factory) (inventory.Client, er
 	return inventory.NewUnstructuredClient(factory, fromUnstructured, toUnstructured, InventoryGVK, inventory.StatusPolicyAll)
 }
 
-func toUnstructured(uObj *unstructured.Unstructured, inv *inventory.UnstructuredInventory) (*unstructured.Unstructured, error) {
+func toUnstructured(uObj *unstructured.Unstructured, inv *inventory.SingleObjectInventory) (*unstructured.Unstructured, error) {
 	var specObjs []interface{}
 	for _, obj := range inv.ObjectRefs {
 		specObjs = append(specObjs, map[string]interface{}{
@@ -148,8 +148,8 @@ func toUnstructured(uObj *unstructured.Unstructured, inv *inventory.Unstructured
 	return uObj, nil
 }
 
-func fromUnstructured(obj *unstructured.Unstructured) (*inventory.UnstructuredInventory, error) {
-	inv := inventory.NewUnstructuredInventory(obj)
+func fromUnstructured(obj *unstructured.Unstructured) (*inventory.SingleObjectInventory, error) {
+	inv := inventory.NewSingleObjectInventory(obj)
 	s, found, err := unstructured.NestedSlice(obj.Object, "spec", "objects")
 	if err != nil {
 		return nil, err
@@ -177,5 +177,5 @@ func fromUnstructured(obj *unstructured.Unstructured) (*inventory.UnstructuredIn
 }
 
 func WrapInventoryInfoObj(obj *unstructured.Unstructured) (inventory.Info, error) {
-	return inventory.NewUnstructuredInventory(obj).Info(), nil
+	return inventory.NewSingleObjectInventory(obj).Info(), nil
 }


### PR DESCRIPTION
After several iterations/refactors of the original change, the meaning of the UnstructuredInventory struct has changed. The name SingleObjectInventory is a more accurate name to describe the current struct.