### PR TITLE
perf: use metadata client for InventoryPolicyApplyFilter

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cli-utils/pkg/apis/actuation"
 	"sigs.k8s.io/cli-utils/pkg/apply/cache"
@@ -42,13 +43,14 @@ import (
 // parameters and/or the set of resources that needs to be applied to the
 // cluster, different sets of tasks might be needed.
 type Applier struct {
-	pruner        *prune.Pruner
-	statusWatcher watcher.StatusWatcher
-	invClient     inventory.Client
-	client        dynamic.Interface
-	openAPIGetter discovery.OpenAPISchemaInterface
-	mapper        meta.RESTMapper
-	infoHelper    info.Helper
+	pruner         *prune.Pruner
+	statusWatcher  watcher.StatusWatcher
+	invClient      inventory.Client
+	client         dynamic.Interface
+	metadataClient metadata.Interface
+	openAPIGetter  discovery.OpenAPISchemaInterface
+	mapper         meta.RESTMapper
+	infoHelper     info.Helper
 }
 
 // prepareObjects returns the set of objects to apply and to prune or
@@ -128,7 +130,7 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.Info, objects objec
 		// Build list of apply validation filters.
 		applyFilters := []filter.ValidationFilter{
 			filter.InventoryPolicyApplyFilter{
-				Client:    a.client,
+				Client:    a.metadataClient,
 				Mapper:    a.mapper,
 				Inv:       invInfo,
 				InvPolicy: options.InventoryPolicy,

--- a/pkg/apply/applier_builder.go
+++ b/pkg/apply/applier_builder.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/apply/info"
@@ -38,12 +39,13 @@ func (b *ApplierBuilder) Build() (*Applier, error) {
 			Client:    bx.client,
 			Mapper:    bx.mapper,
 		},
-		statusWatcher: bx.statusWatcher,
-		invClient:     bx.invClient,
-		client:        bx.client,
-		openAPIGetter: bx.discoClient,
-		mapper:        bx.mapper,
-		infoHelper:    info.NewHelper(bx.mapper, bx.unstructuredClientForMapping),
+		statusWatcher:  bx.statusWatcher,
+		invClient:      bx.invClient,
+		client:         bx.client,
+		metadataClient: bx.metadataClient,
+		openAPIGetter:  bx.discoClient,
+		mapper:         bx.mapper,
+		infoHelper:     info.NewHelper(bx.mapper, bx.unstructuredClientForMapping),
 	}, nil
 }
 
@@ -59,6 +61,11 @@ func (b *ApplierBuilder) WithInventoryClient(invClient inventory.Client) *Applie
 
 func (b *ApplierBuilder) WithDynamicClient(client dynamic.Interface) *ApplierBuilder {
 	b.client = client
+	return b
+}
+
+func (b *ApplierBuilder) WithMetadataClient(client metadata.Interface) *ApplierBuilder {
+	b.metadataClient = client
 	return b
 }
 

--- a/pkg/apply/builder.go
+++ b/pkg/apply/builder.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
@@ -21,6 +22,7 @@ type commonBuilder struct {
 	// factory is only used to retrieve things that have not been provided explicitly.
 	factory                      util.Factory
 	invClient                    inventory.Client
+	metadataClient               metadata.Interface
 	client                       dynamic.Interface
 	discoClient                  discovery.CachedDiscoveryInterface
 	mapper                       meta.RESTMapper
@@ -70,6 +72,12 @@ func (cb *commonBuilder) finalize() (*commonBuilder, error) {
 		cx.restConfig, err = cx.factory.ToRESTConfig()
 		if err != nil {
 			return nil, fmt.Errorf("error getting rest config: %v", err)
+		}
+	}
+	if cx.metadataClient == nil {
+		cx.metadataClient, err = metadata.NewForConfig(cx.restConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error getting metadata client: %v", err)
 		}
 	}
 	if cx.unstructuredClientForMapping == nil {

--- a/pkg/apply/filter/inventory-policy-apply-filter.go
+++ b/pkg/apply/filter/inventory-policy-apply-filter.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/object"
 )
@@ -20,7 +20,7 @@ import (
 // if an object should be applied based on the cluster object's inventory id,
 // the id for the inventory object, and the inventory policy.
 type InventoryPolicyApplyFilter struct {
-	Client    dynamic.Interface
+	Client    metadata.Interface
 	Mapper    meta.RESTMapper
 	Inv       inventory.Info
 	InvPolicy inventory.Policy
@@ -55,7 +55,7 @@ func (ipaf InventoryPolicyApplyFilter) Filter(ctx context.Context, obj *unstruct
 }
 
 // getObject retrieves the passed object from the cluster, or an error if one occurred.
-func (ipaf InventoryPolicyApplyFilter) getObject(ctx context.Context, id object.ObjMetadata) (*unstructured.Unstructured, error) {
+func (ipaf InventoryPolicyApplyFilter) getObject(ctx context.Context, id object.ObjMetadata) (*metav1.PartialObjectMetadata, error) {
 	mapping, err := ipaf.Mapper.RESTMapping(id.GroupKind)
 	if err != nil {
 		return nil, err

--- a/pkg/inventory/policy.go
+++ b/pkg/inventory/policy.go
@@ -83,7 +83,11 @@ const (
 	NoMatch
 )
 
-func IDMatch(inv Info, obj *unstructured.Unstructured) IDMatchStatus {
+type Annotated interface {
+	GetAnnotations() map[string]string
+}
+
+func IDMatch(inv Info, obj Annotated) IDMatchStatus {
 	annotations := obj.GetAnnotations()
 	value, found := annotations[OwningInventoryKey]
 	if !found {
@@ -95,7 +99,7 @@ func IDMatch(inv Info, obj *unstructured.Unstructured) IDMatchStatus {
 	return NoMatch
 }
 
-func CanApply(inv Info, obj *unstructured.Unstructured, policy Policy) (bool, error) {
+func CanApply(inv Info, obj Annotated, policy Policy) (bool, error) {
 	matchStatus := IDMatch(inv, obj)
 	switch matchStatus {
 	case Empty:


### PR DESCRIPTION
This optimizes the InventoryPolicyApplyFilter to use a metadata client instead of a dynamic client. This filter only needs object metadata to perform its functionality, so it does not need the entire object.