### PR TITLE
Informer cleanup

### DIFF
--- a/pkg/kstatus/watcher/dynamic_informer_factory_test.go
+++ b/pkg/kstatus/watcher/dynamic_informer_factory_test.go
@@ -191,7 +191,7 @@ func TestResourceNotFoundError(t *testing.T) {
 			require.NoError(t, err)
 
 			// Block until context cancel or timeout.
-			informer.Run(ctx.Done())
+			informer.RunWithContext(ctx)
 		})
 	}
 }

--- a/pkg/kstatus/watcher/dynamic_informer_factory_test.go
+++ b/pkg/kstatus/watcher/dynamic_informer_factory_test.go
@@ -181,7 +181,7 @@ func TestResourceNotFoundError(t *testing.T) {
 			mapping, err := fakeMapper.RESTMapping(carpGVK.GroupKind())
 			require.NoError(t, err)
 
-			informer := informerFactory.NewInformer(ctx, mapping, namespace)
+			informer := informerFactory.NewInformer(mapping, namespace)
 
 			err = informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
 				tc.errorHandler(t, err)
@@ -442,7 +442,7 @@ func TestNewFilteredListWatchFromDynamicClientList(t *testing.T) {
 			tc.setup(fakeClient)
 
 			ctx := context.Background()
-			lw := NewFilteredListWatchFromDynamicClient(ctx, fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
+			lw := NewFilteredListWatchFromDynamicClient(fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
 
 			obj, err := lw.ListWithContext(ctx, tc.listInput.options)
 			testutil.AssertEqual(t, tc.listOuput.object, obj)
@@ -690,7 +690,7 @@ func TestNewFilteredListWatchFromDynamicClientWatch(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 			defer cancel()
 
-			lw := NewFilteredListWatchFromDynamicClient(ctx, fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
+			lw := NewFilteredListWatchFromDynamicClient(fakeClient, tc.args.resource, tc.args.namespace, tc.args.filters)
 
 			watcher, err := lw.WatchWithContext(ctx, tc.watchInput.options)
 

--- a/pkg/kstatus/watcher/object_status_reporter.go
+++ b/pkg/kstatus/watcher/object_status_reporter.go
@@ -327,7 +327,7 @@ func (w *ObjectStatusReporter) startInformerNow(
 		return err
 	}
 
-	informer := w.InformerFactory.NewInformer(ctx, mapping, gkn.Namespace)
+	informer := w.InformerFactory.NewInformer(mapping, gkn.Namespace)
 
 	w.informerRefs[gkn].SetInformer(informer)
 

--- a/pkg/kstatus/watcher/object_status_reporter.go
+++ b/pkg/kstatus/watcher/object_status_reporter.go
@@ -361,7 +361,7 @@ func (w *ObjectStatusReporter) startInformerNow(
 	// Informer will be stopped when the context is cancelled.
 	go func() {
 		klog.V(3).Infof("Watch starting: %v", gkn)
-		informer.Run(ctx.Done())
+		informer.RunWithContext(ctx)
 		klog.V(3).Infof("Watch stopped: %v", gkn)
 		// Signal to the caller there will be no more events for this GroupKind.
 		close(eventCh)


### PR DESCRIPTION
Please see commits.

I'm proposing to make a breaking change to signatures of some functions to remove context since it is passed from the informer itself now.

@karlkfi @seans3 @mortent WDYT?

