### PR TITLE
kstatus update for suspended jobs

### DIFF
--- a/pkg/kstatus/status/core.go
+++ b/pkg/kstatus/status/core.go
@@ -562,6 +562,15 @@ func jobConditions(u *unstructured.Unstructured) (*Result, error) {
 				return newFailedStatus("JobFailed",
 					fmt.Sprintf("Job Failed. failed: %d/%d", failed, completions)), nil
 			}
+		// Suspended jobs should not be considered in-progress.
+		case "Suspended":
+			if c.Status == corev1.ConditionTrue {
+				return &Result{
+					Status:     CurrentStatus,
+					Message:    "Job is suspended",
+					Conditions: []Condition{},
+				}, nil
+			}
 		}
 	}
 

--- a/pkg/kstatus/status/core_test.go
+++ b/pkg/kstatus/status/core_test.go
@@ -1,0 +1,42 @@
+package status_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+)
+
+func TestSuspendedJobConditions(t *testing.T) {
+	jobManifest := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: test
+   generation: 1
+   namespace: qual
+status:
+  conditions:
+  - type: Suspended
+    status: "%s"
+    reason: JobSuspended
+`
+
+	suspendedJobManifest := fmt.Sprintf(jobManifest, "True")
+	inprogressJobManifest := fmt.Sprintf(jobManifest, "False")
+
+	suspendedJob := testutil.YamlToUnstructured(t, suspendedJobManifest)
+	inprogressJob := testutil.YamlToUnstructured(t, inprogressJobManifest)
+
+	res, err := status.Compute(suspendedJob)
+	assert.NoError(t, err)
+
+	assert.Equal(t, status.Status("Current"), res.Status)
+
+	res, err = status.Compute(inprogressJob)
+	assert.NoError(t, err)
+
+	assert.Equal(t, status.Status("InProgress"), res.Status)
+}

--- a/pkg/kstatus/status/core_test.go
+++ b/pkg/kstatus/status/core_test.go
@@ -1,3 +1,6 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package status_test
 
 import (

--- a/pkg/kstatus/status/core_test.go
+++ b/pkg/kstatus/status/core_test.go
@@ -12,6 +12,10 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 )
 
+// Tests are based on https://kubernetes.io/docs/concepts/workloads/controllers/job/#suspending-a-job.
+
+// Validate that a job with spec.suspend set to true and a condition of type
+// Suspended with status True is considered Current.
 func TestSuspendedJobConditions(t *testing.T) {
 	jobManifest := `
 apiVersion: batch/v1
@@ -20,25 +24,78 @@ metadata:
    name: test
    generation: 1
    namespace: qual
+spec:
+  suspend: true
 status:
   conditions:
   - type: Suspended
-    status: "%s"
-    reason: JobSuspended
+    status: "True"
 `
 
-	suspendedJobManifest := fmt.Sprintf(jobManifest, "True")
-	inprogressJobManifest := fmt.Sprintf(jobManifest, "False")
-
-	suspendedJob := testutil.YamlToUnstructured(t, suspendedJobManifest)
-	inprogressJob := testutil.YamlToUnstructured(t, inprogressJobManifest)
+	suspendedJob := testutil.YamlToUnstructured(t, jobManifest)
 
 	res, err := status.Compute(suspendedJob)
 	assert.NoError(t, err)
 
 	assert.Equal(t, status.Status("Current"), res.Status)
+}
 
-	res, err = status.Compute(inprogressJob)
+// Validate that a job previously suspended shows as in-progress if the
+// spec.suspend is set to false.
+func TestPreviouslySuspendedJobConditions(t *testing.T) {
+	jobManifest := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: test
+   generation: 1
+   namespace: qual
+spec:
+  suspend: false
+status:
+  conditions:
+  - type: Suspended
+    status: "False"
+`
+
+	suspendedJob := testutil.YamlToUnstructured(t, jobManifest)
+
+	res, err := status.Compute(suspendedJob)
+	assert.NoError(t, err)
+
+	assert.Equal(t, status.Status("InProgress"), res.Status)
+}
+
+// Validate that a job that is transitioning to or from the suspended state
+// will show as in-progress.
+func TestSuspendedJobTransitionConditions(t *testing.T) {
+	jobManifest := `
+apiVersion: batch/v1
+kind: Job
+metadata:
+   name: test
+   generation: 1
+   namespace: qual
+spec:
+  suspend: %t
+status:
+  conditions:
+  - type: Suspended
+    status: "%s"
+`
+
+	toSuspendedStateManifest := fmt.Sprintf(jobManifest, true, "False")
+	fromSuspendedStateManifest := fmt.Sprintf(jobManifest, false, "True")
+
+	toSuspendedJob := testutil.YamlToUnstructured(t, toSuspendedStateManifest)
+	fromSuspendedJob := testutil.YamlToUnstructured(t, fromSuspendedStateManifest)
+
+	res, err := status.Compute(toSuspendedJob)
+	assert.NoError(t, err)
+
+	assert.Equal(t, status.Status("InProgress"), res.Status)
+
+	res, err = status.Compute(fromSuspendedJob)
 	assert.NoError(t, err)
 
 	assert.Equal(t, status.Status("InProgress"), res.Status)

--- a/pkg/kstatus/status/util.go
+++ b/pkg/kstatus/status/util.go
@@ -141,3 +141,21 @@ func GetIntField(obj map[string]interface{}, fieldPath string, defaultValue int)
 	}
 	return defaultValue
 }
+
+func GetBoolField(obj map[string]interface{}, fieldPath string, defaultValue bool) bool {
+	fields := strings.Split(fieldPath, ".")
+	if fields[0] == "" {
+		fields = fields[1:]
+	}
+
+	val, found, err := apiunstructured.NestedFieldNoCopy(obj, fields...)
+	if !found || err != nil {
+		return defaultValue
+	}
+
+	switch v := val.(type) {
+	case bool:
+		return v
+	}
+	return defaultValue
+}

--- a/pkg/kstatus/status/util.go
+++ b/pkg/kstatus/status/util.go
@@ -119,8 +119,10 @@ func GetStringField(obj map[string]interface{}, fieldPath string, defaultValue s
 	return rv
 }
 
-// GetIntField return field as string defaulting to value if not found
+// GetIntField return field as int defaulting to value if not found
 func GetIntField(obj map[string]interface{}, fieldPath string, defaultValue int) int {
+	var rv = defaultValue
+
 	fields := strings.Split(fieldPath, ".")
 	if fields[0] == "" {
 		fields = fields[1:]
@@ -128,7 +130,7 @@ func GetIntField(obj map[string]interface{}, fieldPath string, defaultValue int)
 
 	val, found, err := apiunstructured.NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
-		return defaultValue
+		return rv
 	}
 
 	switch v := val.(type) {
@@ -139,10 +141,13 @@ func GetIntField(obj map[string]interface{}, fieldPath string, defaultValue int)
 	case int64:
 		return int(v)
 	}
-	return defaultValue
+	return rv
 }
 
+// GetBoolField return field as boolean defaulting to value if not found
 func GetBoolField(obj map[string]interface{}, fieldPath string, defaultValue bool) bool {
+	var rv = defaultValue
+
 	fields := strings.Split(fieldPath, ".")
 	if fields[0] == "" {
 		fields = fields[1:]
@@ -150,12 +155,11 @@ func GetBoolField(obj map[string]interface{}, fieldPath string, defaultValue boo
 
 	val, found, err := apiunstructured.NestedFieldNoCopy(obj, fields...)
 	if !found || err != nil {
-		return defaultValue
+		return rv
 	}
 
-	switch v := val.(type) {
-	case bool:
+	if v, ok := val.(bool); ok {
 		return v
 	}
-	return defaultValue
+	return rv
 }


### PR DESCRIPTION
Suspended jobs are returning as in-progress which makes it seem like the job is running, but it should be considered as current since suspended jobs will not run.