### PR TITLE
feat: add support to prevent updates on objects

### DIFF
--- a/pkg/apply/applier.go
+++ b/pkg/apply/applier.go
@@ -135,6 +135,11 @@ func (a *Applier) Run(ctx context.Context, invInfo inventory.Info, objects objec
 				Inv:       invInfo,
 				InvPolicy: options.InventoryPolicy,
 			},
+			// consider consolidating these two filters to minimize repeated Get calls
+			filter.PreventUpdateFilter{
+				Client: a.metadataClient,
+				Mapper: a.mapper,
+			},
 			filter.DependencyFilter{
 				TaskContext:       taskContext,
 				ActuationStrategy: actuation.ActuationStrategyApply,

--- a/pkg/apply/filter/prevent-update-filter.go
+++ b/pkg/apply/filter/prevent-update-filter.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/metadata"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// PreventUpdateFilter implements ValidationFilter interface to determine
+// if an object should not be updated because of an "ignore mutation" annotation.
+type PreventUpdateFilter struct {
+	Client metadata.Interface
+	Mapper meta.RESTMapper
+}
+
+const PreventUpdateFilterName = "PreventUpdateFilter"
+
+// Name returns the preferred name for the filter. Usually
+// used for logging.
+func (puf PreventUpdateFilter) Name() string {
+	return PreventUpdateFilterName
+}
+
+// Filter returns a AnnotationPreventedUpdateError if the object apply
+// should be skipped.
+func (puf PreventUpdateFilter) Filter(ctx context.Context, obj *unstructured.Unstructured) error {
+	a := obj.GetAnnotations()
+	if val, ok := a[common.LifecycleMutationAnnotation]; ok && val == common.IgnoreMutation {
+		_, err := puf.getObject(ctx, object.UnstructuredToObjMetadata(obj))
+		if apierrors.IsNotFound(err) { // object NotFound - apply
+			return nil
+		} else if err != nil { // unexpected error - fatal
+			return NewFatalError(fmt.Errorf("failed to get current object from cluster: %w", err))
+		}
+		// Object exists - skip apply
+		return &AnnotationPreventedUpdateError{
+			Annotation: common.LifecycleMutationAnnotation,
+			Value:      common.IgnoreMutation,
+		}
+	}
+	return nil
+}
+
+// getObject retrieves the passed object from the cluster, or an error if one occurred.
+func (puf PreventUpdateFilter) getObject(ctx context.Context, id object.ObjMetadata) (*metav1.PartialObjectMetadata, error) {
+	mapping, err := puf.Mapper.RESTMapping(id.GroupKind)
+	if err != nil {
+		return nil, err
+	}
+	namespacedClient := puf.Client.Resource(mapping.Resource).Namespace(id.Namespace)
+	return namespacedClient.Get(ctx, id.Name, metav1.GetOptions{})
+}
+
+type AnnotationPreventedUpdateError struct {
+	Annotation string
+	Value      string
+}
+
+func (e *AnnotationPreventedUpdateError) Error() string {
+	return fmt.Sprintf("annotation prevents apply (%q: %q)", e.Annotation, e.Value)
+}
+
+func (e *AnnotationPreventedUpdateError) Is(err error) bool {
+	if err == nil {
+		return false
+	}
+	tErr, ok := err.(*AnnotationPreventedUpdateError)
+	if !ok {
+		return false
+	}
+	return e.Annotation == tErr.Annotation &&
+		e.Value == tErr.Value
+}

--- a/pkg/apply/filter/prevent-update-filter_test.go
+++ b/pkg/apply/filter/prevent-update-filter_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+)
+
+func TestPreventUpdateFilter(t *testing.T) {
+	tests := map[string]struct {
+		objAnnotations map[string]string
+		expectedError  error
+	}{
+		"empty object annotations": {
+			objAnnotations: map[string]string{},
+		},
+		"object contains matching key but mismatched value": {
+			objAnnotations: map[string]string{
+				common.LifecycleMutationAnnotation: "foo",
+			},
+		},
+		"object contains matching annotation key/value": {
+			objAnnotations: map[string]string{
+				common.LifecycleMutationAnnotation: common.IgnoreMutation,
+			},
+			expectedError: &AnnotationPreventedUpdateError{
+				Annotation: common.LifecycleMutationAnnotation,
+				Value:      common.IgnoreMutation,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			obj := defaultObj.DeepCopy()
+			obj.SetAnnotations(tc.objAnnotations)
+			metadataObj := defaultMetadataObj.DeepCopy()
+			metadataObj.SetAnnotations(tc.objAnnotations)
+			filter := PreventUpdateFilter{
+				Client: metadatafake.NewSimpleMetadataClient(scheme.Scheme, metadataObj),
+				Mapper: testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme,
+					scheme.Scheme.PrioritizedVersionsAllGroups()...),
+			}
+			err := filter.Filter(t.Context(), obj)
+			testutil.AssertEqual(t, tc.expectedError, err)
+		})
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -41,6 +41,14 @@ const (
 	// PreventDeletion is the value used with LifecycleDeletionAnnotation
 	// to prevent deleting a resource.
 	PreventDeletion = "detach"
+
+	// LifecycleMutationAnnotation is the lifecycle annotation key for mutation operation.
+	LifecycleMutationAnnotation = "client.lifecycle.config.k8s.io/mutation"
+
+	// IgnoreMutation is the value used with LifecycleMutationAnnotation to
+	// prevent mutating a resource. That is, if the resource exists on the cluster
+	// then the applier will make no attempt to modify it.
+	IgnoreMutation = "ignore"
 )
 
 // RandomStr returns an eight-digit (with leading zeros) string of a

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -158,6 +158,10 @@ var _ = Describe("E2E", func() {
 					deletionPreventionTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 				})
 
+				It("MutationPrevention", func() {
+					mutationPreventionTest(ctx, c, invConfig, inventoryName, namespace.GetName())
+				})
+
 				It("CustomResource", func() {
 					crdTest(ctx, c, invConfig, inventoryName, namespace.GetName())
 				})

--- a/test/e2e/mutation_prevention_test.go
+++ b/test/e2e/mutation_prevention_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive
+	. "github.com/onsi/gomega"    //nolint:revive
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cli-utils/pkg/apply"
+	"sigs.k8s.io/cli-utils/pkg/apply/event"
+	"sigs.k8s.io/cli-utils/pkg/apply/filter"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/cli-utils/pkg/testutil"
+	"sigs.k8s.io/cli-utils/test/e2e/e2eutil"
+	"sigs.k8s.io/cli-utils/test/e2e/invconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func mutationPreventionTest(ctx context.Context, c client.Client, invConfig invconfig.InventoryConfig, inventoryName, namespaceName string) {
+	By("Apply resources")
+	applier := invConfig.ApplierFactoryFunc()
+
+	inventoryID := fmt.Sprintf("%s-%s", inventoryName, namespaceName)
+	inventoryInfo, err := invconfig.CreateInventoryInfo(invConfig, inventoryName, namespaceName, inventoryID)
+	Expect(err).ToNot(HaveOccurred())
+
+	uDep := e2eutil.ManifestToUnstructured(deployment1)
+	resources := []*unstructured.Unstructured{
+		e2eutil.WithAnnotation(e2eutil.WithNamespace(uDep, namespaceName), common.LifecycleMutationAnnotation, common.IgnoreMutation),
+	}
+
+	e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
+		ReconcileTimeout: 2 * time.Minute,
+	}))
+
+	By("Verify deployment created")
+	obj := e2eutil.AssertUnstructuredExists(ctx, c, e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName))
+	Expect(obj.GetAnnotations()[inventory.OwningInventoryKey]).To(Equal(inventoryInfo.GetID().String()))
+
+	By("Mutate the on-cluster Deployment object replica count")
+	dep := &appsv1.Deployment{}
+	key := types.NamespacedName{Name: uDep.GetName(), Namespace: uDep.GetNamespace()}
+	err = c.Get(ctx, key, dep)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(*dep.Spec.Replicas).To(Equal(int32(4))) // verify original replica count
+	dep.Spec.Replicas = ptr.To(int32(3))
+	err = c.Update(ctx, dep)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Dry-run apply resources")
+
+	e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
+		ReconcileTimeout: 2 * time.Minute,
+		DryRunStrategy:   common.DryRunClient,
+	}))
+
+	By("Verify deployment still exists and has the mutated replica count")
+	obj = e2eutil.AssertUnstructuredExists(ctx, c, e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName))
+	replicas, found, err := unstructured.NestedInt64(obj.Object, "spec", "replicas")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(replicas).To(Equal(int64(3)))
+
+	By("Apply resources")
+
+	applierEvents := e2eutil.RunCollect(applier.Run(ctx, inventoryInfo, resources, apply.ApplierOptions{
+		ReconcileTimeout: 2 * time.Minute,
+	}))
+	expEvents := []testutil.ExpEvent{
+		{
+			// InitTask
+			EventType: event.InitType,
+			InitEvent: &testutil.ExpInitEvent{},
+		},
+		{
+			// InvAddTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Started,
+			},
+		},
+		{
+			// InvAddTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.InventoryAction,
+				GroupName: "inventory-add-0",
+				Type:      event.Finished,
+			},
+		},
+		{
+			// ApplyTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Started,
+			},
+		},
+		{
+			// Skip apply of Deployment
+			EventType: event.ApplyType,
+			ApplyEvent: &testutil.ExpApplyEvent{
+				GroupName:  "apply-0",
+				Status:     event.ApplySkipped,
+				Identifier: object.UnstructuredToObjMetadata(uDep),
+				Error: &filter.AnnotationPreventedUpdateError{
+					Annotation: common.LifecycleMutationAnnotation,
+					Value:      common.IgnoreMutation,
+				},
+			},
+		},
+		{
+			// ApplyTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.ApplyAction,
+				GroupName: "apply-0",
+				Type:      event.Finished,
+			},
+		},
+		{
+			// WaitTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Started,
+			},
+		},
+		{
+			// Deployment reconcile skipped.
+			EventType: event.WaitType,
+			WaitEvent: &testutil.ExpWaitEvent{
+				GroupName:  "wait-0",
+				Status:     event.ReconcileSkipped,
+				Identifier: object.UnstructuredToObjMetadata(uDep),
+			},
+		},
+		{
+			// WaitTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.WaitAction,
+				GroupName: "wait-0",
+				Type:      event.Finished,
+			},
+		},
+		{
+			// InvSetTask start
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Started,
+			},
+		},
+		{
+			// InvSetTask finished
+			EventType: event.ActionGroupType,
+			ActionGroupEvent: &testutil.ExpActionGroupEvent{
+				Action:    event.InventoryAction,
+				GroupName: "inventory-set-0",
+				Type:      event.Finished,
+			},
+		},
+	}
+	Expect(testutil.EventsToExpEvents(applierEvents)).To(testutil.Equal(expEvents))
+
+	By("Verify deployment still exists and has the mutated replica count")
+	obj = e2eutil.AssertUnstructuredExists(ctx, c, e2eutil.WithNamespace(e2eutil.ManifestToUnstructured(deployment1), namespaceName))
+	replicas, found, err = unstructured.NestedInt64(obj.Object, "spec", "replicas")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(found).To(BeTrue())
+	Expect(replicas).To(Equal(int64(3)))
+}


### PR DESCRIPTION
This change adds a new actuation feature to the applier which allows objects to be created but not updated. This is useful in cases where the user wants to create the object if it does not exists, but then allow other clients to make updates to the object that are not reverted by the applier.

The feature is used by providing the ignore mutation annotation on the declared object.